### PR TITLE
fix(dp): allow zero-length Tuya TLVs

### DIFF
--- a/lib/sensors/IntelligentDPAutoDiscovery.js
+++ b/lib/sensors/IntelligentDPAutoDiscovery.js
@@ -792,7 +792,8 @@ class IntelligentDPAutoDiscovery {
       found.push({
         dpId,
         value,
-        dpType: candidate.dpType ?? candidate.datatype ?? candidate.dataType ?? candidate.type ?? 'unknown'
+        dpType: candidate.dpType ?? candidate.datatype ?? candidate.dataType ?? candidate.type ?? 'unknown',
+        length: candidate.length ?? candidate.len
       });
     };
 
@@ -808,13 +809,7 @@ class IntelligentDPAutoDiscovery {
     }
 
     if (Buffer.isBuffer(payload)) {
-      for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
-        const parsed = this._parseTuyaTLV(payload, offset);
-        if (parsed.length) {
-          parsed.forEach(pushDP);
-          break;
-        }
-      }
+      this._parseBestTuyaTLV(payload).forEach(pushDP);
     }
 
     const deduped = new Map();
@@ -825,6 +820,29 @@ class IntelligentDPAutoDiscovery {
     return [...deduped.values()].slice(0, 16);
   }
 
+  _parseBestTuyaTLV(buffer) {
+    let best = null;
+    for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
+      const parsed = this._parseTuyaTLV(buffer, offset);
+      if (!parsed.length) {continue;}
+      const score = this._scoreTuyaTLVOffset(parsed, offset);
+      if (!best || score > best.score) {
+        best = { parsed, score };
+      }
+    }
+    return best?.parsed || [];
+  }
+
+  _scoreTuyaTLVOffset(parsed, offset) {
+    const positiveLength = parsed.filter(dp => Number(dp.length) > 0).length;
+    const zeroLength = parsed.length - positiveLength;
+    const startsWithZeroLength = Number(parsed[0]?.length) === 0;
+    let score = positiveLength * 20 + parsed.length - zeroLength * 5 - offset;
+    if (offset === 0) {score += 3;}
+    if (offset > 0 && startsWithZeroLength) {score -= 30;}
+    return score;
+  }
+
   _parseTuyaTLV(buffer, startOffset) {
     const datapoints = [];
     let offset = startOffset;
@@ -832,12 +850,12 @@ class IntelligentDPAutoDiscovery {
       const dpId = buffer.readUInt8(offset);
       const dpType = buffer.readUInt8(offset + 1);
       const len = buffer.readUInt16BE(offset + 2);
-      if (dpId === 0 || dpId > 255 || dpType > 5 || len <= 0 || len > 64 || offset + 4 + len > buffer.length) {
+      if (dpId === 0 || dpId > 255 || dpType > 5 || len > 64 || offset + 4 + len > buffer.length) {
         return datapoints;
       }
 
       const data = buffer.slice(offset + 4, offset + 4 + len);
-      datapoints.push({ dpId, dpType, value: this._decodeTuyaValue(dpType, data) });
+      datapoints.push({ dpId, dpType, length: len, value: this._decodeTuyaValue(dpType, data) });
       offset += 4 + len;
     }
     return datapoints;

--- a/lib/sensors/IntelligentDPAutoDiscovery.js
+++ b/lib/sensors/IntelligentDPAutoDiscovery.js
@@ -825,7 +825,7 @@ class IntelligentDPAutoDiscovery {
     for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
       const parsed = this._parseTuyaTLV(buffer, offset);
       if (!parsed.length) {continue;}
-      const score = this._scoreTuyaTLVOffset(parsed, offset);
+      const score = IntelligentDPAutoDiscovery._scoreTuyaTLVOffset(parsed, offset);
       if (!best || score > best.score) {
         best = { parsed, score };
       }
@@ -833,7 +833,7 @@ class IntelligentDPAutoDiscovery {
     return best?.parsed || [];
   }
 
-  _scoreTuyaTLVOffset(parsed, offset) {
+  static _scoreTuyaTLVOffset(parsed, offset) {
     const positiveLength = parsed.filter(dp => Number(dp.length) > 0).length;
     const zeroLength = parsed.length - positiveLength;
     const startsWithZeroLength = Number(parsed[0]?.length) === 0;

--- a/lib/zigbee/IntelligentFrameAnalyzer.js
+++ b/lib/zigbee/IntelligentFrameAnalyzer.js
@@ -202,22 +202,12 @@ class IntelligentFrameAnalyzer {
     for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
       const parsed = this._parseTuyaTLV(buffer, offset);
       if (!parsed.length) {continue;}
-      const score = this._scoreTuyaTLVOffset(parsed, offset);
+      const score = IntelligentDPAutoDiscovery._scoreTuyaTLVOffset(parsed, offset);
       if (!best || score > best.score) {
         best = { parsed, score };
       }
     }
     return best?.parsed || [];
-  }
-
-  _scoreTuyaTLVOffset(parsed, offset) {
-    const positiveLength = parsed.filter(dp => Number(dp.length) > 0).length;
-    const zeroLength = parsed.length - positiveLength;
-    const startsWithZeroLength = Number(parsed[0]?.length) === 0;
-    let score = positiveLength * 20 + parsed.length - zeroLength * 5 - offset;
-    if (offset === 0) {score += 3;}
-    if (offset > 0 && startsWithZeroLength) {score -= 30;}
-    return score;
   }
 
   _parseTuyaTLV(buffer, startOffset) {

--- a/lib/zigbee/IntelligentFrameAnalyzer.js
+++ b/lib/zigbee/IntelligentFrameAnalyzer.js
@@ -167,7 +167,8 @@ class IntelligentFrameAnalyzer {
       datapoints.push({
         dpId,
         dpType: item.dpType ?? item.datatype ?? item.dataType ?? item.type ?? 'unknown',
-        value: item.value ?? item.dpValue ?? item.data ?? item.rawValue
+        value: item.value ?? item.dpValue ?? item.data ?? item.rawValue,
+        length: item.length ?? item.len
       });
     };
 
@@ -197,11 +198,26 @@ class IntelligentFrameAnalyzer {
   }
 
   _parseTuyaPayload(buffer) {
+    let best = null;
     for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
       const parsed = this._parseTuyaTLV(buffer, offset);
-      if (parsed.length) {return parsed;}
+      if (!parsed.length) {continue;}
+      const score = this._scoreTuyaTLVOffset(parsed, offset);
+      if (!best || score > best.score) {
+        best = { parsed, score };
+      }
     }
-    return [];
+    return best?.parsed || [];
+  }
+
+  _scoreTuyaTLVOffset(parsed, offset) {
+    const positiveLength = parsed.filter(dp => Number(dp.length) > 0).length;
+    const zeroLength = parsed.length - positiveLength;
+    const startsWithZeroLength = Number(parsed[0]?.length) === 0;
+    let score = positiveLength * 20 + parsed.length - zeroLength * 5 - offset;
+    if (offset === 0) {score += 3;}
+    if (offset > 0 && startsWithZeroLength) {score -= 30;}
+    return score;
   }
 
   _parseTuyaTLV(buffer, startOffset) {
@@ -212,12 +228,12 @@ class IntelligentFrameAnalyzer {
       const dpId = buffer.readUInt8(offset);
       const dpType = buffer.readUInt8(offset + 1);
       const len = buffer.readUInt16BE(offset + 2);
-      if (dpId <= 0 || dpType > 5 || len <= 0 || len > 64 || offset + 4 + len > buffer.length) {
+      if (dpId <= 0 || dpType > 5 || len > 64 || offset + 4 + len > buffer.length) {
         return datapoints;
       }
 
       const data = buffer.slice(offset + 4, offset + 4 + len);
-      datapoints.push({ dpId, dpType, value: this._decodeTuyaValue(dpType, data) });
+      datapoints.push({ dpId, dpType, length: len, value: this._decodeTuyaValue(dpType, data) });
       offset += 4 + len;
     }
 

--- a/test/dynamic-dp-auto-discovery.test.js
+++ b/test/dynamic-dp-auto-discovery.test.js
@@ -166,6 +166,21 @@ describe('dynamic DP auto discovery', function() {
     assert.strictEqual(decoded.datapoints[0].value, 90);
   });
 
+  it('accepts zero-length Tuya datapoints without treating them as offset noise', function() {
+    const device = createDevice();
+    const analyzer = new IntelligentFrameAnalyzer(device);
+    const payload = Buffer.from([0x0a, 0x03, 0x00, 0x00]);
+
+    const decoded = analyzer.parse(1, 0xEF00, { Payload: payload, CommandID: 0x00 }, { lqi: 120 });
+    const report = device._dpAutoDiscovery.getLearningReport();
+
+    assert.strictEqual(decoded.datapoints.length, 1);
+    assert.strictEqual(decoded.datapoints[0].dpId, 10);
+    assert.strictEqual(decoded.datapoints[0].length, 0);
+    assert.strictEqual(decoded.datapoints[0].value, '');
+    assert(report.dps['10']);
+  });
+
   it('preserves normalized raw frame diagnostics when no Buffer payload is present', function() {
     const device = createDevice(['measure_battery']);
     const discovery = new IntelligentDPAutoDiscovery(device);


### PR DESCRIPTION
## Summary
- address Gemini feedback from PR #451 by allowing zero-length Tuya TLV datapoints
- keep offset-noise protection with scored TLV offset selection instead of rejecting len=0
- preserve parsed TLV length through frame normalization and add regression coverage

## Validation
- npx mocha test\\dynamic-dp-auto-discovery.test.js --timeout 5000 --exit
- npm test
- npm run check
- npm run check:athom
- npm run precommit
- git diff --check
- push pre-push gate