### PR TITLE
docs(maintenance): align SDK3 flow-card guidance with `getTriggerCard` API

### DIFF
--- a/scripts/maintenance/master-self-heal.js
+++ b/scripts/maintenance/master-self-heal.js
@@ -13,7 +13,7 @@
  *  1. sdk3-phantom-methods   — Replace getDeviceConditionCard/getDeviceActionCard
  *  2. fingerprint-case       — Lowercase ALL fingerprints in driver.compose.json
  *  3. probe-dedup-static     — Remove measure_temperature.probe from pure-ZCL drivers
- *  4. flow-card-try-catch    — Wrap bare getDeviceTriggerCard in try-catch
+ *  4. flow-card-try-catch    — Wrap bare getTriggerCard in try-catch
  *  5. energy-batteries       — Add energy.batteries if measure_battery is declared
  *  6. multigang-flow-routing — Replace raw ZCL onOff.setOn() with triggerCapabilityListener
  *  7. dp-variant-doc         — Flag DP mappings missing variant comments
@@ -26,7 +26,7 @@
  *  14. logic-case-audit       — Flag suspected case-sensitive comparisons
  *  15. this-prefix-safety     — Replace global SDK method calls with 'this.' (ReferenceError prevention)
  *  16. defensive-get-device   — Inject defensive getDeviceById override in drivers
- *  29. safe-flow-lookup       — Wrap getDeviceTriggerCard in try-catch
+ *  29. safe-flow-lookup       — Wrap getTriggerCard in try-catch
  *  30. wifi-qr-stability      — Enforce larger QR codes and regional schema in WiFi drivers
  */
 'use strict';

--- a/scripts/maintenance/sdk3-smart-linter.js
+++ b/scripts/maintenance/sdk3-smart-linter.js
@@ -426,7 +426,7 @@ To properly handle multi-gang, hybrid Tuya/ZCL routers, and buttons across ALL l
 3. PHYSICAL STATE ARRIVAL (Device -> Homey):
    - When state arrives horizontally from the device either via ZCL Report (this.zclNode...on('attr')) or Custom Tuya DP (_handleTuyaDatapoint), check this._appCommandPending.
    - If _appCommandPending === true: This is a bidirectional ACK of the virtual command. Do nothing except this.setCapabilityValue.
-   - If _appCommandPending !== true: THIS IS A PHYSICAL BUTTON PRESS / REAL WORLD EVENT. Trigger this.homey.flow.getDeviceTriggerCard('turned_on_physical_gangX').trigger(this)!
+   - If _appCommandPending !== true: THIS IS A PHYSICAL BUTTON PRESS / REAL WORLD EVENT. Trigger this.homey.flow.getTriggerCard('turned_on_physical_gangX').trigger(this)!
 4. RAW / STREAM / CUSTOM FALLBACKS:
    - For heavily customized tuples (e.g. TS004F/Scene buttons), catch raw commands via this.zclNode.on('rawCommand').
    - Before acting, translate the raw endpoint and cluster command directly into a normalized triggerCapabilityListener or a direct Flow trigger! This unifies the execution pipe.


### PR DESCRIPTION
### Motivation
- Maintenance guidance referenced deprecated/non-existent SDK v3 helper names which cause confusion and unsafe examples for Flow triggers.
- Documentation and automated maintenance rules should match Homey SDK v3 API names to avoid false positives in auto-fix tooling.

### Description
- Replaced `getDeviceTriggerCard('...')` example text with the SDK v3 correct `getTriggerCard('...')` usage in `scripts/maintenance/sdk3-smart-linter.js` to show the safe example for physical button events. (`scripts/maintenance/sdk3-smart-linter.js`).
- Updated rule descriptions and prose that referred to the old phrasing in `scripts/maintenance/master-self-heal.js` so the maintenance engine and docs consistently reference `getTriggerCard`. (`scripts/maintenance/master-self-heal.js`).
- Change is documentation/guidance only and does not alter runtime flow-card lookup or replacement logic in other scripts.

### Testing
- Ran syntax checks with `node --check scripts/maintenance/sdk3-smart-linter.js` which succeeded. 
- Ran syntax checks with `node --check scripts/maintenance/master-self-heal.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8fa54be883209b4666b661599c5c)