### PR TITLE
fix(ci): retry Homey publish API timeouts

### DIFF
--- a/.github/actions/homey-app-publish/action.yml
+++ b/.github/actions/homey-app-publish/action.yml
@@ -38,16 +38,33 @@ runs:
           exit 1
         fi
         cd "$PUBLISH_DIR"
-        npm ci --omit=dev --ignore-scripts --no-audit --no-fund || npm install --omit=dev --ignore-scripts --no-audit --no-fund
+        if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+          npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+        else
+          npm install --omit=dev --ignore-scripts --no-audit --no-fund
+        fi
         node "$GITHUB_WORKSPACE/scripts/maintenance/prune-publish-payload.cjs" "$PUBLISH_DIR"
         HOMEY_CHECK_FINAL_PUBLISH_DIR=1 node "$GITHUB_WORKSPACE/scripts/ci/publish-size-gate.cjs" --strict --final
+
+        run_homey_cli_publish() {
+          if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
+            HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR"
+          else
+            HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR"
+          fi
+        }
+
         set +e
-        if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
-          publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR" 2>&1)
-        else
-          publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR" 2>&1)
-        fi
+        publish_output=$(run_homey_cli_publish 2>&1)
         publish_status=$?
+
+        if [ "$publish_status" -ne 0 ] && printf '%s\n' "$publish_output" | grep -Eiq 'Timeout after [0-9]+ms|fetch failed|ETIMEDOUT|ECONNRESET|ECONNABORTED'; then
+          echo "::warning::Homey CLI publish hit a transient API timeout; retrying via direct Athom Apps API with extended timeouts."
+          fallback_output=$(HOMEY_PAT="$HOMEY_PAT" HOMEY_API_TIMEOUT_MS="${HOMEY_API_TIMEOUT_MS:-60000}" HOMEY_BUILD_POLL_TIMEOUT_MS="${HOMEY_BUILD_POLL_TIMEOUT_MS:-240000}" node "$GITHUB_WORKSPACE/scripts/direct-api-publish.js" --path "$PUBLISH_DIR" 2>&1)
+          fallback_status=$?
+          publish_output="$(printf '%s\n%s' "$publish_output" "$fallback_output")"
+          publish_status=$fallback_status
+        fi
         set -e
         printf '%s\n' "$publish_output"
         APP_ID=$(node -p "require('./app.json').id" 2>/dev/null || echo "com.dlnraja.tuya.zigbee")

--- a/.github/actions/homey-publish/action.yml
+++ b/.github/actions/homey-publish/action.yml
@@ -56,12 +56,33 @@ runs:
           exit 1
         fi
         cd "$PUBLISH_DIR"
-        npm ci --omit=dev --ignore-scripts --no-audit --no-fund || npm install --omit=dev --ignore-scripts --no-audit --no-fund
+        if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+          npm ci --omit=dev --ignore-scripts --no-audit --no-fund
+        else
+          npm install --omit=dev --ignore-scripts --no-audit --no-fund
+        fi
         node "$GITHUB_WORKSPACE/scripts/maintenance/prune-publish-payload.cjs" "$PUBLISH_DIR"
         HOMEY_CHECK_FINAL_PUBLISH_DIR=1 node "$GITHUB_WORKSPACE/scripts/ci/publish-size-gate.cjs" --strict --final
+
+        run_homey_cli_publish() {
+          if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
+            HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR"
+          else
+            HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" homey app publish --path "$PUBLISH_DIR"
+          fi
+        }
+
         set +e
-        publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" homey app publish --path "$PUBLISH_DIR" 2>&1)
+        publish_output=$(run_homey_cli_publish 2>&1)
         publish_status=$?
