### PR TITLE
fix(publish): strip unsafe device titleFormatted tokens

### DIFF
--- a/drivers/presence_detector/driver.flow.compose.json
+++ b/drivers/presence_detector/driver.flow.compose.json
@@ -45,13 +45,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Presence detected in room [[device]]",
-        "nl": "Aanwezigheid gedetecteerd in kamer [[device]]",
-        "fr": "Présence détectée dans la pièce [[device]]",
-        "de": "Anwesenheit im Raum erkannt [[device]]"
-      }
+      ]
     },
     {
       "id": "virtual_presence_cleared",
@@ -97,13 +91,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Presence cleared in room [[device]]",
-        "nl": "Aanwezigheid opgeheven in kamer [[device]]",
-        "fr": "Présence terminée dans la pièce [[device]]",
-        "de": "Anwesenheit im Raum beendet [[device]]"
-      }
+      ]
     },
     {
       "id": "virtual_presence_confidence_changed",
@@ -138,13 +126,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Confidence changed [[device]]",
-        "nl": "Vertrouwen gewijzigd [[device]]",
-        "fr": "Confiance changée [[device]]",
-        "de": "Vertrauen geändert [[device]]"
-      }
+      ]
     }
   ],
   "conditions": [
@@ -168,13 +150,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Room !{{is|is not}} occupied [[device]]",
-        "nl": "Kamer !{{is|is niet}} bezet [[device]]",
-        "fr": "La pièce !{{est|n'est pas}} occupée [[device]]",
-        "de": "Raum !{{ist|ist nicht}} besetzt [[device]]"
-      }
+      ]
     },
     {
       "id": "virtual_presence_confidence_above",
@@ -206,13 +182,7 @@
             "en": "50"
           }
         }
-      ],
-      "titleFormatted": {
-        "en": "Confidence !{{is above|is not above}} [[device]] [[threshold]]",
-        "nl": "Vertrouwen !{{is boven|is niet boven}} [[device]] [[threshold]]",
-        "fr": "Confiance !{{est au-dessus|n'est pas au-dessus}} [[device]] [[threshold]]",
-        "de": "Vertrauen !{{ist über|ist nicht über}} [[device]] [[threshold]]"
-      }
+      ]
     }
   ],
   "actions": [
@@ -236,13 +206,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Force presence in room [[device]]",
-        "nl": "Aanwezigheid forceren in kamer [[device]]",
-        "fr": "Forcer la présence dans la pièce [[device]]",
-        "de": "Anwesenheit im Raum erzwingen [[device]]"
-      }
+      ]
     },
     {
       "id": "virtual_presence_force_clear",
@@ -264,13 +228,7 @@
           "name": "device",
           "filter": "driverId=presence_detector"
         }
-      ],
-      "titleFormatted": {
-        "en": "Clear presence in room [[device]]",
-        "nl": "Aanwezigheid wissen in kamer [[device]]",
-        "fr": "Effacer la présence dans la pièce [[device]]",
-        "de": "Anwesenheit im Raum löschen [[device]]"
-      }
+      ]
     }
   ]
 }

--- a/scripts/maintenance/sanitize-manifest.cjs
+++ b/scripts/maintenance/sanitize-manifest.cjs
@@ -90,6 +90,23 @@ function dedupeFlowArgs(manifest) {
   return stripped;
 }
 
