### PR TITLE
[codex] fix Homey build selection edge cases

### DIFF
--- a/.github/scripts/auto-promote-puppeteer.js
+++ b/.github/scripts/auto-promote-puppeteer.js
@@ -9,6 +9,7 @@
 'use strict';
 const fs = require('fs'), path = require('path');
 const { promoteViaBrowserSession } = require('./promote-via-session');
+const { versionTextRegex } = require('./homey-build-selection');
 
 // Dynamically read App ID from app.json
 const APP_JSON_PATH = path.join(__dirname, '..', '..', 'app.json');
@@ -30,6 +31,9 @@ const SUM = process.env.GITHUB_STEP_SUMMARY || null;
 
 function log(m) { console.log(m); if (SUM) try { fs.appendFileSync(SUM, m+'\n'); } catch {} }
 const sleep = ms => new Promise(r => setTimeout(r, ms));
+function browserRegexPayload(regex) {
+  return regex ? { source: regex.source, flags: regex.flags } : null;
+}
 async function waitReady(page, label, ms = 6000) {
   await sleep(ms);
   try { await page.waitForNetworkIdle({ idleTime: 1500, timeout: 10000 }); } catch {}
@@ -354,18 +358,23 @@ async function findAndPromote(page, captured) {
   }
 
   if (APP_VERSION) {
-    const currentVersionState = await page.evaluate((version) => {
+    const currentVersionState = await page.evaluate((version, versionRegex) => {
+      const matchesVersion = (value) => {
+        if (!version) return true;
+        if (!versionRegex) return false;
+        return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
+      };
       const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
       const matching = rows
         .map(row => (row.textContent || '').replace(/\s+/g, ' ').trim())
-        .filter(text => text.includes(version));
+        .filter(text => matchesVersion(text));
       return {
         count: matching.length,
         hasDraft: matching.some(text => /\bdraft\b/i.test(text)),
         hasTest: matching.some(text => /\btest\b/i.test(text)),
         sample: matching[0] || '',
       };
-    }, APP_VERSION);
+    }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
     log(`  Current version row check: count=${currentVersionState.count}, draft=${currentVersionState.hasDraft}, test=${currentVersionState.hasTest}`);
     if (currentVersionState.sample) log('  Current version sample: ' + currentVersionState.sample.slice(0, 220));
     if (currentVersionState.hasTest) {
@@ -382,11 +391,17 @@ async function findAndPromote(page, captured) {
 
   // Strategy 1: Click "SUBMISSION >" link next to first draft build row
   log('  Strategy 1: Find SUBMISSION link for draft');
-  const clicked = await page.evaluate((version) => {
+  const clicked = await page.evaluate((version, versionRegex) => {
+    const matchesVersion = (value) => {
+      if (!version) return true;
+      if (!versionRegex) return false;
+      return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
+    };
     const rows = [...document.querySelectorAll('tr')];
     for (const row of rows) {
-      if (!/draft/i.test(row.textContent)) continue;
-      if (version && !row.textContent.includes(version)) continue;
+      const rowText = row.textContent || '';
+      if (!/draft/i.test(rowText)) continue;
+      if (!matchesVersion(rowText)) continue;
       const link = row.querySelector('a');
       if (link && /submission/i.test(link.textContent)) {
         link.click();
@@ -404,7 +419,7 @@ async function findAndPromote(page, captured) {
       }
     }
     return null;
-  }, APP_VERSION);
+  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
 
   if (clicked) {
     log(`  ${clicked}`);
@@ -466,17 +481,22 @@ async function findAndPromote(page, captured) {
 
   // Strategy 2: Click on the draft row first, then look for promote
   log('  No direct promote button found, trying row click...');
-  const rowClicked = await page.evaluate((version) => {
+  const rowClicked = await page.evaluate((version, versionRegex) => {
+    const matchesVersion = (value) => {
+      if (!version) return true;
+      if (!versionRegex) return false;
+      return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
+    };
     const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
     for (const r of rows) {
       const text = r.textContent || '';
-      if (text.toLowerCase().includes('draft') && (!version || text.includes(version))) {
+      if (text.toLowerCase().includes('draft') && matchesVersion(text)) {
         r.click();
         return true;
       }
     }
     return false;
-  }, APP_VERSION);
+  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
 
   if (rowClicked) {
     log('  Clicked draft row');

--- a/.github/scripts/dashboard-fallback.js
+++ b/.github/scripts/dashboard-fallback.js
@@ -1,7 +1,12 @@
 #!/usr/bin/env node
 'use strict';
 const { fetchWithRetry } = require('./retry-helper');
+const { selectPromotionTarget, summarizeBuild, versionTextRegex } = require('./homey-build-selection');
 const APP = 'com.dlnraja.tuya.zigbee';
+
+function browserRegexPayload(regex) {
+  return regex ? { source: regex.source, flags: regex.flags } : null;
+}
 
 async function dashboardFallback(ver, log) {
   log = log || console.log;
@@ -53,9 +58,14 @@ async function dashboardFallback(ver, log) {
     await new Promise(r => setTimeout(r, 5000));
 
     log(`  Looking for version ${ver} to promote to test...`);
-    const promoted = await page.evaluate((version) => {
+    const promoted = await page.evaluate((version, versionRegex) => {
+      const matchesVersion = (value) => {
+        if (!version) return true;
+        if (!versionRegex) return false;
+        return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
+      };
       const rows = Array.from(document.querySelectorAll('tr'));
-      const targetRow = rows.find(r => r.textContent.includes(version) && r.textContent.includes('draft'));
+      const targetRow = rows.find(r => matchesVersion(r.textContent) && /\bdraft\b/i.test(r.textContent || ''));
       if (!targetRow) return false;
 
       const buttons = Array.from(targetRow.querySelectorAll('button'));
@@ -73,7 +83,7 @@ async function dashboardFallback(ver, log) {
         return true;
       }
       return false;
-    }, ver);
+    }, ver, browserRegexPayload(versionTextRegex(ver)));
 
     if (promoted) {
       log('  Successfully clicked promote to test button via Puppeteer.');
@@ -124,9 +134,16 @@ async function _tryApiPromote(token, ver, log) {
     const br = await fetchWithRetry(`${BASE}/app/${APP}/build`, { headers: h }, { retries: 2, label: 'athom' });
     const builds = await br.json();
     const list = Array.isArray(builds) ? builds : builds.builds || builds.data || [];
-    const draft = list.find(b => (!b.channel || b.channel === 'draft') && b.version === ver)
-      || list.find(b => !b.channel || b.channel === 'draft');
-    if (!draft) { log('  No draft build found'); return false; }
+    const selection = selectPromotionTarget(list, ver);
+    if (selection.status === 'already-test') {
+      log(`  Current version already on test: ${summarizeBuild(selection.build)}`);
+      return true;
+    }
+    if (selection.status !== 'promote') {
+      log(`  No promotable draft for requested version ${ver}: ${selection.status} (${summarizeBuild(selection.build)})`);
+      return false;
+    }
+    const draft = selection.build;
     const buildId = draft.id || draft._id;
     log(`  Found draft build ${buildId} v${draft.version}`);
 

--- a/.github/scripts/homey-build-selection.js
+++ b/.github/scripts/homey-build-selection.js
@@ -4,6 +4,22 @@ function normalizeVersion(version) {
   return String(version || '').trim().replace(/^v/i, '');
 }
 
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function versionTextRegex(version) {
+  const normalized = normalizeVersion(version);
+  if (!normalized) return null;
+  return new RegExp(`(?:^|[^0-9.])${escapeRegExp(normalized)}(?:[^0-9.]|$)`);
+}
+
+function textHasVersion(text, version) {
+  const regex = versionTextRegex(version);
+  if (!regex) return false;
+  return regex.test(String(text || ''));
+}
+
 function rawBuildId(build) {
   return build?.id || build?.buildId || build?._id || null;
 }
@@ -47,7 +63,8 @@ function sortBuildsDesc(builds) {
 }
 
 function isDraft(build) {
-  return buildState(build) === 'draft';
+  const state = buildState(build);
+  return state === 'draft' || state === '' || state === 'none';
 }
 
 function isTest(build) {
@@ -89,6 +106,8 @@ function selectPromotionTarget(rawBuilds, expectedVersion) {
 
 module.exports = {
   normalizeVersion,
+  versionTextRegex,
+  textHasVersion,
   numericBuildId,
   buildState,
   normalizeBuild,

--- a/test/homey-build-selection.test.js
+++ b/test/homey-build-selection.test.js
@@ -2,8 +2,10 @@
 
 const assert = require('assert');
 const {
+  isDraft,
   selectPromotionTarget,
   summarizeBuild,
+  textHasVersion,
 } = require('../.github/scripts/homey-build-selection');
 
 describe('Homey build selection', function() {
@@ -33,5 +35,27 @@ describe('Homey build selection', function() {
     ], '9.0.150');
 
     assert.strictEqual(result.status, 'current-not-found');
+  });
+
+  it('treats empty and none build states as draft candidates', function() {
+    assert.strictEqual(isDraft({ id: 2520, version: '9.0.151', state: '' }), true);
+    assert.strictEqual(isDraft({ id: 2521, version: '9.0.151', channel: 'none' }), true);
+    assert.strictEqual(isDraft({ id: 2522, version: '9.0.151', status: 'test' }), false);
+  });
+
+  it('matches versions exactly in dashboard text', function() {
+    assert.strictEqual(textHasVersion('Build #2519 v9.0.150 test', '9.0.150'), true);
+    assert.strictEqual(textHasVersion('Build #2519 v9.0.150 test', '9.0.15'), false);
+    assert.strictEqual(textHasVersion('Build #2520 v9.0.1500 draft', '9.0.150'), false);
+  });
+
+  it('selects a current version draft when Athom reports an empty state', function() {
+    const result = selectPromotionTarget([
+      { id: 2520, version: '9.0.151', state: '' },
+      { id: 2519, version: '9.0.150', state: 'test' },
+    ], '9.0.151');
+
+    assert.strictEqual(result.status, 'promote');
+    assert.strictEqual(result.build.id, 2520);
   });
 });


### PR DESCRIPTION
## What changed

- Added a shared exact version matcher for Homey build/dashboard text.
- Replaced partial `includes(version)` matching in the Puppeteer and dashboard promotion fallbacks.
- Treat Athom transient empty/`none` build states as draft candidates in the shared selector.
- Reused `selectPromotionTarget()` in `dashboard-fallback.js` so it no longer falls back to historical drafts when the requested version is known.

## Why

Gemini review comments on #442 correctly flagged two edge cases:
- `9.0.15` could be matched inside `9.0.150` by browser fallback code.
- newly uploaded Athom builds may briefly report empty/`none` state before settling as draft.

This keeps daily/manual promotion pointed at the current app version and avoids stale draft promotion regressions.

## Validation

- `node --check .github/scripts/homey-build-selection.js`
- `node --check .github/scripts/auto-promote-puppeteer.js`
- `node --check .github/scripts/dashboard-fallback.js`
- `npx mocha test/homey-build-selection.test.js`
- `npm run precommit`
- Git pre-commit hook
- Git pre-push gate