+
+        if [ "$publish_status" -ne 0 ] && printf '%s\n' "$publish_output" | grep -Eiq 'Timeout after [0-9]+ms|fetch failed|ETIMEDOUT|ECONNRESET|ECONNABORTED'; then
+          echo "::warning::Homey CLI publish hit a transient API timeout; retrying via direct Athom Apps API with extended timeouts."
+          fallback_output=$(HOMEY_PAT="$HOMEY_PAT" HOMEY_API_TIMEOUT_MS="${HOMEY_API_TIMEOUT_MS:-60000}" HOMEY_BUILD_POLL_TIMEOUT_MS="${HOMEY_BUILD_POLL_TIMEOUT_MS:-240000}" node "$GITHUB_WORKSPACE/scripts/direct-api-publish.js" --path "$PUBLISH_DIR" 2>&1)
+          fallback_status=$?
+          publish_output="$(printf '%s\n%s' "$publish_output" "$fallback_output")"
+          publish_status=$fallback_status
+        fi
         set -e
         printf '%s\n' "$publish_output"
         APP_ID=$(node -p "require('./app.json').id" 2>/dev/null || echo "com.dlnraja.tuya.zigbee")

--- a/.github/workflows/auto-fix-and-publish.yml
+++ b/.github/workflows/auto-fix-and-publish.yml
@@ -119,14 +119,28 @@ jobs:
             exit 1
           fi
           cd "$PUBLISH_DIR"
-          npm ci --omit=dev --ignore-scripts --no-audit --no-fund || npm install --omit=dev --ignore-scripts --no-audit --no-fund
-          set +e
-          if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
-            publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR" 2>&1)
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --omit=dev --ignore-scripts --no-audit --no-fund
           else
-            publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR" 2>&1)
+            npm install --omit=dev --ignore-scripts --no-audit --no-fund
           fi
+          run_homey_cli_publish() {
+            if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
+              HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR"
+            else
+              HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR"
+            fi
+          }
+          set +e
+          publish_output=$(run_homey_cli_publish 2>&1)
           publish_status=$?
+          if [ "$publish_status" -ne 0 ] && printf '%s\n' "$publish_output" | grep -Eiq 'Timeout after [0-9]+ms|fetch failed|ETIMEDOUT|ECONNRESET|ECONNABORTED'; then
+            echo "::warning::Homey CLI publish hit a transient API timeout; retrying via direct Athom Apps API with extended timeouts."
+            fallback_output=$(HOMEY_PAT="$HOMEY_PAT" HOMEY_API_TIMEOUT_MS="${HOMEY_API_TIMEOUT_MS:-60000}" HOMEY_BUILD_POLL_TIMEOUT_MS="${HOMEY_BUILD_POLL_TIMEOUT_MS:-240000}" node "$GITHUB_WORKSPACE/scripts/direct-api-publish.js" --path "$PUBLISH_DIR" 2>&1)
+            fallback_status=$?
+            publish_output="$(printf '%s\n%s' "$publish_output" "$fallback_output")"
+            publish_status=$fallback_status
+          fi
           set -e
           printf '%s\n' "$publish_output"
           if [ "$publish_status" -ne 0 ]; then

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -96,14 +96,28 @@ jobs:
             exit 1
           fi
           cd "$PUBLISH_DIR"
-          npm ci --omit=dev --ignore-scripts --no-audit --no-fund || npm install --omit=dev --ignore-scripts --no-audit --no-fund
-          set +e
-          if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
-            publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR" 2>&1)
+          if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
+            npm ci --omit=dev --ignore-scripts --no-audit --no-fund
           else
