### PR TITLE
fix(ci): promote current Homey build only

### DIFF
--- a/.github/scripts/auto-promote-oauth.js
+++ b/.github/scripts/auto-promote-oauth.js
@@ -2,6 +2,10 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const {
+  selectPromotionTarget,
+  summarizeBuild,
+} = require('./homey-build-selection');
 
 // Dynamically read App ID from app.json
 const APP_JSON_PATH = path.join(__dirname, '..', '..', 'app.json');
@@ -12,6 +16,7 @@ try {
   console.error('Warning: could not read app.json:', e.message);
 }
 const APP = appJson.id || 'com.dlnraja.tuya.zigbee';
+const APP_VERSION = appJson.version || '';
 
 const E = process.env.HOMEY_EMAIL, P = process.env.HOMEY_PASSWORD;
 const SUM = process.env.GITHUB_STEP_SUMMARY;
@@ -152,9 +157,11 @@ async function promoteViaCloudApi(rawToken) {
       log('  CloudAPI deleg('+aud+'): obtained');
       const api = new AthomAppsAPI({token});
       const builds = await api.getBuilds({appId:APP});
-      const draft = builds.find(b=>/draft/i.test(b.channel||''));
-      if(!draft){log('  No draft');process.exit(0)}
-      await api.updateBuildChannel({appId:APP,buildId:draft.id||draft._id,channel:'test'});
+      const selection = selectPromotionTarget(builds, APP_VERSION);
+      log('  CloudAPI selection: '+selection.status+' '+summarizeBuild(selection.build));
+      if(selection.status === 'already-test') return;
+      if(selection.status !== 'promote'){log('  No current-version draft to promote');process.exit(0)}
+      await api.updateBuildChannel({appId:APP,buildId:selection.build.id||selection.build._id,channel:'test'});
       log('  Promoted via CloudAPI!'); return;
     } catch(e){log('  CloudAPI('+aud+'): '+e.message)}
   }
@@ -169,10 +176,12 @@ async function promoteWithSdk(apiTk) {
   }
   const builds = await api.getBuilds({appId:APP});
   log('  Builds: '+builds.length);