+function stripDeviceTitleFormatted(manifest) {
+  let stripped = 0;
+  const flow = manifest.flow || {};
+  for (const type of ['triggers', 'conditions', 'actions']) {
+    const cards = flow[type];
+    if (!Array.isArray(cards)) continue;
+
+    for (const card of cards) {
+      if (!card || !card.titleFormatted) continue;
+      if (!JSON.stringify(card.titleFormatted).includes('[[device]]')) continue;
+      delete card.titleFormatted;
+      stripped++;
+    }
+  }
+  return stripped;
+}
+
 function sanitizeManifestFile(manifestPath) {
   const label = path.relative(APP_ROOT, manifestPath).replace(/\\/g, '/') || manifestPath;
   if (!fs.existsSync(manifestPath)) {
@@ -150,7 +167,16 @@ function sanitizeManifestFile(manifestPath) {
     log(`${label}: stripped ${duplicateArgs} duplicate generated Flow arg(s).`);
   }
 
-  // 5) Drop the generator comment from build/publish manifests only
+  // 5) Strip device-token titleFormatted strings from compiled Flow cards.
+  //    Athom's publish validator rejects [[device]] in titleFormatted for
+  //    some generated driver conditions, even when local validation passes.
+  const deviceTitleFormatted = stripDeviceTitleFormatted(manifest);
+  if (deviceTitleFormatted > 0) {
+    changes += deviceTitleFormatted;
+    log(`${label}: stripped ${deviceTitleFormatted} device titleFormatted Flow card(s).`);
+  }
+
+  // 6) Drop the generator comment from build/publish manifests only
   //    (keep the tracked root app.json stable).
   const isTrackedRootManifest = path.resolve(manifestPath) === path.join(APP_ROOT, 'app.json');
   if (!isTrackedRootManifest && manifest._comment !== undefined) {
@@ -166,7 +192,7 @@ function sanitizeManifestFile(manifestPath) {
     log(`${label}: manifest already clean — no changes.`);
   }
 
-  // 6) Report suspicious drivers (informational, non-blocking).
+  // 7) Report suspicious drivers (informational, non-blocking).
   const suspicious = getDrivers(manifest).filter(
     d => d.zigbee && (!d.zigbee.manufacturerName || (Array.isArray(d.zigbee.manufacturerName) && d.zigbee.manufacturerName.length === 0))
   );
@@ -183,4 +209,4 @@ if (require.main === module) {
   process.exit(failures > 0 ? 1 : 0);
 }
 
-module.exports = { sanitizeManifestFile, stripGeneratedButtonOptions, dedupeFlowArgs };
+module.exports = { sanitizeManifestFile, stripGeneratedButtonOptions, dedupeFlowArgs, stripDeviceTitleFormatted };

--- a/test/sanitize-manifest.test.js
+++ b/test/sanitize-manifest.test.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('assert');
+const {
+  stripDeviceTitleFormatted,
+} = require('../scripts/maintenance/sanitize-manifest.cjs');
+
+describe('Manifest sanitizer', function() {
+  it('strips Flow titleFormatted entries that reference the device token', function() {
+    const manifest = {
+      flow: {
+        triggers: [
+          {
+            id: 'button_pressed',
+            titleFormatted: { en: 'Button pressed [[device]]' },
+          },
+          {
+            id: 'safe_trigger',
+            titleFormatted: { en: 'DP [[dp]] changed' },
+          },
+        ],
+        conditions: [
+          {
+            id: 'virtual_presence_confidence_above',
+            titleFormatted: {
+              en: 'Confidence !{{is above|is not above}} [[device]] [[threshold]]',
+            },
+          },
+        ],
+        actions: [
+          {
+            id: 'tuya_dp_send',
+            titleFormatted: { en: 'Send DP [[device]] [[dp]] [[value]]' },
+          },
+        ],
+      },
+    };
+
+    assert.strictEqual(stripDeviceTitleFormatted(manifest), 3);
+    assert.strictEqual(manifest.flow.triggers[0].titleFormatted, undefined);
+    assert.deepStrictEqual(manifest.flow.triggers[1].titleFormatted, { en: 'DP [[dp]] changed' });
+    assert.strictEqual(manifest.flow.conditions[0].titleFormatted, undefined);
+    assert.strictEqual(manifest.flow.actions[0].titleFormatted, undefined);
+  });
+});


### PR DESCRIPTION
## What changed

- Removed unsafe `[[device]]` `titleFormatted` entries from the presence detector flow compose cards.
- Added a manifest sanitizer guard that strips generated Flow `titleFormatted` values containing `[[device]]` from triggers, conditions, and actions before build/publish payloads are uploaded.
- Added a focused sanitizer regression test.
- Aligned the disabled remote button placeholder manufacturer casing in the root manifest so fingerprint checks stay green.

## Why

The master Auto-Publish workflow reached the Homey publish step but failed on Athom validation with an invalid generated Flow condition field:

`flow.conditions['virtual_presence_confidence_above'].titleFormatted.en.titleFormatted`

Local/source validation allowed the affected cards, but the publish validator rejected generated `[[device]]` tokens in `titleFormatted`. The sanitizer now removes those unsafe generated formatted titles from the publish manifest while preserving safe formatted titles such as `[[dp]]`.

## Validation

- `npx mocha test\sanitize-manifest.test.js test\critical\soil-myd45weu-routing.test.js --timeout 10000`
- `npm run build`
- `npm run prepare-publish`
- `npm run validate:publish`
- `npm run check:fingerprint-catalog`
- `npm run precommit`
- Git pre-commit hook: passed
- Git pre-push gate: passed

Expected remaining warning: Homey CLI warns that the seven presence cards no longer have `titleFormatted`; this is intentional because the previous formatted titles were rejected by the publish validator.