### PR TITLE
fix(ci): verify Homey draft promotion accurately

### DIFF
--- a/.github/scripts/auto-promote-puppeteer.js
+++ b/.github/scripts/auto-promote-puppeteer.js
@@ -34,6 +34,22 @@ const sleep = ms => new Promise(r => setTimeout(r, ms));
 function browserRegexPayload(regex) {
   return regex ? { source: regex.source, flags: regex.flags } : null;
 }
+
+const BUILD_ROW_SELECTOR = [
+  'tr',
+  '[role="row"]',
+  '[data-rowindex]',
+  '[class*="MuiDataGrid-row"]',
+  '[class*="MuiTableRow"]',
+  '[class*="row"]',
+  '[class*="item"]',
+  '[class*="build"]',
+].join(', ');
+
+function browserBuildRowSelector() {
+  return BUILD_ROW_SELECTOR;
+}
+
 async function waitReady(page, label, ms = 6000) {
   await sleep(ms);
   try { await page.waitForNetworkIdle({ idleTime: 1500, timeout: 10000 }); } catch {}
@@ -358,23 +374,28 @@ async function findAndPromote(page, captured) {
   }
 
   if (APP_VERSION) {
-    const currentVersionState = await page.evaluate((version, versionRegex) => {
+    const currentVersionState = await page.evaluate((version, versionRegex, rowSelector) => {
       const matchesVersion = (value) => {
         if (!version) return true;
         if (!versionRegex) return false;
         return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
       };
-      const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
+      const rows = [...document.querySelectorAll(rowSelector)];
       const matching = rows
         .map(row => (row.textContent || '').replace(/\s+/g, ' ').trim())
+        .filter(Boolean)
         .filter(text => matchesVersion(text));
+      if (!matching.length) {
+        const bodyText = (document.body?.innerText || '').replace(/\s+/g, ' ').trim();
+        if (matchesVersion(bodyText)) matching.push(bodyText);
+      }
       return {
         count: matching.length,
         hasDraft: matching.some(text => /\bdraft\b/i.test(text)),
         hasTest: matching.some(text => /\btest\b/i.test(text)),
         sample: matching[0] || '',
       };
-    }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
+    }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)), browserBuildRowSelector());
     log(`  Current version row check: count=${currentVersionState.count}, draft=${currentVersionState.hasDraft}, test=${currentVersionState.hasTest}`);
     if (currentVersionState.sample) log('  Current version sample: ' + currentVersionState.sample.slice(0, 220));
     if (currentVersionState.hasTest) {
@@ -391,13 +412,13 @@ async function findAndPromote(page, captured) {
 
   // Strategy 1: Click "SUBMISSION >" link next to first draft build row
   log('  Strategy 1: Find SUBMISSION link for draft');
-  const clicked = await page.evaluate((version, versionRegex) => {
+  const clicked = await page.evaluate((version, versionRegex, rowSelector) => {
     const matchesVersion = (value) => {
       if (!version) return true;
       if (!versionRegex) return false;
       return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
     };
-    const rows = [...document.querySelectorAll('tr')];
+    const rows = [...document.querySelectorAll(rowSelector)];
     for (const row of rows) {
       const rowText = row.textContent || '';
       if (!/draft/i.test(rowText)) continue;
@@ -406,6 +427,12 @@ async function findAndPromote(page, captured) {
       if (link && /submission/i.test(link.textContent)) {
         link.click();
         return 'SUBMISSION link in draft row: ' + link.href;
+      }
+      const rowAction = [...row.querySelectorAll('button, a, [role="button"]')]
+        .find(el => /submission|publish|release|promote|test|actions?/i.test(el.textContent || el.getAttribute('aria-label') || el.getAttribute('title') || ''));
+      if (rowAction) {
+        rowAction.click();
+        return 'Action in draft row: ' + ((rowAction.textContent || rowAction.getAttribute('aria-label') || rowAction.getAttribute('title') || '').trim() || rowAction.tagName);
       }
       const anyLink = [...row.querySelectorAll('a')].find(a => a.href);
       if (anyLink) { anyLink.click(); return 'Link in draft row: ' + anyLink.href; }
@@ -419,7 +446,7 @@ async function findAndPromote(page, captured) {
       }
     }
     return null;
-  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
+  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)), browserBuildRowSelector());
 
   if (clicked) {
     log(`  ${clicked}`);
@@ -481,13 +508,13 @@ async function findAndPromote(page, captured) {
 
   // Strategy 2: Click on the draft row first, then look for promote
   log('  No direct promote button found, trying row click...');
-  const rowClicked = await page.evaluate((version, versionRegex) => {
+  const rowClicked = await page.evaluate((version, versionRegex, rowSelector) => {
     const matchesVersion = (value) => {
       if (!version) return true;
       if (!versionRegex) return false;
       return new RegExp(versionRegex.source, versionRegex.flags).test(String(value || ''));
     };
-    const rows = [...document.querySelectorAll('tr, [class*="row"], [class*="item"], [class*="build"]')];
+    const rows = [...document.querySelectorAll(rowSelector)];
     for (const r of rows) {
       const text = r.textContent || '';
       if (text.toLowerCase().includes('draft') && matchesVersion(text)) {
@@ -496,7 +523,7 @@ async function findAndPromote(page, captured) {
       }
     }
     return false;
-  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)));
+  }, APP_VERSION, browserRegexPayload(versionTextRegex(APP_VERSION)), browserBuildRowSelector());
 
   if (rowClicked) {
     log('  Clicked draft row');

--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -360,6 +360,7 @@ jobs:
         run: node .github/scripts/auto-publish-draft.js
 
       - name: Verify draft promotion result
+        id: verify_test
         if: steps.check_pat.outputs.has_pat == 'true'
         env:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
@@ -367,8 +368,7 @@ jobs:
           if [ "${{ steps.promote_puppeteer.outcome }}" != "success" ] && \
              [ "${{ steps.promote_oauth.outcome }}" != "success" ] && \
              [ "${{ steps.promote_api.outcome }}" != "success" ]; then
-            echo "::error::All draft-to-test promotion tiers failed"
-            exit 1
+            echo "::warning::All draft-to-test promotion tiers returned non-success; verifying actual Homey channel state before failing."
           fi
           node .github/scripts/verify-test-version.js
 
@@ -472,9 +472,12 @@ jobs:
           APP_ID=$(node -p "require('./app.json').id" 2>/dev/null || echo "com.dlnraja.tuya.zigbee")
           echo "## v${{ steps.info.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Changelog:** ${{ steps.cl.outputs.text }}" >> $GITHUB_STEP_SUMMARY
-          if [ "${{ steps.check_pat.outputs.has_pat }}" == "true" ]; then
+          if [ "${{ steps.check_pat.outputs.has_pat }}" == "true" ] && [ "${{ steps.verify_test.outcome }}" == "success" ]; then
             echo "✅ Published to Homey App Store (Test channel)" >> $GITHUB_STEP_SUMMARY
             echo "[Install test version](https://homey.app/a/$APP_ID/test/)" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.check_pat.outputs.has_pat }}" == "true" ]; then
+            echo "⚠️ Published draft build, but Homey test promotion was not confirmed" >> $GITHUB_STEP_SUMMARY
+            echo "[Open Homey test page](https://homey.app/a/$APP_ID/test/)" >> $GITHUB_STEP_SUMMARY
           else
             echo "⚠️ Validated only — HOMEY_PAT not set" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/daily-promote-to-test.yml
+++ b/.github/workflows/daily-promote-to-test.yml
@@ -119,11 +119,11 @@ jobs:
              [ "${{ steps.oauth.outcome }}" != "success" ] && \
              [ "${{ steps.api.outcome }}" != "success" ] && \
              [ "${{ steps.retry.outcome }}" != "success" ]; then
-            echo "::error::All draft-to-test promotion tiers failed"
-            exit 1
+            echo "::warning::All draft-to-test promotion tiers returned non-success; verify-test-version will check actual Homey channel state."
           fi
 
       - name: Verify test version
+        id: verify_test
         env:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
         run: node .github/scripts/verify-test-version.js

--- a/.github/workflows/draft-to-test.yml
+++ b/.github/workflows/draft-to-test.yml
@@ -117,14 +117,14 @@ jobs:
         run: echo "version=$(node -p \"require('./app.json').version\")" >> $GITHUB_OUTPUT
 
       - name: Verify draft promotion result
+        id: verify_test
         env:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
         run: |
           if [ "${{ steps.promote_puppeteer.outcome }}" != "success" ] && \
              [ "${{ steps.promote_oauth.outcome }}" != "success" ] && \
              [ "${{ steps.promote_api.outcome }}" != "success" ]; then
-            echo "::error::All draft-to-test promotion tiers failed"
-            exit 1
+            echo "::warning::All draft-to-test promotion tiers returned non-success; verifying actual Homey channel state before failing."
           fi
           node .github/scripts/verify-test-version.js
 

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -149,13 +149,13 @@ jobs:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
         run: node .github/scripts/auto-publish-draft.js
       - name: Verify draft promotion result
+        id: verify_test
         env:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
         run: |
           if [ "${{ steps.promote_puppeteer.outcome }}" != "success" ] && \
              [ "${{ steps.promote_api.outcome }}" != "success" ]; then
-            echo "::error::All stable draft-to-test promotion tiers failed"
-            exit 1
+            echo "::warning::All stable draft-to-test promotion tiers returned non-success; verifying actual Homey channel state before failing."
           fi
           node .github/scripts/verify-test-version.js
       - name: Summary

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -278,6 +278,7 @@ jobs:
         run: node .github/scripts/auto-publish-draft.js
 
       - name: Verify draft promotion result
+        id: verify_test
         if: steps.pat.outputs.ok == 'true'
         env:
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
@@ -285,8 +286,7 @@ jobs:
           if [ "${{ steps.promote_puppeteer.outcome }}" != "success" ] && \
              [ "${{ steps.promote_oauth.outcome }}" != "success" ] && \
              [ "${{ steps.promote_api.outcome }}" != "success" ]; then
-            echo "::error::All draft-to-test promotion tiers failed"
-            exit 1
+            echo "::warning::All draft-to-test promotion tiers returned non-success; verifying actual Homey channel state before failing."
           fi
           node .github/scripts/verify-test-version.js
 


### PR DESCRIPTION
## Summary
- make the Homey Puppeteer promotion script detect current MUI/DataGrid build rows, including v-less versions like 9.0.152
- let promotion workflows run verify-test-version.js for the actual Homey channel state instead of failing before diagnostics
- make the auto-publish summary distinguish a confirmed test promotion from an unconfirmed draft publish

## Validation
- node --check .github/scripts/auto-promote-puppeteer.js
- node --check .github/scripts/verify-test-version.js
- npm run check:yaml
- npm run precommit

Context: #445 published v9.0.152 as a draft, but Auto-Publish on Push failed at Verify draft promotion result because all promotion tiers returned non-success; dashboard monitor showed v9.0.152 still draft and v9.0.150 still test.