### PR TITLE
[codex] fix Homey test promotion API

### DIFF
--- a/.github/scripts/auto-promote-oauth.js
+++ b/.github/scripts/auto-promote-oauth.js
@@ -199,9 +199,10 @@ async function promoteRaw(apiTk) {
   const pid=selection.build.id||selection.build._id;
   const base=r.url.substring(0,r.url.indexOf('/app/'));
   const pr=await fetch(base+'/app/'+APP+'/build/'+pid+'/channel',{
-    method:'PUT',headers:{...hd,'Content-Type':'application/json'},
+    method:'POST',headers:{...hd,'Content-Type':'application/json'},
     body:JSON.stringify({channel:'test'})});
-  log('  Promote: '+pr.status);
-  if(!pr.ok) throw new Error('promote '+pr.status);
+  const text=pr.ok?'':await pr.text().catch(()=>'');
+  log('  Promote: '+pr.status+(text?' '+text.slice(0,200):''));
+  if(!pr.ok) throw new Error('promote '+pr.status+(text?': '+text.slice(0,200):''));
   log('  Promoted!');
 }

--- a/.github/scripts/auto-publish-draft.js
+++ b/.github/scripts/auto-publish-draft.js
@@ -15,6 +15,11 @@ const {
   sortBuildsDesc,
   summarizeBuild,
 } = require('./homey-build-selection');
+const {
+  createClient: createHomeyAppsClient,
+  getBuilds: getSdkBuilds,
+  updateBuildChannel,
+} = require('./homey-apps-api-client');
 
 // Dynamically read App ID and version from app.json
 const APP_JSON_PATH = path.join(__dirname, '..', '..', 'app.json');
@@ -107,6 +112,46 @@ async function promoteBuild(token, buildId, apiBase) {
   return false;
 }
 
