### PR TITLE
fix: guard Google Assistant voice buttons and verified automerge

### DIFF
--- a/.github/scripts/smart-pr-merge.js
+++ b/.github/scripts/smart-pr-merge.js
@@ -43,6 +43,64 @@ function git(cmd) {
   }
 }
 
+function sh(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+function runRequired(command, options = {}) {
+  try {
+    return execSync(command, {
+      encoding: 'utf8',
+      timeout: options.timeout || 60000,
+      env: options.env || process.env,
+    }).trim();
+  } catch (e) {
+    const stdout = e.stdout?.toString().trim();
+    const stderr = e.stderr?.toString().trim();
+    const detail = [stdout, stderr, e.message].filter(Boolean).join('\n');
+    throw new Error(`${command} failed\n${detail}`);
+  }
+}
+
+function gitRequired(cmd, options = {}) {
+  return runRequired(`git ${cmd}`, options);
+}
+
+function ghRequired(cmd, options = {}) {
+  return runRequired(`gh ${cmd}`, {
+    ...options,
+    env: { ...process.env, GH_TOKEN: GH },
+  });
+}
+
+function configureGitIdentity() {
+  gitRequired('config user.name "github-actions[bot]"');
+  gitRequired('config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
+}
+
+function checkoutBaseBranch() {
+  gitRequired('fetch origin master');
+  gitRequired('checkout -B master origin/master');
+}
+
+function abortMergeQuietly() {
+  git('merge --abort 2>/dev/null || true');
+}
+
+function verifyIntegrated(prNumber, prData) {
+  if (!prData.headRefOid) {
+    throw new Error(`PR #${prNumber} has no headRefOid; refusing to report a merge without verification`);
+  }
+
+  gitRequired('fetch origin master');
+  const containingBranches = gitRequired(`branch -r --contains ${prData.headRefOid}`);
+  if (!containingBranches.split(/\s+/).includes('origin/master')) {
+    throw new Error(`PR #${prNumber} head ${prData.headRefOid} is not reachable from origin/master`);
+  }
+
+  log(`  ✅ Verified PR #${prNumber} head is reachable from origin/master`);
+}
+
 // Classify what a PR changes
 function classifyChanges(files) {
   const cats = { drivers: [], fingerprints: [], scripts: [], workflows: [], deps: [], docs: [], other: [] };
@@ -419,8 +477,10 @@ function generateMergeSummary(prData, cats, risk, reasons, mergeType, conflictFi
   return lines.join('\n');
 }
 
-// Close a PR with a human-readable summary, then delete the branch
+// Comment on a merged PR only after verifying the head commit reached master.
 function closePR(prNumber, prData, cats, risk, reasons, mergeType, conflictFiles) {
+  verifyIntegrated(prNumber, prData);
+
   const summary = generateMergeSummary(prData, cats, risk, reasons, mergeType, conflictFiles || []);
 
   // Write comment to temp file to avoid shell escaping issues with backticks, quotes, etc.
@@ -435,10 +495,7 @@ function closePR(prNumber, prData, cats, risk, reasons, mergeType, conflictFiles
     gh(`pr comment ${prNumber} -R ${REPO} --body "✅ PR #${prNumber} merged via Smart Auto-Merge"`);
   }
 
-  // Close the PR with a human-readable closing comment
-  gh(`pr close ${prNumber} -R ${REPO} --comment "Merged into master — all changes integrated successfully. See above comment for details."`);
-
-  // Delete the remote branch (cleanup)
+  // Delete the remote branch (cleanup). GitHub's merge API may already have done this.
   const branch = prData.headRefName;
   if (branch && branch !== 'master' && branch !== 'main') {
     log(`  Deleting branch: ${branch}`);
@@ -448,7 +505,7 @@ function closePR(prNumber, prData, cats, risk, reasons, mergeType, conflictFiles
   // Clean up temp file
   try { fs.unlinkSync(tmpFile); } catch {}
 
-  log(`  ✅ PR #${prNumber} closed with detailed summary and branch deleted`);
+  log(`  ✅ PR #${prNumber} verified, commented, and branch cleanup attempted`);
 }
 
 // Process a single PR
@@ -456,7 +513,7 @@ async function processPR(prNumber) {
   log(`\n### Processing PR #${prNumber}`);
 
   // Get PR info
-  const prJson = gh(`pr view ${prNumber} -R ${REPO} --json title,author,headRefName,body,files,labels,state,mergeable`);
+  const prJson = gh(`pr view ${prNumber} -R ${REPO} --json title,author,headRefName,headRefOid,body,files,labels,state,mergeable`);
   if (!prJson) {
     log(`  Could not fetch PR #${prNumber}`);
     return false;
@@ -489,6 +546,8 @@ async function processPR(prNumber) {
   if (prData.mergeable === 'CONFLICTING') {
     log('  ⚠️ PR has merge conflicts');
 
+    checkoutBaseBranch();
+
     // Fetch the PR branch
     git(`fetch origin pull/${prNumber}/head:pr-${prNumber}`);
 
@@ -504,12 +563,14 @@ async function processPR(prNumber) {
       validation.checks.forEach(c => log(`  ${c}`));
 
       if (validation.valid && risk <= 5) {
-        git(`commit -m "Merge PR #${prNumber}: ${prData.title} (conflicts resolved) [skip ci]"`);
-        git('push origin HEAD');
+        configureGitIdentity();
+        gitRequired(`commit -m ${sh(`Merge PR #${prNumber}: ${prData.title} (conflicts resolved) [skip ci]`)}`);
+        gitRequired('push origin HEAD:refs/heads/master');
         closePR(prNumber, prData, cats, risk, reasons, 'conflict-resolved', conflict.files);
         return true;
       } else {
-        git('reset --hard HEAD~1');
+        abortMergeQuietly();
+        git('reset --hard origin/master');
         log(`  Validation failed or risk too high (${risk}/10), labeling for review`);
         gh(`pr edit ${prNumber} -R ${REPO} --add-label "needs-review,has-conflicts"`);
         gh(`pr comment ${prNumber} -R ${REPO} --body "⚠️ **Tentative de résolution automatique des conflits**\n\nLe merge a été tenté mais la validation a échoué ou le risque est trop élevé (${risk}/10).\n\n**Fichiers en conflit :** ${conflict.files.join(', ')}\n\nMerci de vérifier manuellement avant de fusionner.\n\n_🤖 Smart PR Auto-Merge_"`);
@@ -529,20 +590,22 @@ async function processPR(prNumber) {
     if (risk <= 4) {
       log('  Low risk, auto-merging...');
 
-      // Validate first by checking out the PR branch
-      git(`fetch origin pull/${prNumber}/head:pr-${prNumber}`);
-      git(`merge --no-commit --no-ff pr-${prNumber}`);
+      // Validate first by checking out master and merging the PR branch locally.
+      checkoutBaseBranch();
+      gitRequired(`fetch origin pull/${prNumber}/head:pr-${prNumber}`);
+      gitRequired(`merge --no-commit --no-ff pr-${prNumber}`);
 
       const validation = validateMerge();
       validation.checks.forEach(c => log(`  ${c}`));
 
       if (validation.valid) {
-        git(`commit -m "Merge PR #${prNumber}: ${prData.title} [skip ci]"`);
-        git('push origin HEAD');
+        abortMergeQuietly();
+        ghRequired(`pr merge ${prNumber} -R ${REPO} --merge --delete-branch --subject ${sh(`Merge PR #${prNumber}: ${prData.title}`)}`);
         closePR(prNumber, prData, cats, risk, reasons, 'clean');
         return true;
       } else {
-        git('merge --abort 2>/dev/null || git reset --hard HEAD');
+        abortMergeQuietly();
+        git('reset --hard origin/master');
         log('  Validation failed, requesting review');
         gh(`pr edit ${prNumber} -R ${REPO} --add-label "needs-review"`);
         gh(`pr comment ${prNumber} -R ${REPO} --body "⚠️ **Validation échouée**\n\nLe merge a été tenté mais la validation du code a échoué. Vérifiez les erreurs de syntaxe dans les drivers.\n\nChecks: ${validation.checks.join(' | ')}\n\n_🤖 Smart PR Auto-Merge_"`);

--- a/.github/workflows/smart-pr-merge.yml
+++ b/.github/workflows/smart-pr-merge.yml
@@ -93,17 +93,16 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-        run: node .github/scripts/smart-pr-merge.js "${{ steps.pr.outputs.mode }}" "${{ steps.pr.outputs.number }}"
-
-      - name: "Commit merge results"
-        continue-on-error: true
-        if: steps.merge.outputs.merged == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git diff --cached --quiet || git commit -m "Merge PR improvements [skip ci]"
-          git push origin HEAD || true
+          node .github/scripts/smart-pr-merge.js "${{ steps.pr.outputs.mode }}" "${{ steps.pr.outputs.number }}"
+
+      - name: "Verify smart merge result"
+        if: steps.merge.outputs.merged == 'true'
+        run: |
+          git status --short
+          echo "Smart merge script handled the verified merge and branch cleanup."
 
       - name: Summary
         if: always()

--- a/docs/BUTTON_CAPABILITY_GUIDE.md
+++ b/docs/BUTTON_CAPABILITY_GUIDE.md
@@ -18,6 +18,28 @@ Physical wireless buttons (TS0041, TS0215A, scene switches, etc.) are **event-on
 - They don't have an "on" or "off" state to display
 - The `button.1` capability is configured with `maintenanceAction: true` which hides it from the main UI
 
+### Google Assistant / Alexa Voice Safety
+
+Homey expanded Google Assistant and Alexa device sync in Homey Pro v12.3.3 / Homey app v9.1.0, including more controllable devices, Google Assistant PIN protection for security devices, and per-device voice assistant exclusions. That makes it more important that this app does not expose `button.*` capabilities as voice commands.
+
+Rule for this app:
+
+- All `button.*` capabilities must be `getable: false`, `setable: false`, and `maintenanceAction: true`.
+- Real voice control must use stateful capabilities such as `onoff`, `dim`, `windowcoverings`, or `locked`.
+- Virtual helper buttons such as `button.toggle`, `button.toggle_1`, and `button.identify` are maintenance/event helpers only; exposing them as setable buttons risks loops, missing listener errors, and ambiguous Google Home/Alexa controls.
+- For locks, alarms, garage doors, and other security-sensitive devices, Homey's Google Assistant PIN/exclusion settings remain the user-facing safety layer; the app must still keep synthetic buttons non-commandable.
+
+Evidence behind this rule:
+
+- GitHub issue `#114` (`TS0041` / `_TZ3000_b4awzgct`) showed a Google Home advertised smart button where the real fixes were fingerprint case variants, event-only flows, and battery handling.
+- Upstream JohanBendz PR `#214` added Moes wall switches advertised for Alexa/Google Home; those devices are stateful switches and should be exposed through `onoff`, not extra virtual `button.*` command surfaces.
+- Mail/forum feedback around Homey Google Assistant/Alexa updates confirms broader voice sync, so the app needs an automated guard rather than relying on users to exclude devices manually.
+
+Automation:
+
+- Run `node scripts/validation/fix-button-capability-options.js --apply` to repair all driver compose files.
+- Run `npm run check:voice` to fail fast if any `button.*` capability becomes voice-commandable again.
+
 ### How to Use Wireless Buttons
 
 #### ✅ Correct Usage: Flow Triggers

--- a/drivers/plug_smart_switch/driver.compose.json
+++ b/drivers/plug_smart_switch/driver.compose.json
@@ -657,12 +657,18 @@
     "button.toggle": {
       "title": {
         "en": "toggle"
-      }
+      },
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     },
     "button.identify": {
       "title": {
         "en": "identify"
-      }
+      },
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     },
     "button.1": {
       "title": {

--- a/drivers/switch/driver.compose.json
+++ b/drivers/switch/driver.compose.json
@@ -539,6 +539,26 @@
       "maintenanceAction": true,
       "getable": false,
       "setable": false
+    },
+    "button.toggle_1": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_2": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.identify": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     }
   },
   "metadata": {

--- a/drivers/switch_1gang/driver.compose.json
+++ b/drivers/switch_1gang/driver.compose.json
@@ -1106,6 +1106,16 @@
       "maintenanceAction": true,
       "getable": false,
       "setable": false
+    },
+    "button.toggle": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.identify": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     }
   },
   "metadata": {

--- a/drivers/switch_2gang/driver.compose.json
+++ b/drivers/switch_2gang/driver.compose.json
@@ -647,6 +647,21 @@
         "nl": "Batterij",
         "de": "Batterie"
       }
+    },
+    "button.toggle_1": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_2": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.identify": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     }
   },
   "metadata": {

--- a/drivers/switch_3gang/driver.compose.json
+++ b/drivers/switch_3gang/driver.compose.json
@@ -663,6 +663,26 @@
         "nl": "Batterij",
         "de": "Batterie"
       }
+    },
+    "button.toggle_1": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_2": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_3": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.identify": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     }
   },
   "metadata": {

--- a/drivers/switch_4gang/driver.compose.json
+++ b/drivers/switch_4gang/driver.compose.json
@@ -709,6 +709,31 @@
         "nl": "Batterij",
         "de": "Batterie"
       }
+    },
+    "button.toggle_1": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_2": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_3": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.toggle_4": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
+    },
+    "button.identify": {
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     }
   },
   "metadata": {

--- a/drivers/switch_wall/driver.compose.json
+++ b/drivers/switch_wall/driver.compose.json
@@ -655,12 +655,18 @@
     "button.toggle": {
       "title": {
         "en": "toggle"
-      }
+      },
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     },
     "button.identify": {
       "title": {
         "en": "identify"
-      }
+      },
+      "setable": false,
+      "maintenanceAction": true,
+      "getable": false
     },
     "button.1": {
       "title": {

--- a/package.json
+++ b/package.json
@@ -45,14 +45,14 @@
     "check:health": "node scripts/validation/check-driver-health.js",
     "check:wifi": "node scripts/validation/check-wifi-lifecycle.js",
     "check:mixin": "node scripts/validation/check-mixin-order.js",
-    "check:all": "npm run check && npm run check:athom",
+    "check:all": "npm run check && npm run check:athom && npm run check:voice",
     "titan": "node scripts/ci/titan-pre-commit.js",
     "titan:json": "node scripts/ci/titan-pre-commit.js --json",
     "titan:fix": "node scripts/ci/pre-commit-checks.js --fix",
     "sync:branches": "node scripts/automation/sync-branches.js",
     "sync:branches:dry": "node scripts/automation/sync-branches.js --dry-run",
-    "precommit": "node scripts/ci/titan-pre-commit.js && node scripts/ci/security-scanner.js && node scripts/validation/check-mixin-order.js && npm run check:timer-context",
-    "precommit:full": "node scripts/ci/titan-pre-commit.js && node scripts/PRE_COMMIT_CHECKS.js && node scripts/ci/security-scanner.js && node scripts/ci/validate-all-yaml.js --json && node scripts/ci/check-flow-ids.js --json",
+    "precommit": "node scripts/ci/titan-pre-commit.js && node scripts/ci/security-scanner.js && node scripts/validation/check-mixin-order.js && npm run check:timer-context && npm run check:voice",
+    "precommit:full": "node scripts/ci/titan-pre-commit.js && node scripts/PRE_COMMIT_CHECKS.js && node scripts/ci/security-scanner.js && node scripts/ci/validate-all-yaml.js --json && node scripts/ci/check-flow-ids.js --json && npm run check:voice",
     "pipeline": "node scripts/ULTIMATE_CI_CD_PIPELINE.js",
     "audit": "node scripts/COMPLETE_POWER_AUDIT.js",
     "clean": "node scripts/CLEAN_APP_JSON.js",
@@ -109,7 +109,8 @@
     "skills:audit": "node scripts/PRE_COMMIT_CHECKS.js",
     "skills:security": "node scripts/ci/security-scanner.js",
     "skills:prepush": "npm run precommit:full && npm test && npm run build-docs",
-    "check:timer-context": "node scripts/validation/check-homey-timer-context.js"
+    "check:timer-context": "node scripts/validation/check-homey-timer-context.js",
+    "check:voice": "node scripts/validation/check-google-assistant-voice-safety.js"
   },
   "keywords": [
     "homey",

--- a/scripts/validation/check-google-assistant-voice-safety.js
+++ b/scripts/validation/check-google-assistant-voice-safety.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Google Assistant / Alexa voice-safety gate.
+ *
+ * Homey can sync more devices to voice assistants than older app versions did.
+ * Real voice commands must stay on stateful capabilities such as onoff, dim,
+ * windowcoverings, locked, and alarm controls. Tuya button.* capabilities are
+ * physical events or maintenance helpers, so they must never be getable/setable
+ * command surfaces.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '../..');
+const DRIVERS_DIR = path.join(ROOT, 'drivers');
+
+const REQUIRED = {
+  getable: false,
+  setable: false,
+  maintenanceAction: true,
+};
+
+const violations = [];
+let checkedDrivers = 0;
+let checkedButtons = 0;
+
+function readJson(file) {
+  return JSON.parse(fs.readFileSync(file, 'utf8'));
+}
+
+for (const driverName of fs.readdirSync(DRIVERS_DIR)) {
+  const driverDir = path.join(DRIVERS_DIR, driverName);
+  if (!fs.statSync(driverDir).isDirectory()) continue;
+
+  const composePath = path.join(driverDir, 'driver.compose.json');
+  if (!fs.existsSync(composePath)) continue;
+
+  checkedDrivers++;
+  let compose;
+  try {
+    compose = readJson(composePath);
+  } catch (err) {
+    violations.push(`${driverName}: invalid driver.compose.json (${err.message})`);
+    continue;
+  }
+
+  const capabilities = Array.isArray(compose.capabilities) ? compose.capabilities : [];
+  const options = compose.capabilitiesOptions && typeof compose.capabilitiesOptions === 'object'
+    ? compose.capabilitiesOptions
+    : {};
+
+  for (const capabilityId of capabilities) {
+    if (!String(capabilityId).startsWith('button.')) continue;
+    checkedButtons++;
+
+    const capabilityOptions = options[capabilityId] || {};
+    for (const [key, expected] of Object.entries(REQUIRED)) {
+      if (capabilityOptions[key] !== expected) {
+        violations.push(`${driverName}: ${capabilityId}.${key} must be ${expected}`);
+      }
+    }
+  }
+}
+
+console.log('Google Assistant voice-safety gate');
+console.log(`Drivers checked: ${checkedDrivers}`);
+console.log(`button.* capabilities checked: ${checkedButtons}`);
+
+if (violations.length > 0) {
+  console.error(`\nVoice-safety violations: ${violations.length}`);
+  for (const violation of violations.slice(0, 30)) {
+    console.error(`  - ${violation}`);
+  }
+  if (violations.length > 30) {
+    console.error(`  - ... ${violations.length - 30} more`);
+  }
+  console.error('\nRun: node scripts/validation/fix-button-capability-options.js --apply');
+  process.exit(1);
+}
+
+console.log('OK: all button.* capabilities are event/maintenance-only.');

--- a/scripts/validation/fix-button-capability-options.js
+++ b/scripts/validation/fix-button-capability-options.js
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 'use strict';
 // fix-button-capability-options.js — Corrige capabilitiesOptions pour les boutons
-// ROOT CAUSE : setable:true → Homey exige registerCapabilityListener
-// FIX : setable:false + maintenanceAction:true (event-only, pas de listener requis)
-// Doc de référence : docs/BUTTON_CAPABILITY_GUIDE.md lignes 148-152
+// ROOT CAUSE : button.* setable/getable ambigu → Homey peut attendre un listener,
+// et les assistants vocaux peuvent interpréter des boutons virtuels comme des
+// commandes alors que les vrais contrôles passent par onoff/windowcoverings/etc.
+// FIX : button.* = event/maintenance only, jamais une commande vocale.
+// Doc de référence : docs/BUTTON_CAPABILITY_GUIDE.md
 
 const fs = require('fs');
 const path = require('path');
@@ -28,19 +30,13 @@ function processDriver(driverDir) {
   const hasButton = caps.some(c => c.startsWith('button.'));
   if (!hasButton) return;
 
-  // Skip les switches (ils ont button.X pour double-clic mais setable:true est légitime)
-  // On ne corrige QUE les boutons purs (event-only)
-  const isSwitch = driverName.startsWith('switch') || driverName === 'switch' ||
-                   driverName.startsWith('wall_switch') || driverName.startsWith('plug');
-  if (isSwitch) return;
-
   const opts = content.capabilitiesOptions || {};
   let changed = false;
 
   for (const capId of caps) {
     if (!capId.startsWith('button.')) continue;
     if (!opts[capId]) opts[capId] = {};
-    // FIX : setable doit être false (event-only), pas true
+    // FIX : setable doit être false (event/maintenance-only), pas true
     if (opts[capId].setable !== false) {
       opts[capId].setable = false;
       changed = true;
@@ -70,7 +66,7 @@ function processDriver(driverDir) {
       try { JSON.parse(fs.readFileSync(composePath, 'utf8')); }
       catch (e) { console.error(`❌ Corruption: ${path.basename(driverDir)}`); return; }
       fixed++;
-      console.log(`✅ ${path.basename(driverDir)}: button caps → setable:false + maintenanceAction:true`);
+      console.log(`✅ ${path.basename(driverDir)}: button caps → getable:false + setable:false + maintenanceAction:true`);
     } else {
       console.log(`🔍 ${path.basename(driverDir)}: needs fix (dry-run)`);
     }

--- a/scripts/validation/validate-driver-mesh.js
+++ b/scripts/validation/validate-driver-mesh.js
@@ -97,14 +97,17 @@ for (const drvName of driverDirs) {
     }
   }
 
-  // ─── 8. Invariant I7 : boutons purs ont setable:false (règle cap guide) ───
-  const isSwitch = drvName.startsWith('switch') || drvName.startsWith('wall_switch') || drvName.startsWith('plug');
-  if (!isSwitch && composeCaps.some(c => c.startsWith('button.'))) {
+  // ─── 8. Invariant I7 : button.* = event/maintenance only ────────────────
+  // Homey/Google Assistant/Alexa voice control must use real stateful
+  // capabilities (onoff, dim, windowcoverings, locked, etc.). button.*
+  // capabilities are physical events or maintenance helpers, not voice commands.
+  if (composeCaps.some(c => c.startsWith('button.'))) {
     const opts = compose.capabilitiesOptions || {};
     for (const c of composeCaps) {
       if (!c.startsWith('button.')) continue;
-      if (opts[c]?.setable === true) {
-        warn(`${drvName}: button "${c}" a setable:true → Missing Capability Listener risk`);
+      const o = opts[c] || {};
+      if (o.getable !== false || o.setable !== false || o.maintenanceAction !== true) {
+        fail(`${drvName}: button "${c}" must be getable:false + setable:false + maintenanceAction:true`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- analyze the Homey Google Assistant/Alexa update mail from 2025-03-27 plus the Google Home-related GitHub/forum signals around smart buttons and Moes switches
- make every `button.*` capability in driver compose files event/maintenance-only with `getable:false`, `setable:false`, and `maintenanceAction:true`
- add an automated Google Assistant/Alexa voice-safety gate and wire it into `check:all`, `precommit`, and `precommit:full`
- document why voice control must stay on stateful capabilities such as `onoff`, `dim`, `windowcoverings`, and `locked`
- fix Smart PR Auto-Merge so it cannot close/comment a PR as merged unless the PR head is actually reachable from `origin/master`

## Root Cause

Homey now syncs a broader set of devices to Google Assistant and Alexa. Some Tuya switch/plug drivers still had virtual helper buttons such as `button.toggle`, `button.toggle_1`, and `button.identify` without explicit event-only options. That leaves room for ambiguous assistant exposure, missing listener expectations, loops, or command surfaces that should actually be handled by real stateful capabilities.

During the first PR attempt (#434), Smart PR Auto-Merge validated the code but then swallowed `git commit`/`git push` failures, closed the PR, deleted the branch, and posted a false merged message while `origin/master` did not contain the head commit. This PR fixes that automation failure too.

## Evidence Cross-Checked

- Homey mail, 2025-03-27: expanded Google Assistant/Alexa sync, PIN support for security devices, and assistant exclusions.
- GitHub issue #114: TS0041 / `_TZ3000_b4awzgct` showed Google Home-marketed smart buttons should be fixed as fingerprint/event-flow/battery devices, not command widgets.
- Upstream JohanBendz PR #214: Moes wall switches advertised for Alexa/Google Home should expose stateful switch control through `onoff`, not synthetic button commands.
- Smart PR Auto-Merge run `28385756150` exposed the false-positive close path from #434.

## Validation

- `npm run check:voice`
- `node scripts\validation\validate-driver-mesh.js`
- `npm run check:all`
- `npm test`
- `npm run precommit`
- `npm run validate:publish`
- `node --check .github\scripts\smart-pr-merge.js`
- `node scripts\ci\validate-all-yaml.js --json`
- commit hook security scan
- push gate Athom/server checks

Known non-blocking warnings remain the existing synthetic manufacturerName pruning warning and future `titleFormatted` warnings from Homey validation.