-  const draft = builds.find(b=>/draft/i.test(b.channel||''));
-  if(!draft){log('  No draft');process.exit(0)}
-  log('  Draft: '+(draft.id||draft._id));
-  await api.updateBuildChannel({appId:APP,buildId:draft.id||draft._id,channel:'test'});
+  const selection = selectPromotionTarget(builds, APP_VERSION);
+  log('  Selection: '+selection.status+' '+summarizeBuild(selection.build));
+  if(selection.status === 'already-test') return;
+  if(selection.status !== 'promote'){log('  No current-version draft to promote');process.exit(0)}
+  log('  Draft: '+(selection.build.id||selection.build._id));
+  await api.updateBuildChannel({appId:APP,buildId:selection.build.id||selection.build._id,channel:'test'});
   log('  Promoted!');
 }
 async function promoteRaw(apiTk) {
@@ -183,9 +192,11 @@ async function promoteRaw(apiTk) {
   if(!ok){const t=await r.text().catch(()=>'');log('  '+t);throw new Error('builds '+r.status+': '+t)}
   const d=await r.json();
   const arr=Array.isArray(d)?d:(d.builds||[]);
-  const draft=arr.find(b=>/draft/i.test(b.channel||''));
-  if(!draft){log('  No draft');process.exit(0)}
-  const pid=draft.id||draft._id;
+  const selection = selectPromotionTarget(arr, APP_VERSION);
+  log('  Selection: '+selection.status+' '+summarizeBuild(selection.build));
+  if(selection.status === 'already-test') return;
+  if(selection.status !== 'promote'){log('  No current-version draft to promote');process.exit(0)}
+  const pid=selection.build.id||selection.build._id;
   const base=r.url.substring(0,r.url.indexOf('/app/'));
   const pr=await fetch(base+'/app/'+APP+'/build/'+pid+'/channel',{
     method:'PUT',headers:{...hd,'Content-Type':'application/json'},

--- a/.github/scripts/auto-promote-puppeteer.js
+++ b/.github/scripts/auto-promote-puppeteer.js
@@ -19,6 +19,7 @@ try {
   console.error('Warning: could not read app.json:', e.message);
 }
 const APP_ID = process.env.TARGET_APP_ID || appJson.id || 'com.dlnraja.tuya.zigbee';
+const APP_VERSION = appJson.version ? String(appJson.version).replace(/^v/i, '') : null;
 
 const BASE = 'https://tools.developer.homey.app';
 const VERSIONS_URL = `${BASE}/apps/app/${APP_ID}/versions`;
@@ -352,14 +353,40 @@ async function findAndPromote(page, captured) {
     return false;
   }
 
+  if (APP_VERSION) {
+    const currentVersionState = await page.evaluate((version) => {
+      const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
+      const matching = rows
+        .map(row => (row.textContent || '').replace(/\s+/g, ' ').trim())
+        .filter(text => text.includes(version));
+      return {
+        count: matching.length,
+        hasDraft: matching.some(text => /\bdraft\b/i.test(text)),
+        hasTest: matching.some(text => /\btest\b/i.test(text)),
+        sample: matching[0] || '',
+      };
+    }, APP_VERSION);
+    log(`  Current version row check: count=${currentVersionState.count}, draft=${currentVersionState.hasDraft}, test=${currentVersionState.hasTest}`);
+    if (currentVersionState.sample) log('  Current version sample: ' + currentVersionState.sample.slice(0, 220));
+    if (currentVersionState.hasTest) {
+      log('  Current version is already on test.');
+      return true;
+    }
+    if (!currentVersionState.hasDraft) {
+      log('  No draft row for current version; ignoring historical draft rows.');
+      return false;
+    }
+  }
+
   if (DRY) { log('  DRY RUN - not clicking'); return false; }
 
   // Strategy 1: Click "SUBMISSION >" link next to first draft build row
   log('  Strategy 1: Find SUBMISSION link for draft');
-  const clicked = await page.evaluate(() => {
+  const clicked = await page.evaluate((version) => {
     const rows = [...document.querySelectorAll('tr')];
     for (const row of rows) {
       if (!/draft/i.test(row.textContent)) continue;
+      if (version && !row.textContent.includes(version)) continue;
       const link = row.querySelector('a');
       if (link && /submission/i.test(link.textContent)) {
         link.click();
@@ -377,7 +404,7 @@ async function findAndPromote(page, captured) {
       }
     }
     return null;
-  });
+  }, APP_VERSION);
 
   if (clicked) {
     log(`  ${clicked}`);
@@ -439,16 +466,17 @@ async function findAndPromote(page, captured) {
 
   // Strategy 2: Click on the draft row first, then look for promote
   log('  No direct promote button found, trying row click...');
-  const rowClicked = await page.evaluate(() => {
+  const rowClicked = await page.evaluate((version) => {
     const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
     for (const r of rows) {
-      if ((r.textContent || '').toLowerCase().includes('draft')) {
+      const text = r.textContent || '';
+      if (text.toLowerCase().includes('draft') && (!version || text.includes(version))) {
         r.click();
         return true;
       }
     }
     return false;
-  });
+  }, APP_VERSION);
 
   if (rowClicked) {
     log('  Clicked draft row');

--- a/.github/scripts/auto-publish-draft.js
+++ b/.github/scripts/auto-publish-draft.js
@@ -10,6 +10,11 @@
 'use strict';
 const fs = require('fs'), path = require('path');
 const { fetchWithRetry } = require('./retry-helper');
+const {
+  selectPromotionTarget,
+  sortBuildsDesc,
+  summarizeBuild,
+} = require('./homey-build-selection');
 
 // Dynamically read App ID and version from app.json
 const APP_JSON_PATH = path.join(__dirname, '..', '..', 'app.json');
@@ -139,48 +144,41 @@ async function main() {
   const builds = result.builds;
   const apiBase = result.base;
   log('Found ' + builds.length + ' build(s) via ' + apiBase);
-  for (const b of builds.slice(0, 10)) {
-    const id = b.id || b._id || 'unknown';
-    const bv = b.version || 'unknown';
-    const ch = b.channel || b.status || 'none';
-    log('  ' + id + ' v' + bv + ' channel=' + ch);
+  sortBuildsDesc(builds).slice(0, 10).forEach(b => log('  ' + summarizeBuild(b)));
+
+  // Step 3: Promote only the current app.json version. Historical drafts can
+  // remain in Athom's list for months and must not be retried automatically.
+  let selection = selectPromotionTarget(builds, ver);
+  log('Selection: ' + selection.status + ' ' + summarizeBuild(selection.build));
+  if (selection.status === 'already-test') {
+    log('\nv' + ver + ' is already on test. Nothing to promote.');
+    return;
   }
 
-  // Step 3: Find draft builds to promote (matching current version or any draft)
-  const drafts = builds.filter(b => {
-    const ch = String(b.channel || b.status || '').toLowerCase();
-    return ch === 'draft' || ch === '' || ch === 'none';
-  });
-
-  // Sort by id desc to get latest first (Athom API returns unsorted)
-  drafts.sort((a, b) => (b.id || 0) - (a.id || 0));
-
-  // Prefer builds matching current app.json version
-  const verDrafts = drafts.filter(b => b.version === ver);
-  const toPromote = verDrafts.length > 0 ? verDrafts : drafts;
+  const toPromote = selection.status === 'promote' ? [selection.build] : [];
 
   if (!toPromote.length) {
     // v5.11.80: Retry — Athom may still be processing the draft
     for (let retry = 1; retry <= 3; retry++) {
-      log('\nNo draft builds yet. Retry ' + retry + '/3 — waiting 60s for Athom...');
+      log('\nNo current-version draft yet. Retry ' + retry + '/3 — waiting 60s for Athom...');
       await new Promise(r => setTimeout(r, 60000));
       const r2 = await getBuilds(token);
       if (r2) {
-        const d2 = r2.builds.filter(b => {
-          const ch = String(b.channel || b.status || '').toLowerCase();
-          return ch === 'draft' || ch === '' || ch === 'none';
-        });
-        const vd2 = d2.filter(b => b.version === ver);
-        const tp2 = vd2.length > 0 ? vd2 : d2;
-        if (tp2.length) {
-          toPromote.push(...tp2);
-          log('Found ' + tp2.length + ' draft build(s) after retry ' + retry);
+        selection = selectPromotionTarget(r2.builds, ver);
+        log('Retry selection: ' + selection.status + ' ' + summarizeBuild(selection.build));
+        if (selection.status === 'already-test') {
+          log('v' + ver + ' reached test after retry ' + retry);
+          return;
+        }
+        if (selection.status === 'promote') {
+          toPromote.push(selection.build);
+          log('Found current-version draft after retry ' + retry);
           break;
         }
       }
     }
     if (!toPromote.length) {
-      log('\nNo draft builds to promote after retries. All builds already have a channel.');
+      log('\nNo current-version draft to promote after retries; ignoring historical drafts.');
       return;
     }
   }

--- a/.github/scripts/homey-build-selection.js
+++ b/.github/scripts/homey-build-selection.js
@@ -1,0 +1,100 @@
+'use strict';
+
+function normalizeVersion(version) {
+  return String(version || '').trim().replace(/^v/i, '');
+}
+
+function rawBuildId(build) {
+  return build?.id || build?.buildId || build?._id || null;
+}
+
+function numericBuildId(build) {
+  const raw = rawBuildId(build);
+  if (raw == null) return 0;
+  const match = String(raw).match(/\d+/g);
+  return match ? Number(match[match.length - 1]) : 0;
+}
+
+function buildState(build) {
+  return String(build?.state || build?.channel || build?.status || '').trim().toLowerCase();
+}
+
+function buildTimeMs(build) {
+  for (const key of ['stateChangedAt', 'updatedAt', 'createdAt', 'lastUpdatedAt', 'lastUpdated']) {
+    const value = build?.[key];
+    if (!value) continue;
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms)) return ms;
+  }
+  return 0;
+}
+
+function normalizeBuild(build) {
+  return {
+    ...build,
+    id: rawBuildId(build),
+    version: normalizeVersion(build?.version || build?.appVersion || build?.semver),
+    state: buildState(build),
+  };
+}
+
+function sortBuildsDesc(builds) {
+  return [...builds].sort((a, b) => {
+    const byId = numericBuildId(b) - numericBuildId(a);
+    if (byId) return byId;
+    return buildTimeMs(b) - buildTimeMs(a);
+  });
+}
+
+function isDraft(build) {
+  return buildState(build) === 'draft';
+}
+
+function isTest(build) {
+  return buildState(build) === 'test';
+}
+
+function summarizeBuild(build) {
+  if (!build) return 'none';
+  return `#${rawBuildId(build) || '?'} v${normalizeVersion(build.version || build.appVersion || build.semver) || '?'} ${buildState(build) || 'unknown'}`;
+}
+
+function selectPromotionTarget(rawBuilds, expectedVersion) {
+  const builds = sortBuildsDesc((rawBuilds || []).filter(Boolean).map(normalizeBuild));
+  const expected = normalizeVersion(expectedVersion);
+
+  if (expected) {
+    const matching = builds.filter(build => normalizeVersion(build.version) === expected);
+    const matchingTest = matching.find(isTest);
+    if (matchingTest) {
+      return { status: 'already-test', build: matchingTest, builds, expected };
+    }
+
+    const matchingDraft = sortBuildsDesc(matching.filter(isDraft))[0];
+    if (matchingDraft) {
+      return { status: 'promote', build: matchingDraft, builds, expected };
+    }
+
+    if (matching.length) {
+      return { status: 'current-not-promotable', build: matching[0], builds, expected };
+    }
+
+    return { status: 'current-not-found', build: builds[0] || null, builds, expected };
+  }
+
+  const draft = sortBuildsDesc(builds.filter(isDraft))[0];
+  if (draft) return { status: 'promote', build: draft, builds, expected: '' };
+  return { status: 'no-draft', build: builds[0] || null, builds, expected: '' };
+}
+
+module.exports = {
+  normalizeVersion,
+  numericBuildId,
+  buildState,
+  normalizeBuild,
+  sortBuildsDesc,
+  isDraft,
+  isTest,
+  summarizeBuild,
+  selectPromotionTarget,
+};

--- a/.github/scripts/promote-via-session.js
+++ b/.github/scripts/promote-via-session.js
@@ -2,6 +2,11 @@
 'use strict';
 const fs = require('fs');
 const path = require('path');
+const {
+  selectPromotionTarget,
+  sortBuildsDesc,
+  summarizeBuild,
+} = require('./homey-build-selection');
 
 // Read App ID dynamically from app.json
 let APP = 'com.dlnraja.tuya.zigbee';
@@ -43,21 +48,12 @@ async function promoteViaBrowserSession(page, log, dry, capturedToken) {
   }
   if(!builds){log('  [SessAPI] No builds');return false;}
   log('  [SessAPI] '+builds.length+' builds, first: '+JSON.stringify(Object.keys(builds[0]||{})));
-  if(builds[0]) log('  [SessAPI] b0: ch='+builds[0].channel+' st='+builds[0].status+' state='+builds[0].state);
-  const last=builds[builds.length-1];
-  if(last) log('  [SessAPI] bLast: id='+last.id+' state='+last.state+' v='+last.version);
-  const drafts=builds.filter(b=>/draft/i.test(b.channel||b.status||b.state||''));
-  if(!drafts.length) return 'no-draft';
-  drafts.sort((a,b)=>(b.id||0)-(a.id||0));
-  // Prefer draft matching current app version, fallback to newest by ID
-  let draft=drafts[0];
-  if(APP_VERSION){
-    const vMatch=drafts.find(d=>d.version===APP_VERSION);
-    if(vMatch){draft=vMatch;log('  [SessAPI] Matched draft to current version '+APP_VERSION);}
-  }
-  log('  [SessAPI] Draft: id='+draft.id+' v='+draft.version+' state='+draft.state+' ('+drafts.length+' drafts)');
-  // Log top 3 drafts for debugging
-  drafts.slice(0,3).forEach((d,i)=>log('  [SessAPI]   #'+(i+1)+': id='+d.id+' v='+d.version+' state='+d.state));
+  sortBuildsDesc(builds).slice(0,5).forEach((b,i)=>log('  [SessAPI] recent #'+(i+1)+': '+summarizeBuild(b)));
+  const selection = selectPromotionTarget(builds, APP_VERSION);
+  log('  [SessAPI] Selection: '+selection.status+' '+summarizeBuild(selection.build));
+  if(selection.status === 'already-test') return true;
+  if(selection.status !== 'promote') return selection.status;
+  const draft=selection.build;
   if(dry) return false;
   const pid=draft.id||draft._id;
   log('  [SessAPI] Using build id='+pid);

--- a/test/homey-build-selection.test.js
+++ b/test/homey-build-selection.test.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const assert = require('assert');
+const {
+  selectPromotionTarget,
+  summarizeBuild,
+} = require('../.github/scripts/homey-build-selection');
+
+describe('Homey build selection', function() {
+  it('treats the current version on test as success even when old drafts exist', function() {
+    const result = selectPromotionTarget([
+      { id: 2471, version: '9.0.15', state: 'draft' },
+      { id: 2519, version: '9.0.150', state: 'test' },
+    ], '9.0.150');
+
+    assert.strictEqual(result.status, 'already-test');
+    assert.strictEqual(summarizeBuild(result.build), '#2519 v9.0.150 test');
+  });
+
+  it('selects the current version draft before newer-looking historical drafts', function() {
+    const result = selectPromotionTarget([
+      { id: 'build-2600', version: '9.0.12', state: 'draft' },
+      { id: 'build-2519', version: 'v9.0.150', state: 'draft' },
+    ], '9.0.150');
+
+    assert.strictEqual(result.status, 'promote');
+    assert.strictEqual(result.build.id, 'build-2519');
+  });
+
+  it('does not fall back to historical drafts when an expected version is known', function() {
+    const result = selectPromotionTarget([
+      { id: 2471, version: '9.0.15', state: 'draft' },
+    ], '9.0.150');
+
+    assert.strictEqual(result.status, 'current-not-found');
+  });
+});


### PR DESCRIPTION
## What changed

- Added a shared Homey build-selection helper for dashboard/API promotion scripts.
- Promotion now targets the current `app.json` version only, or exits successfully when that version is already on the Homey test channel.
- Historical drafts are ignored instead of being retried automatically.
- Puppeteer fallback now refuses to click draft rows that do not contain the current version.
- Added focused unit tests for current-version build selection.

## Why

After `v9.0.150` published and was promoted successfully by `Auto-Publish on Push`, the follow-up `Daily Draft to Test` workflow failed because its retry path selected an old draft (`v9.0.15`) from the Homey build list instead of treating the current `v9.0.150` build as already promoted. This patch prevents the workflow from reanimating stale historical drafts.

## Validation

- `npx mocha test\homey-build-selection.test.js test\sanitize-manifest.test.js --timeout 10000`
- `node --check` on modified promotion scripts
- `npm run precommit`
- Git pre-commit hook: passed
- Git pre-push gate: passed