+async function promoteWithHomeySdk(version) {
+  log('\n### Step 2: Homey SDK list/promote');
+  const client = await createHomeyAppsClient({ log });
+  let builds = await getSdkBuilds(client, APP, { limit: 100 });
+  if (!builds.length) throw new Error('HomeySDK returned no builds');
+
+  log('Found ' + builds.length + ' build(s) via HomeySDK');
+  sortBuildsDesc(builds).slice(0, 10).forEach(b => log('  ' + summarizeBuild(b)));
+
+  let selection = selectPromotionTarget(builds, version);
+  log('SDK selection: ' + selection.status + ' ' + summarizeBuild(selection.build));
+  if (selection.status === 'already-test') {
+    log('\nv' + version + ' is already on test. Nothing to promote.');
+    return true;
+  }
+
+  for (let retry = 1; selection.status !== 'promote' && retry <= 3; retry++) {
+    log('\nNo current-version draft via HomeySDK. Retry ' + retry + '/3 — waiting 60s for Athom...');
+    await new Promise(r => setTimeout(r, 60000));
+    builds = await getSdkBuilds(client, APP, { limit: 100 });
+    selection = selectPromotionTarget(builds, version);
+    log('SDK retry selection: ' + selection.status + ' ' + summarizeBuild(selection.build));
+    if (selection.status === 'already-test') return true;
+  }
+
+  if (selection.status !== 'promote') return false;
+
+  const buildId = selection.build.id || selection.build._id;
+  if (!buildId) throw new Error('Selected draft has no build id');
+  if (DRY) {
+    log('\nDRY RUN - would promote build ' + buildId + ' to test via HomeySDK');
+    return true;
+  }
+
+  log('\nPromoting build ' + buildId + ' to test via HomeySDK updateBuildChannel...');
+  const result = await updateBuildChannel(client, APP, buildId, 'test');
+  log('  HomeySDK updateBuildChannel result: ' + JSON.stringify(result || {}));
+  return true;
+}
+
 async function main() {
   const ver = appJson.version || 'unknown';
   log('## Auto-Publish Draft -> Test');
@@ -121,8 +166,16 @@ async function main() {
     token = PAT;
   }
 
+  try {
+    if (await promoteWithHomeySdk(ver)) return;
+    log('  HomeySDK found no current-version draft; falling back to raw API retries.');
+  } catch (error) {
+    log('  HomeySDK strategy failed: ' + error.message);
+    log('  Falling back to raw API strategy.');
+  }
+
   // Step 2: List builds and find drafts
-  log('\n### Step 2: List builds');
+  log('\n### Step 3: List builds');
   let result = await getBuilds(token);
   if (!result) {
     // v5.11.27: Try again with raw PAT if delegation token was used
@@ -187,7 +240,7 @@ async function main() {
   if (DRY) { log('\nDRY RUN - would promote ' + toPromote.length + ' build(s)'); return; }
 
   // Step 4: Promote
-  log('\n### Step 3: Promote to test');
+  log('\n### Step 4: Promote to test');
   let promoted = 0;
   for (const b of toPromote) {
     const bid = b.id || b._id;

--- a/.github/scripts/homey-apps-api-client.js
+++ b/.github/scripts/homey-apps-api-client.js
@@ -1,0 +1,126 @@
+'use strict';
+
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DEFAULT_TIMEOUT_MS = Number(process.env.HOMEY_API_TIMEOUT_MS || 60000);
+
+function resolveModule(id, extraPaths = []) {
+  return require.resolve(id, {
+    paths: [
+      ...extraPaths,
+      ROOT,
+      process.cwd(),
+    ],
+  });
+}
+
+function loadModule(candidates) {
+  const errors = [];
+  for (const candidate of candidates) {
+    try {
+      return candidate();
+    } catch (error) {
+      errors.push(error.message);
+    }
+  }
+  throw new Error(errors.join(' | '));
+}
+
+function loadAthomApi() {
+  return loadModule([
+    () => {
+      const AthomApi = require(resolveModule('homey/services/AthomApi'));
+      if (typeof AthomApi.createDelegationToken !== 'function') {
+        throw new Error('homey/services/AthomApi missing createDelegationToken');
+      }
+      return AthomApi;
+    },
+    () => {
+      const AthomApi = require(resolveModule('homey/lib/AthomApi'));
+      if (typeof AthomApi.createDelegationToken !== 'function') {
+        throw new Error('homey/lib/AthomApi missing createDelegationToken');
+      }
+      return AthomApi;
+    },
+  ]);
+}
+
+function loadAthomAppsApi() {
+  return loadModule([
+    () => require(resolveModule('homey-api/lib/AthomAppsAPI')),
+    () => {
+      const homeyPackageRoot = path.dirname(resolveModule('homey/package.json'));
+      return require(resolveModule('homey-api/lib/AthomAppsAPI', [homeyPackageRoot]));
+    },
+    () => {
+      const { AthomAppsAPI } = require(resolveModule('homey-api'));
+      if (!AthomAppsAPI) throw new Error('homey-api missing AthomAppsAPI export');
+      return AthomAppsAPI;
+    },
+    () => {
+      const homeyPackageRoot = path.dirname(resolveModule('homey/package.json'));
+      const { AthomAppsAPI } = require(resolveModule('homey-api', [homeyPackageRoot]));
+      if (!AthomAppsAPI) throw new Error('homey-api missing AthomAppsAPI export');
+      return AthomAppsAPI;
+    },
+    () => {
+      const { AthomAppsAPI } = require(resolveModule('athom-api'));
+      if (!AthomAppsAPI) throw new Error('athom-api missing AthomAppsAPI export');
+      return AthomAppsAPI;
+    },
+  ]);
+}
+
+function normalizeToken(tokenObj) {
+  return tokenObj?.token || tokenObj?.access_token || tokenObj;
+}
+
+function normalizeBuilds(response) {
+  if (Array.isArray(response)) return response;
+  if (Array.isArray(response?.data)) return response.data;
+  if (Array.isArray(response?.builds)) return response.builds;
+  if (Array.isArray(response?.items)) return response.items;
+  return [];
+}
+
+async function createClient({ log = () => {}, timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
+  const AthomApi = loadAthomApi();
+  const AthomAppsAPI = loadAthomAppsApi();
+  log('  [HomeySDK] Requesting apps delegation token...');
+  const token = normalizeToken(await AthomApi.createDelegationToken({ audience: 'apps' }));
+  if (!token) throw new Error('HomeySDK delegation token missing');
+  log('  [HomeySDK] Delegation token obtained');
+  return {
+    api: new AthomAppsAPI({ token }),
+    token,
+    timeoutMs,
+  };
+}
+
+async function getBuilds(client, appId, { limit = 100 } = {}) {
+  const response = await client.api.getBuilds({
+    $token: client.token,
+    $timeout: client.timeoutMs,
+    appId,
+    $query: { limit },
+  });
+  return normalizeBuilds(response);
+}
+
+async function updateBuildChannel(client, appId, buildId, channel = 'test') {
+  return client.api.updateBuildChannel({
+    $token: client.token,
+    $timeout: client.timeoutMs,
+    appId,
+    buildId,
+    channel,
+  });
+}
+
+module.exports = {
+  createClient,
+  getBuilds,
+  updateBuildChannel,
+  normalizeBuilds,
+};

--- a/.github/scripts/promote-via-session.js
+++ b/.github/scripts/promote-via-session.js
@@ -59,6 +59,7 @@ async function promoteViaBrowserSession(page, log, dry, capturedToken) {
   log('  [SessAPI] Using build id='+pid);
   const bodies=[{channel:'test'},{state:'test'},{channel:'test',state:'test'}];
   const eps=[
+    ['POST',`${BASE}/app/${APP}/build/${pid}/channel`],
     ['PUT',`${BASE}/app/${APP}/build/${pid}`],
     ['PUT',`${BASE}/app/${APP}/build/${pid}/channel`],
     ['POST',`${BASE}/app/${APP}/build/${pid}/publish`],

--- a/.github/scripts/verify-test-version.js
+++ b/.github/scripts/verify-test-version.js
@@ -5,6 +5,10 @@ const fs = require('fs');
 const path = require('path');
 const { execFileSync } = require('child_process');
 const { fetchWithRetry } = require('./retry-helper');
+const {
+  createClient: createHomeyAppsClient,
+  getBuilds: getSdkBuilds,
+} = require('./homey-apps-api-client');
 
 const ROOT = path.join(__dirname, '..', '..');
 const APP = process.env.APP_ID || 'com.dlnraja.tuya.zigbee';
@@ -145,6 +149,39 @@ async function directVerify(expectedVersion) {
   return false;
 }
 
+async function sdkVerify(expectedVersion) {
+  try {
+    const client = await createHomeyAppsClient({ log });
+    const builds = normalizeBuilds(await getSdkBuilds(client, APP, { limit: 100 }));
+    if (!builds.length) {
+      log('Homey SDK returned no builds');
+      return null;
+    }
+
+    const result = classifyBuilds(builds, expectedVersion);
+    log(`Homey SDK builds: ${builds.length} total, ${result.test.length} test, ${result.draft.length} draft`);
+
+    if (result.inTest) {
+      log(`OK: v${expectedVersion} is on test channel`);
+      return true;
+    }
+
+    if (result.inDraft) {
+      log(`v${expectedVersion} is still in draft`);
+      return false;
+    }
+
+    const latestText = result.latest
+      ? `latest v${result.latest.version || '?'} ${result.latest.state || 'unknown'} #${result.latest.id || '?'}`
+      : 'latest unavailable';
+    log(`v${expectedVersion} not found via Homey SDK (${latestText})`);
+    return false;
+  } catch (error) {
+    log(`Homey SDK verify warning: ${error.message}`);
+    return null;
+  }
+}
+
 function readDashboardReport(expectedVersion) {
   if (!fs.existsSync(REPORT_PATH)) return false;
   const report = JSON.parse(fs.readFileSync(REPORT_PATH, 'utf8'));
@@ -233,7 +270,9 @@ async function main() {
   const delayMs = Number(process.env.HOMEY_TEST_VERIFY_DELAY_MS || 30000);
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     log(`Verification attempt ${attempt}/${maxAttempts}`);
-    if (await directVerify(version)) return;
+    const sdkResult = await sdkVerify(version);
+    if (sdkResult === true) return;
+    if (sdkResult === null && await directVerify(version)) return;
     if (dashboardFallback(version)) return;
     if (attempt < maxAttempts) await sleep(delayMs);
   }

--- a/scripts/direct-api-publish.js
+++ b/scripts/direct-api-publish.js
@@ -47,7 +47,21 @@ function resolveModule(id, extraPaths = []) {
 }
 
 const homeyPackageRoot = path.dirname(resolveModule('homey/package.json'));
-const AthomApi = require(resolveModule('homey/lib/AthomApi'));
+function requireAthomApi() {
+  const candidates = ['homey/services/AthomApi', 'homey/lib/AthomApi'];
+  const errors = [];
+  for (const id of candidates) {
+    try {
+      const mod = require(resolveModule(id));
+      if (typeof mod.createDelegationToken === 'function') return mod;
+      errors.push(`${id}: createDelegationToken missing`);
+    } catch (error) {
+      errors.push(`${id}: ${error.message}`);
+    }
+  }
+  throw new Error(`Cannot load Homey AthomApi (${errors.join(' | ')})`);
+}
+const AthomApi = requireAthomApi();
 const AthomAppsAPI = require(resolveModule('homey-api/lib/AthomAppsAPI', [homeyPackageRoot]));
 const tar = require(resolveModule('tar-fs', [homeyPackageRoot]));
 const fetch = require(resolveModule('node-fetch', [homeyPackageRoot]));
@@ -72,7 +86,9 @@ function log(...args) { console.log('[direct-publish]', ...args); }
 function err(...args) { console.error('[direct-publish]', ...args); }
 
 async function buildApi() {
-  const token = await AthomApi.createDelegationToken({ audience: 'apps' });
+  const tokenObj = await AthomApi.createDelegationToken({ audience: 'apps' });
+  const token = tokenObj?.token || tokenObj?.access_token || tokenObj;
+  if (!token) throw new Error('Homey apps delegation token missing');
   const api = new AthomAppsAPI({ token });
   return { api, token };
 }


### PR DESCRIPTION
## What changed
- Add a shared Homey Apps SDK client that uses the Homey CLI `services/AthomApi` delegation flow.
- Promote draft builds to test through `AthomAppsAPI.updateBuildChannel()` before raw API fallbacks.
- Fix raw/session promotion fallbacks to call `POST /app/{appId}/build/{buildId}/channel`.
- Verify test-channel state through the SDK first to avoid PAT-only `401/404` and rate-limit-heavy fallbacks.
- Harden `scripts/direct-api-publish.js` to load the AthomApi module that actually exposes `createDelegationToken()`.

## Why
Auto-Publish #28579575491 published v9.0.155 to draft, but draft-to-test promotion failed. The browser/session tier listed build #2523, then attempted the wrong channel update method and got `404`, leaving test on v9.0.150.

## Checks
- `node --check` on all touched scripts
- `npm run check:yaml`
- `git diff --check`
- `npm run precommit`
- `npm run prepush`