-            publish_output=$(HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR" 2>&1)
+            npm install --omit=dev --ignore-scripts --no-audit --no-fund
           fi
+          run_homey_cli_publish() {
+            if [ -x "$GITHUB_WORKSPACE/node_modules/.bin/homey" ]; then
+              HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" "$GITHUB_WORKSPACE/node_modules/.bin/homey" app publish --path "$PUBLISH_DIR"
+            else
+              HOMEY_HEADLESS=1 HOMEY_PAT="$HOMEY_PAT" npx homey app publish --path "$PUBLISH_DIR"
+            fi
+          }
+          set +e
+          publish_output=$(run_homey_cli_publish 2>&1)
           publish_status=$?
+          if [ "$publish_status" -ne 0 ] && printf '%s\n' "$publish_output" | grep -Eiq 'Timeout after [0-9]+ms|fetch failed|ETIMEDOUT|ECONNRESET|ECONNABORTED'; then
+            echo "::warning::Homey CLI publish hit a transient API timeout; retrying via direct Athom Apps API with extended timeouts."
+            fallback_output=$(HOMEY_PAT="$HOMEY_PAT" HOMEY_API_TIMEOUT_MS="${HOMEY_API_TIMEOUT_MS:-60000}" HOMEY_BUILD_POLL_TIMEOUT_MS="${HOMEY_BUILD_POLL_TIMEOUT_MS:-240000}" node "$GITHUB_WORKSPACE/scripts/direct-api-publish.js" --path "$PUBLISH_DIR" 2>&1)
+            fallback_status=$?
+            publish_output="$(printf '%s\n%s' "$publish_output" "$fallback_output")"
+            publish_status=$fallback_status
+          fi
           set -e
           printf '%s\n' "$publish_output"
           if [ "$publish_status" -ne 0 ]; then

--- a/scripts/direct-api-publish.js
+++ b/scripts/direct-api-publish.js
@@ -21,18 +21,36 @@
 
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const os = require('os');
+const zlib = require('zlib');
+const { pipeline } = require('stream/promises');
 
-// Resolve the global homey CLI install (avoids relying on the app's own node_modules).
-const HOMEY_CLI_ROOT = 'C:/Users/HP/AppData/Roaming/npm/node_modules/homey';
-const AthomApi = require(path.join(HOMEY_CLI_ROOT, 'services/AthomApi'));
-const AthomAppsAPI = require(path.join(HOMEY_CLI_ROOT, 'node_modules/homey-api/lib/AthomAppsAPI'));
+function argValue(name) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return null;
+  return process.argv[index + 1] || null;
+}
 
-const APP_ROOT = path.resolve(__dirname, '..');
+const APP_ROOT = path.resolve(argValue('--path') || process.env.HOMEY_PUBLISH_PATH || path.join(__dirname, '..'));
 const APP_JSON = JSON.parse(fs.readFileSync(path.join(APP_ROOT, 'app.json'), 'utf8'));
 const APP_ID = APP_JSON.id;
 const APP_VERSION = APP_JSON.version;
 const MAX_ARCHIVE_MB = Number(process.env.HOMEY_ARCHIVE_MAX_MB || 20);
