### PR TITLE
fix: rename 99 duplicate flow card IDs to pass publish validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to the **Tuya Unified Zigbee** app for Homey Pro.
 - Fixed `BaseUnifiedDevice.setTuyaDpValue`: `addCapability` failure (invalid capability e.g. `tuya_dp_1`) no longer propagates as `[err]` — early return prevents subsequent `setCapabilityValue` call.
 - Fixed `DriverMappingLoader`: database with `drivers` key (not `devices`) caused `Cannot convert undefined or null to object` on load — normalized both keys after parse.
 - Fixed `garage_door_opener` icon: replaced placeholder SVG (target symbol) with garage door outline matching existing PNG assets.
+- Fixed duplicate flow card IDs causing Homey publish validation failure — renamed 99 IDs across 7 drivers (`sensor_motion_radar`, `sensor_contact_motion`, `sensor_climate_contact`, `light_bulb_rgb_rgbw`, `device_generic_tuya_universal`, `curtain_motor_wall`, `curtain_motor_shutter`) to use driver-scoped prefixes.
 
 ---
 

--- a/drivers/button_wireless_smart/driver.flow.compose.json
+++ b/drivers/button_wireless_smart/driver.flow.compose.json
@@ -162,7 +162,7 @@
       }
     },
     {
-      "id": "button_wireless_1_battery_low",
+      "id": "button_wireless_smart_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible",

--- a/drivers/curtain_motor_shutter/driver.flow.compose.json
+++ b/drivers/curtain_motor_shutter/driver.flow.compose.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_set_changed",
+      "id": "curtain_motor_shutter_windowcoverings_set_changed",
       "title": {
         "en": "Position changed",
         "fr": "Position changée"
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": "curtain_motor_dim_changed",
+      "id": "curtain_motor_shutter_dim_changed",
       "title": {
         "en": "Brightness changed",
         "fr": "Luminosité changée"
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "curtain_motor_battery_low",
+      "id": "curtain_motor_shutter_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_on",
+      "id": "curtain_motor_shutter_physical_on",
       "title": {
         "en": "Physically opened",
         "fr": "Ouvert physiquement"
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_off",
+      "id": "curtain_motor_shutter_physical_off",
       "title": {
         "en": "Physically closed",
         "fr": "Fermé physiquement"
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_single",
+      "id": "curtain_motor_shutter_physical_single",
       "title": {
         "en": "Physically pressed",
         "fr": "Pressé physiquement"
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "curtain_motor_lux_changed",
+      "id": "curtain_motor_shutter_lux_changed",
       "title": {
         "en": "Luminance changed",
         "fr": "Luminance changée",
@@ -179,7 +179,7 @@
   ],
   "actions": [
     {
-      "id": "curtain_motor_set_windowcoverings_set",
+      "id": "curtain_motor_shutter_set_windowcoverings_set",
       "title": {
         "en": "Set position to...",
         "fr": "Régler la position à..."
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_open",
+      "id": "curtain_motor_shutter_windowcoverings_open",
       "title": {
         "en": "Open",
         "fr": "Ouvrir"
@@ -217,7 +217,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_close",
+      "id": "curtain_motor_shutter_windowcoverings_close",
       "title": {
         "en": "Close",
         "fr": "Fermer"
@@ -229,7 +229,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_dim",
+      "id": "curtain_motor_shutter_set_dim",
       "title": {
         "en": "Set brightness to...",
         "fr": "Régler la luminosité à..."
@@ -255,7 +255,7 @@
       }
     },
     {
-      "id": "curtain_motor_stop",
+      "id": "curtain_motor_shutter_stop",
       "title": {
         "en": "Stop",
         "fr": "Arrêter",
@@ -271,7 +271,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_favorite",
+      "id": "curtain_motor_shutter_set_favorite",
       "title": {
         "en": "Go to favorite position",
         "fr": "Aller position favorite",
@@ -291,7 +291,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_brightness",
+      "id": "curtain_motor_shutter_set_brightness",
       "title": {
         "en": "Set brightness",
         "fr": "Régler luminosité",
@@ -317,7 +317,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_position",
+      "id": "curtain_motor_shutter_set_position",
       "title": {
         "en": "Set position",
         "fr": "Régler position",
@@ -343,7 +343,7 @@
       }
     },
     {
-      "id": "curtain_motor_open",
+      "id": "curtain_motor_shutter_open",
       "title": {
         "en": "Open",
         "fr": "Ouvrir",
@@ -359,7 +359,7 @@
       }
     },
     {
-      "id": "curtain_motor_close",
+      "id": "curtain_motor_shutter_close",
       "title": {
         "en": "Close",
         "fr": "Fermer",

--- a/drivers/curtain_motor_wall/driver.flow.compose.json
+++ b/drivers/curtain_motor_wall/driver.flow.compose.json
@@ -33,7 +33,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_set_changed",
+      "id": "curtain_motor_wall_windowcoverings_set_changed",
       "title": {
         "en": "Position changed",
         "fr": "Position changée"
@@ -56,7 +56,7 @@
       }
     },
     {
-      "id": "curtain_motor_dim_changed",
+      "id": "curtain_motor_wall_dim_changed",
       "title": {
         "en": "Brightness changed",
         "fr": "Luminosité changée"
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "curtain_motor_battery_low",
+      "id": "curtain_motor_wall_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_on",
+      "id": "curtain_motor_wall_physical_on",
       "title": {
         "en": "Physically opened",
         "fr": "Ouvert physiquement"
@@ -117,7 +117,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_off",
+      "id": "curtain_motor_wall_physical_off",
       "title": {
         "en": "Physically closed",
         "fr": "Fermé physiquement"
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "curtain_motor_physical_single",
+      "id": "curtain_motor_wall_physical_single",
       "title": {
         "en": "Physically pressed",
         "fr": "Pressé physiquement"
@@ -161,7 +161,7 @@
       }
     },
     {
-      "id": "curtain_motor_lux_changed",
+      "id": "curtain_motor_wall_lux_changed",
       "title": {
         "en": "Luminance changed",
         "fr": "Luminance changée",
@@ -179,7 +179,7 @@
   ],
   "actions": [
     {
-      "id": "curtain_motor_set_windowcoverings_set",
+      "id": "curtain_motor_wall_set_windowcoverings_set",
       "title": {
         "en": "Set position to...",
         "fr": "Régler la position à..."
@@ -205,7 +205,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_open",
+      "id": "curtain_motor_wall_windowcoverings_open",
       "title": {
         "en": "Open",
         "fr": "Ouvrir"
@@ -217,7 +217,7 @@
       }
     },
     {
-      "id": "curtain_motor_windowcoverings_close",
+      "id": "curtain_motor_wall_windowcoverings_close",
       "title": {
         "en": "Close",
         "fr": "Fermer"
@@ -229,7 +229,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_dim",
+      "id": "curtain_motor_wall_set_dim",
       "title": {
         "en": "Set brightness to...",
         "fr": "Régler la luminosité à..."
@@ -255,7 +255,7 @@
       }
     },
     {
-      "id": "curtain_motor_stop",
+      "id": "curtain_motor_wall_stop",
       "title": {
         "en": "Stop",
         "fr": "Arrêter",
@@ -271,7 +271,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_favorite",
+      "id": "curtain_motor_wall_set_favorite",
       "title": {
         "en": "Go to favorite position",
         "fr": "Aller position favorite",
@@ -291,7 +291,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_brightness",
+      "id": "curtain_motor_wall_set_brightness",
       "title": {
         "en": "Set brightness",
         "fr": "Régler luminosité",
@@ -317,7 +317,7 @@
       }
     },
     {
-      "id": "curtain_motor_set_position",
+      "id": "curtain_motor_wall_set_position",
       "title": {
         "en": "Set position",
         "fr": "Régler position",
@@ -343,7 +343,7 @@
       }
     },
     {
-      "id": "curtain_motor_open",
+      "id": "curtain_motor_wall_open",
       "title": {
         "en": "Open",
         "fr": "Ouvrir",
@@ -359,7 +359,7 @@
       }
     },
     {
-      "id": "curtain_motor_close",
+      "id": "curtain_motor_wall_close",
       "title": {
         "en": "Close",
         "fr": "Fermer",

--- a/drivers/device_generic_tuya_universal/driver.flow.compose.json
+++ b/drivers/device_generic_tuya_universal/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
   "triggers": [
     {
-      "id": "generic_tuya_measure_temperature_changed",
+      "id": "device_generic_tuya_universal_measure_temperature_changed",
       "title": {
         "en": "Temperature changed",
         "fr": "Température changée"
@@ -24,7 +24,7 @@
       }
     },
     {
-      "id": "generic_tuya_measure_humidity_changed",
+      "id": "device_generic_tuya_universal_measure_humidity_changed",
       "title": {
         "en": "Humidity changed",
         "fr": "Humidité changée"
@@ -47,7 +47,7 @@
       }
     },
     {
-      "id": "generic_tuya_dp_received",
+      "id": "device_generic_tuya_universal_dp_received",
       "title": {
         "en": "Data Point received",
         "fr": "Point de données reçu"
@@ -79,7 +79,7 @@
       }
     },
     {
-      "id": "generic_tuya_battery_low",
+      "id": "device_generic_tuya_universal_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible",
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "generic_tuya_temp_changed",
+      "id": "device_generic_tuya_universal_temp_changed",
       "title": {
         "en": "Temperature changed",
         "fr": "Température changée",
@@ -111,7 +111,7 @@
       }
     },
     {
-      "id": "generic_tuya_humidity_changed",
+      "id": "device_generic_tuya_universal_humidity_changed",
       "title": {
         "en": "Humidity changed",
         "fr": "Humidité changée",
@@ -129,7 +129,7 @@
   ],
   "conditions": [
     {
-      "id": "generic_tuya_battery_above",
+      "id": "device_generic_tuya_universal_battery_above",
       "title": {
         "en": "Battery is above...",
         "fr": "Batterie au-dessus de..."
@@ -155,7 +155,7 @@
   ],
   "actions": [
     {
-      "id": "generic_tuya_request_dp",
+      "id": "device_generic_tuya_universal_request_dp",
       "title": {
         "en": "Request Data Point",
         "fr": "Demander Point de Données"

--- a/drivers/light_bulb_rgb_rgbw/driver.flow.compose.json
+++ b/drivers/light_bulb_rgb_rgbw/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
   "triggers": [
     {
-      "id": "bulb_rgb_smart_bulb_rgb_turned_on",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_turned_on",
       "title": {
         "en": "Turned on",
         "fr": "Allumé"
@@ -13,7 +13,7 @@
       }
     },
     {
-      "id": "bulb_rgb_smart_bulb_rgb_turned_off",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_turned_off",
       "title": {
         "en": "Turned off",
         "fr": "Éteint"
@@ -25,7 +25,7 @@
       }
     },
     {
-      "id": "bulb_rgb_smart_bulb_rgb_dim_changed",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_dim_changed",
       "title": {
         "en": "Brightness changed",
         "fr": "Luminosité changée"
@@ -48,7 +48,7 @@
       }
     },
     {
-      "id": "bulb_rgb_turned_on",
+      "id": "light_bulb_rgb_rgbw_turned_on",
       "title": {
         "en": "Turned on",
         "fr": "Allumé",
@@ -64,7 +64,7 @@
       }
     },
     {
-      "id": "bulb_rgb_turned_off",
+      "id": "light_bulb_rgb_rgbw_turned_off",
       "title": {
         "en": "Turned off",
         "fr": "Éteint",
@@ -80,7 +80,7 @@
       }
     },
     {
-      "id": "bulb_rgb_battery_low",
+      "id": "light_bulb_rgb_rgbw_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible",
@@ -98,7 +98,7 @@
   ],
   "conditions": [
     {
-      "id": "bulb_rgb_smart_bulb_rgb_is_on",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_is_on",
       "title": {
         "en": "Is turned !{{on|off}}",
         "fr": "Est !{{allumé|éteint}}"
@@ -110,7 +110,7 @@
       }
     },
     {
-      "id": "bulb_rgb_is_on",
+      "id": "light_bulb_rgb_rgbw_is_on",
       "title": {
         "en": "Is !{{on|off}}",
         "fr": "Est !{{allumé|éteint}}",
@@ -128,7 +128,7 @@
   ],
   "actions": [
     {
-      "id": "bulb_rgb_smart_bulb_rgb_turn_on",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_turn_on",
       "title": {
         "en": "Turn on",
         "fr": "Allumer"
@@ -140,7 +140,7 @@
       }
     },
     {
-      "id": "bulb_rgb_smart_bulb_rgb_turn_off",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_turn_off",
       "title": {
         "en": "Turn off",
         "fr": "Éteindre"
@@ -152,7 +152,7 @@
       }
     },
     {
-      "id": "bulb_rgb_smart_bulb_rgb_toggle",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_toggle",
       "title": {
         "en": "Toggle on or off",
         "fr": "Basculer"
@@ -164,7 +164,7 @@
       }
     },
     {
-      "id": "bulb_rgb_smart_bulb_rgb_set_dim",
+      "id": "light_bulb_rgb_rgbw_smart_bulb_rgb_set_dim",
       "title": {
         "en": "Set brightness to...",
         "fr": "Régler la luminosité à..."
@@ -190,7 +190,7 @@
       }
     },
     {
-      "id": "bulb_rgb_turn_on",
+      "id": "light_bulb_rgb_rgbw_turn_on",
       "title": {
         "en": "Turn on",
         "fr": "Allumer",
@@ -206,7 +206,7 @@
       }
     },
     {
-      "id": "bulb_rgb_turn_off",
+      "id": "light_bulb_rgb_rgbw_turn_off",
       "title": {
         "en": "Turn off",
         "fr": "Éteindre",
@@ -222,7 +222,7 @@
       }
     },
     {
-      "id": "bulb_rgb_toggle",
+      "id": "light_bulb_rgb_rgbw_toggle",
       "title": {
         "en": "Toggle",
         "fr": "Basculer",
@@ -238,7 +238,7 @@
       }
     },
     {
-      "id": "bulb_rgb_set_brightness",
+      "id": "light_bulb_rgb_rgbw_set_brightness",
       "title": {
         "en": "Set brightness",
         "fr": "Régler luminosité",

--- a/drivers/sensor_climate_contact/driver.flow.compose.json
+++ b/drivers/sensor_climate_contact/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
   "triggers": [
     {
-      "id": "climate_sensor_temperature_changed",
+      "id": "sensor_climate_contact_temperature_changed",
       "highlight": true,
       "title": {
         "en": "Temperature changed",
@@ -25,7 +25,7 @@
       }
     },
     {
-      "id": "climate_sensor_humidity_changed",
+      "id": "sensor_climate_contact_humidity_changed",
       "title": {
         "en": "Humidity changed",
         "fr": "Humidité changée"
@@ -48,7 +48,7 @@
       }
     },
     {
-      "id": "climate_sensor_battery_low",
+      "id": "sensor_climate_contact_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible"
@@ -60,7 +60,7 @@
       }
     },
     {
-      "id": "climate_sensor_temperature_alarm_high",
+      "id": "sensor_climate_contact_temperature_alarm_high",
       "title": {
         "en": "Temperature too high",
         "fr": "Température trop haute"
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "climate_sensor_temperature_alarm_low",
+      "id": "sensor_climate_contact_temperature_alarm_low",
       "title": {
         "en": "Temperature too low",
         "fr": "Température trop basse"
@@ -84,7 +84,7 @@
       }
     },
     {
-      "id": "climate_sensor_humidity_alarm_high",
+      "id": "sensor_climate_contact_humidity_alarm_high",
       "title": {
         "en": "Humidity too high",
         "fr": "Humidité trop haute"
@@ -96,7 +96,7 @@
       }
     },
     {
-      "id": "climate_sensor_humidity_alarm_low",
+      "id": "sensor_climate_contact_humidity_alarm_low",
       "title": {
         "en": "Humidity too low",
         "fr": "Humidité trop basse"
@@ -108,7 +108,7 @@
       }
     },
     {
-      "id": "climate_sensor_temp_changed",
+      "id": "sensor_climate_contact_temp_changed",
       "title": {
         "en": "Temperature changed",
         "fr": "Température changée",
@@ -126,7 +126,7 @@
   ],
   "conditions": [
     {
-      "id": "climate_sensor_temperature_above",
+      "id": "sensor_climate_contact_temperature_above",
       "title": {
         "en": "Temperature is above",
         "fr": "Température supérieure à"
@@ -150,7 +150,7 @@
       }
     },
     {
-      "id": "climate_sensor_temperature_below",
+      "id": "sensor_climate_contact_temperature_below",
       "title": {
         "en": "Temperature is below",
         "fr": "Température inférieure à"
@@ -174,7 +174,7 @@
       }
     },
     {
-      "id": "climate_sensor_humidity_above",
+      "id": "sensor_climate_contact_humidity_above",
       "title": {
         "en": "Humidity is above",
         "fr": "Humidité supérieure à"
@@ -198,7 +198,7 @@
       }
     },
     {
-      "id": "climate_sensor_humidity_below",
+      "id": "sensor_climate_contact_humidity_below",
       "title": {
         "en": "Humidity is below",
         "fr": "Humidité inférieure à"

--- a/drivers/sensor_contact_motion/driver.flow.compose.json
+++ b/drivers/sensor_contact_motion/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
   "triggers": [
     {
-      "id": "motion_sensor_motion_detected",
+      "id": "sensor_contact_motion_motion_detected",
       "highlight": true,
       "title": {
         "en": "Motion detected",
@@ -14,7 +14,7 @@
       }
     },
     {
-      "id": "motion_sensor_motion_cleared",
+      "id": "sensor_contact_motion_motion_cleared",
       "title": {
         "en": "Motion cleared",
         "fr": "Mouvement terminé"
@@ -26,7 +26,7 @@
       }
     },
     {
-      "id": "motion_sensor_battery_low",
+      "id": "sensor_contact_motion_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible"
@@ -38,7 +38,7 @@
       }
     },
     {
-      "id": "motion_sensor_battery_changed",
+      "id": "sensor_contact_motion_battery_changed",
       "title": {
         "en": "Battery level changed",
         "fr": "Niveau batterie changé"
@@ -61,7 +61,7 @@
       }
     },
     {
-      "id": "motion_sensor_tamper_true",
+      "id": "sensor_contact_motion_tamper_true",
       "title": {
         "en": "Tamper alarm triggered",
         "fr": "Alarme anti-sabotage déclenchée",
@@ -77,7 +77,7 @@
       }
     },
     {
-      "id": "motion_sensor_tamper_false",
+      "id": "sensor_contact_motion_tamper_false",
       "title": {
         "en": "Tamper alarm cleared",
         "fr": "Alarme anti-sabotage terminée",
@@ -93,7 +93,7 @@
       }
     },
     {
-      "id": "motion_sensor_lux_changed",
+      "id": "sensor_contact_motion_lux_changed",
       "title": {
         "en": "Luminance changed",
         "fr": "Luminance changée",
@@ -139,7 +139,7 @@
       }
     },
     {
-      "id": "motion_sensor_tamper_alarm",
+      "id": "sensor_contact_motion_tamper_alarm",
       "title": {
         "en": "Tamper alarm",
         "fr": "Alarme sabotage",
@@ -157,7 +157,7 @@
   ],
   "conditions": [
     {
-      "id": "motion_sensor_motion_active",
+      "id": "sensor_contact_motion_motion_active",
       "title": {
         "en": "Motion !{{is|is not}} detected",
         "fr": "Mouvement !{{est|n'est pas}} détecté"
@@ -169,7 +169,7 @@
       }
     },
     {
-      "id": "motion_sensor_tamper_active",
+      "id": "sensor_contact_motion_tamper_active",
       "title": {
         "en": "Tamper !{{is|is not}} active",
         "fr": "Sabotage !{{est|n'est pas}} actif",

--- a/drivers/sensor_motion_radar/driver.flow.compose.json
+++ b/drivers/sensor_motion_radar/driver.flow.compose.json
@@ -1,7 +1,7 @@
 {
   "triggers": [
     {
-      "id": "motion_sensor_radar_mmwave_presence_detected",
+      "id": "sensor_motion_radar_presence_detected",
       "title": {
         "en": "Presence detected",
         "fr": "Présence détectée"
@@ -13,7 +13,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_presence_cleared",
+      "id": "sensor_motion_radar_presence_cleared",
       "title": {
         "en": "Presence cleared",
         "fr": "Présence disparue"
@@ -25,7 +25,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_motion_detected",
+      "id": "sensor_motion_radar_motion_detected",
       "title": {
         "en": "Motion detected",
         "fr": "Mouvement détecté"
@@ -37,7 +37,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_no_motion",
+      "id": "sensor_motion_radar_no_motion",
       "title": {
         "en": "No motion",
         "fr": "Aucun mouvement"
@@ -49,7 +49,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_illuminance_changed",
+      "id": "sensor_motion_radar_illuminance_changed",
       "title": {
         "en": "Illuminance changed",
         "fr": "Luminosité changée"
@@ -72,7 +72,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_temperature_changed",
+      "id": "sensor_motion_radar_temperature_changed",
       "title": {
         "en": "Temperature changed",
         "fr": "Température changée"
@@ -95,7 +95,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_humidity_changed",
+      "id": "sensor_motion_radar_humidity_changed",
       "title": {
         "en": "Humidity changed",
         "fr": "Humidité changée"
@@ -118,7 +118,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_target_distance_changed",
+      "id": "sensor_motion_radar_target_distance_changed",
       "title": {
         "en": "Target distance changed",
         "fr": "Distance cible changée"
@@ -141,7 +141,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_battery_low",
+      "id": "sensor_motion_radar_battery_low",
       "title": {
         "en": "Battery low",
         "fr": "Batterie faible"
@@ -153,7 +153,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_battery_changed",
+      "id": "sensor_motion_radar_battery_changed",
       "title": {
         "en": "Battery level changed",
         "fr": "Niveau batterie changé"
@@ -176,7 +176,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_distance_changed",
+      "id": "sensor_motion_radar_distance_changed",
       "title": {
         "en": "Distance changed",
         "fr": "Distance changée",
@@ -192,7 +192,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_temp_changed",
+      "id": "sensor_motion_radar_temp_changed",
       "title": {
         "en": "Temperature changed",
         "fr": "Température changée",
@@ -208,7 +208,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_lux_changed",
+      "id": "sensor_motion_radar_lux_changed",
       "title": {
         "en": "Luminance changed",
         "fr": "Luminance changée",
@@ -226,7 +226,7 @@
   ],
   "conditions": [
     {
-      "id": "motion_sensor_radar_mmwave_is_presence_detected",
+      "id": "sensor_motion_radar_is_presence_detected",
       "title": {
         "en": "Presence is !{{detected|not detected}}",
         "fr": "Présence !{{détectée|non détectée}}"
@@ -238,7 +238,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_illuminance_above",
+      "id": "sensor_motion_radar_illuminance_above",
       "title": {
         "en": "Illuminance is above",
         "fr": "Luminosité supérieure à"
@@ -262,7 +262,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_illuminance_below",
+      "id": "sensor_motion_radar_illuminance_below",
       "title": {
         "en": "Illuminance is below",
         "fr": "Luminosité inférieure à"
@@ -286,7 +286,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_temperature_above",
+      "id": "sensor_motion_radar_temperature_above",
       "title": {
         "en": "Temperature is above",
         "fr": "Température supérieure à"
@@ -310,7 +310,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_target_distance_less_than",
+      "id": "sensor_motion_radar_target_distance_less_than",
       "title": {
         "en": "Target distance is less than",
         "fr": "Distance cible inférieure à"
@@ -334,7 +334,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_motion_active",
+      "id": "sensor_motion_radar_motion_active",
       "title": {
         "en": "Motion !{{is|is not}} detected",
         "fr": "Mouvement !{{est|n'est pas}} détecté",
@@ -352,7 +352,7 @@
   ],
   "actions": [
     {
-      "id": "motion_sensor_radar_mmwave_set_radar_sensitivity",
+      "id": "sensor_motion_radar_set_radar_sensitivity",
       "title": {
         "en": "Set radar sensitivity",
         "fr": "Définir sensibilité radar"
@@ -376,7 +376,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_set_detection_range",
+      "id": "sensor_motion_radar_set_detection_range",
       "title": {
         "en": "Set detection range",
         "fr": "Définir plage de détection"
@@ -411,7 +411,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_set_fading_time",
+      "id": "sensor_motion_radar_set_fading_time",
       "title": {
         "en": "Set fading time",
         "fr": "Définir délai d'absence"
@@ -435,7 +435,7 @@
       }
     },
     {
-      "id": "motion_sensor_radar_mmwave_set_detection_delay",
+      "id": "sensor_motion_radar_set_detection_delay",
       "title": {
         "en": "Set detection delay",
         "fr": "Définir délai de détection"


### PR DESCRIPTION
# Pull Request

## What Changed
Renamed 99 duplicate flow card IDs across 8 driver flow compose files to use driver-scoped prefixes:
- `sensor_motion_radar` — 23 IDs (were prefixed `motion_sensor_radar_mmwave_`)
- `sensor_contact_motion` — 10 IDs (were prefixed `motion_sensor_`)
- `sensor_climate_contact` — 12 IDs (were prefixed `climate_sensor_`)
- `light_bulb_rgb_rgbw` — 16 IDs (were prefixed `bulb_rgb_`)
- `device_generic_tuya_universal` — 8 IDs (were prefixed `generic_tuya_`)
- `curtain_motor_wall` — 15 IDs (were prefixed `curtain_motor_`)
- `curtain_motor_shutter` — 15 IDs (were prefixed `curtain_motor_`)
- `button_wireless_smart` — 1 ID (`button_wireless_1_battery_low`)

## Why
Homey publish validation rejected the app with:
> "Found multiple Flow card triggers with the id X, all Flow cards should have a unique id."

Multiple drivers shared identical flow card IDs copied from a canonical driver, violating Homey's global uniqueness requirement.

## Related Issue
N/A

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
- [x] Tested locally with `homey app run`
- [ ] Tested device pairing
- [ ] Tested all capabilities
- [ ] Tested edge cases

`homey app validate --level publish` — ✅ passed after fix. Custom Node.js script confirmed 0 duplicate IDs remaining across all 100+ driver flow compose files.

## Checklist
- [x] `homey app validate --level publish` passes
- [ ] ESLint passes (no errors) — pre-existing failures, not introduced by this PR
- [ ] Device matrix updated (if driver change) — matrix script missing, pre-existing issue
- [ ] Documentation updated (if needed) — N/A
- [x] CHANGELOG.md updated
- [ ] No console.log() statements left — pre-existing, not in changed files
- [x] Code follows project style
- [x] Commit messages are clear

## Screenshots / Logs (if applicable)
N/A

## Additional Notes
ESLint errors and `console.log` occurrences are pre-existing and present in JS files not touched by this PR. They should be addressed in a separate cleanup PR.