### PR TITLE
fix: stop Tuya soil sensor safe capability crash

### DIFF
--- a/lib/TuyaSpecificClusterDevice.js
+++ b/lib/TuyaSpecificClusterDevice.js
@@ -145,10 +145,25 @@ class TuyaSpecificClusterDevice extends ZigBeeDevice {
         }
     }
 
-    async setCapabilityValueSafe(capability, value) {
-        if (this.hasCapability(capability)) {
-            return this.setCapabilityValue(capability, value).catch(this.error);
+    async safeSetCapabilityValue(capability, value) {
+        if (this._destroyed || this.destroyed) return undefined;
+
+        try {
+            if (typeof this.hasCapability === 'function' && !this.hasCapability(capability)) {
+                return undefined;
+            }
+
+            return await this.setCapabilityValue(capability, value);
+        } catch (err) {
+            if (typeof this.error === 'function') {
+                this.error(`[SAFE-SET] ${capability} failed:`, err);
+            }
+            return undefined;
         }
+    }
+
+    async setCapabilityValueSafe(capability, value) {
+        return this.safeSetCapabilityValue(capability, value);
     }
 
     markAppCommand() {


### PR DESCRIPTION
## Summary

Fixes the Homey crash reported by email for `com.dlnraja.tuya.zigbee` on Homey Pro 2023, where `soilsensor_2.updateData()` called `this.safeSetCapabilityValue(...)` but the Tuya-specific base device class did not define that method.

## Root cause

`drivers/soilsensor_2/device.js` and other Tuya-specific drivers expect `safeSetCapabilityValue()`. `TuyaSpecificClusterDevice` only exposed `setCapabilityValueSafe()`, so datapoint updates crashed with `TypeError: this.safeSetCapabilityValue is not a function`.

## Change

- Adds `safeSetCapabilityValue(capability, value)` to `lib/TuyaSpecificClusterDevice.js`.
- Keeps `setCapabilityValueSafe()` as an alias for existing callers.
- Guards destroyed devices, missing capabilities, and capability write errors so datapoint processing does not crash the app.

## Validation

- `node --check lib\TuyaSpecificClusterDevice.js`
- `npm test`
- `npm run check:all`
- `npm run precommit`
- `npm run validate:fingerprints`
- `node .github\scripts\fp-collision-check.js --baseline .github\fingerprint-collision-baseline.json`
- `npm run validate:publish`
- Git pre-commit and pre-push gates passed, including security scan.