+const API_TIMEOUT_MS = Number(process.env.HOMEY_API_TIMEOUT_MS || 60000);
+const BUILD_POLL_TIMEOUT_MS = Number(process.env.HOMEY_BUILD_POLL_TIMEOUT_MS || 240000);
+const BUILD_POLL_INTERVAL_MS = Number(process.env.HOMEY_BUILD_POLL_INTERVAL_MS || 5000);
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MODULE_PATHS = [APP_ROOT, REPO_ROOT, process.cwd()];
+
+function resolveModule(id, extraPaths = []) {
+  return require.resolve(id, { paths: [...extraPaths, ...MODULE_PATHS] });
+}
+
+const homeyPackageRoot = path.dirname(resolveModule('homey/package.json'));
+const AthomApi = require(resolveModule('homey/lib/AthomApi'));
+const AthomAppsAPI = require(resolveModule('homey-api/lib/AthomAppsAPI', [homeyPackageRoot]));
+const tar = require(resolveModule('tar-fs', [homeyPackageRoot]));
+const fetch = require(resolveModule('node-fetch', [homeyPackageRoot]));
 
 const STATE = {
   PENDING: 'pending',
@@ -62,8 +80,9 @@ async function buildApi() {
 async function listBuilds(api, token) {
   const builds = await api.getBuilds({
     $token: token,
+    $timeout: API_TIMEOUT_MS,
     appId: APP_ID,
-    query: { limit: 50 },
+    $query: { limit: 50 },
   });
   const list = Array.isArray(builds) ? builds : (builds?.data || []);
   list.sort((a, b) => (b.id || 0) - (a.id || 0));
@@ -77,7 +96,6 @@ async function listBuilds(api, token) {
 }
 
 function ensureArchive() {
-  // Prefer a freshly-built .homeybuild/<app>.tar.gz
   const candidates = [
     path.join(APP_ROOT, '.homeybuild', `${APP_ID}.tar.gz`),
     path.join(APP_ROOT, '.homeybuild', 'app.tar.gz'),
@@ -100,20 +118,51 @@ function ensureArchive() {
       return c;
     }
   }
-  log('No archive found, building via `homey app build`...');
-  const r = spawnSync('npx', ['homey', 'app', 'build'], { cwd: APP_ROOT, stdio: 'inherit', shell: true });
-  if (r.status !== 0) throw new Error('homey app build failed');
-  for (const c of candidates) {
-    if (fs.existsSync(c)) return c;
-  }
-  throw new Error('No archive produced by build');
+  return null;
+}
+
+async function packDirectory(appPath) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'homey-direct-publish-'));
+  const archivePath = path.join(tmpDir, `${APP_ID}.tar.gz`);
+  let appSize = 0;
+  let numFiles = 0;
+
+  await pipeline(
+    tar.pack(appPath, {
+      dereference: true,
+      map(header) {
+        if (header.type === 'file') numFiles += 1;
+        return header;
+      },
+      ignore(name) {
+        const rel = path.relative(appPath, name).replace(/\\/g, '/');
+        if (!rel) return false;
+        if (rel.startsWith('.')) return true;
+        if (rel.includes('/.git/')) return true;
+        return false;
+      },
+    }).on('data', (chunk) => {
+      appSize += chunk.length;
+    }),
+    zlib.createGzip(),
+    fs.createWriteStream(archivePath),
+  );
+
+  const archiveMB = fs.statSync(archivePath).size / 1024 / 1024;
+  log(`Packed ${numFiles} files from ${appPath} (${(appSize / 1024 / 1024).toFixed(2)} MB raw, ${archiveMB.toFixed(2)} MB gz).`);
+  return archivePath;
 }
 
 async function pollBuildState(api, token, buildId, { timeoutMs = 180000, intervalMs = 5000 } = {}) {
   const deadline = Date.now() + timeoutMs;
   let last = null;
   while (Date.now() < deadline) {
-    const b = await api.getBuild({ $token: token, appId: APP_ID, buildId });
+    const b = await api.getBuild({
+      $token: token,
+      $timeout: API_TIMEOUT_MS,
+      appId: APP_ID,
+      buildId,
+    });
     const state = b?.state;
     if (state !== last) {
       log(`Build #${buildId} state: ${state} (approved=${b?.approved})`);
@@ -135,16 +184,16 @@ async function setChannel(api, token, buildId, channel) {
   log(`Setting build #${buildId} channel to "${channel}"...`);
   const res = await api.updateBuildChannel({
     $token: token,
+    $timeout: API_TIMEOUT_MS,
     appId: APP_ID,
     buildId,
-    body: { channel },
+    channel,
   });
   log('Channel update result:', JSON.stringify(res));
   return res;
 }
 
 async function uploadArchive(url, method, headers, archivePath) {
-  const fetch = require(path.join(HOMEY_CLI_ROOT, 'node_modules/node-fetch'));
   const sz = fs.statSync(archivePath).size;
   if (sz === 0) {
     throw new Error(`FATAL: archive ${archivePath} is 0 bytes — refuse to upload (would cause processing_failed).`);
@@ -208,7 +257,7 @@ async function uploadArchive(url, method, headers, archivePath) {
  */
 function readChangelog() {
   try {
-  const clPath = path.join(APP_ROOT, '.homeychangelog.json');
+    const clPath = path.join(APP_ROOT, '.homeychangelog.json');
     if (!fs.existsSync(clPath)) {
       log('No .homeychangelog.json found, using generic changelog.');
       return { en: `v${APP_VERSION}: maintenance release` };
@@ -232,21 +281,54 @@ function readChangelog() {
   }
 }
 
+function readReadme() {
+  const readme = {};
+  const englishPath = path.join(APP_ROOT, 'README.txt');
+  if (fs.existsSync(englishPath)) {
+    readme.en = fs.readFileSync(englishPath, 'utf8');
+  }
+
+  for (const entry of fs.readdirSync(APP_ROOT, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    const match = /^README\.([a-z]{2})\.txt$/i.exec(entry.name);
+    if (!match) continue;
+    readme[match[1].toLowerCase()] = fs.readFileSync(path.join(APP_ROOT, entry.name), 'utf8');
+  }
+
+  if (!readme.en) {
+    readme.en = `${APP_ID} v${APP_VERSION}`;
+  }
+  return readme;
+}
+
+function readEnv() {
+  const envPath = path.join(APP_ROOT, 'env.json');
+  if (!fs.existsSync(envPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(envPath, 'utf8'));
+  } catch (e) {
+    throw new Error(`Invalid env.json: ${e.message}`);
+  }
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   const doChannel = argv.includes('--channel')
     ? argv[argv.indexOf('--channel') + 1]
     : null;
   const listOnly = argv.includes('--list');
-  const skipBuild = argv.includes('--skip-build');
 
   log(`App: ${APP_ID} v${APP_VERSION}`);
+  log(`Path: ${APP_ROOT}`);
+  log(`API timeout: ${API_TIMEOUT_MS}ms`);
   const { api, token } = await buildApi();
 
   await listBuilds(api, token);
   if (listOnly) return;
 
   const changelog = readChangelog();
+  const readme = readReadme();
+  const env = readEnv();
   log(`Changelog (en): ${changelog.en.slice(0, 80)}${changelog.en.length > 80 ? '…' : ''}`);
 
   log(`Creating new build for ${APP_ID}@${APP_VERSION}...`);
@@ -256,11 +338,12 @@ async function main() {
   // made the API see no named params → server returned "Invalid Version: undefined".
   const created = await api.createBuild({
     $token: token,
+    $timeout: API_TIMEOUT_MS,
     appId: APP_ID,
     version: APP_VERSION,
     changelog,
-    env: {},
-    readme: {},
+    env,
+    readme,
   });
 
   const { url, method, headers, buildId } = created;
@@ -270,15 +353,14 @@ async function main() {
   }
   log(`Created build #${buildId}. Upload target ready.`);
 
-  // --skip-build: reuse an existing archive instead of rebuilding.
-  // (Previously both branches of this ternary were identical, making
-  // the flag a no-op. Now the intent is explicit: skipBuild just means
-  // "do not force a rebuild even if the archive is stale".)
-  const archivePath = ensureArchive();
+  const archivePath = ensureArchive() || await packDirectory(APP_ROOT);
   await uploadArchive(url, method, headers, archivePath);
 
   log('Polling Athom until the build is processed...');
-  const finalBuild = await pollBuildState(api, token, buildId);
+  const finalBuild = await pollBuildState(api, token, buildId, {
+    timeoutMs: BUILD_POLL_TIMEOUT_MS,
+    intervalMs: BUILD_POLL_INTERVAL_MS,
+  });
   log(`Build #${buildId} final state: ${finalBuild.state}`);
 
   if (doChannel) {


### PR DESCRIPTION
## Summary
- add a portable `scripts/direct-api-publish.js --path <dir>` fallback that uses the same Athom Apps API flow with configurable 60s API timeouts
- keep the official Homey CLI publish path first, then retry through direct API only on transient timeout/fetch/network failures
- apply the same fallback to the main publish action, legacy local publish action, auto-fix publish, and stable publish flows
- avoid noisy `npm ci` failures in prepared publish dirs that do not contain a lockfile

## Root cause
The latest master publish reached Homey CLI publish and failed before draft promotion with `Timeout after 10000ms` after `Pre-processing app...`. The payload size gates and Homey validation had passed, so the failure was the Homey/Homey API default 10s request timeout, not a manifest or AggregateError issue.

## Validation
- node --check scripts/direct-api-publish.js
- npm run check:yaml
- git diff --check
- npm run precommit
- pre-commit hook
- pre-push gate