### PR TITLE
fix(zigbee): harden raw state advertisements

### DIFF
--- a/drivers/button_wireless_4/device.js
+++ b/drivers/button_wireless_4/device.js
@@ -325,6 +325,8 @@ class Button4GangDevice extends ButtonDevice {
       : resolvePressType(pressType, '4G');
     const count = type === 'multi' ? 3 : type === 'double' ? 2 : 1;
 
+    if (this._isDeduped(btn, `flow_${type}`, 750)) return;
+
     if (typeof this.triggerButtonPress === 'function') {
       await this.triggerButtonPress(btn, type, count, { source: 'physical' });
       return;
@@ -355,10 +357,10 @@ class Button4GangDevice extends ButtonDevice {
   /**
    * v10.1.1: Debounce helper for E000 onOff commands
    */
-  _isDeduped(ep, cmd) {
+  _isDeduped(ep, cmd, windowMs = 500) {
     const now = Date.now();
     const key = `${ep}_${cmd}`;
-    if (now - (this._e000Dedup?.[key] || 0) < 500) return true;
+    if (now - (this._e000Dedup?.[key] || 0) < windowMs) return true;
     if (!this._e000Dedup) this._e000Dedup = {};
     this._e000Dedup[key] = now;
     return false;

--- a/lib/clusters/TuyaBoundCluster.js
+++ b/lib/clusters/TuyaBoundCluster.js
@@ -376,7 +376,7 @@ class TuyaBoundCluster extends BoundCluster {
     };
 
     // dpValues can be Buffer or array
-    const dpValues = payload.dpValues || payload.data || payload.dp;
+    const dpValues = payload.dpValues ?? payload.data ?? payload.dp;
 
     if (!dpValues) {
       this.log('⚠️ No dpValues in payload');

--- a/lib/clusters/TuyaE000BoundCluster.js
+++ b/lib/clusters/TuyaE000BoundCluster.js
@@ -49,6 +49,7 @@ class TuyaE000BoundCluster extends BoundCluster {
     this._device = device;
     this._frameLog = []; // v5.5.796: Store frames for debugging
     this._lastButtonPress = 0; // v5.5.796: Debounce
+    this._lastButtonPressByKey = new Map();
   }
 
   /**
@@ -93,17 +94,19 @@ class TuyaE000BoundCluster extends BoundCluster {
     this._storeFrame(frame, meta, rawFrame);
 
     try {
-      // v5.5.796: Debounce rapid duplicate frames (within 200ms)
-      const now = Date.now();
-      if (now - this._lastButtonPress < 200) {
-        this.log('⏭️ Debounced duplicate frame');
-        return null;
-      }
-
       // Parse button press from frame using multiple strategies
       const buttonPress = this._parseButtonPress(frame, rawFrame, cmdId);
       
       if (buttonPress && typeof this._onButtonPress === 'function') {
+        const now = Date.now();
+        const key = this._buttonDedupKey(buttonPress, data, cmdId);
+        const lastSeen = this._lastButtonPressByKey.get(key) || 0;
+        if (now - lastSeen < 300) {
+          this.log(`⏭️ Debounced duplicate button frame (${key})`);
+          return null;
+        }
+        this._lastButtonPressByKey.set(key, now);
+        this._cleanupButtonDedup(now);
         this._lastButtonPress = now;
         this.log(`🔘 Button ${buttonPress.button} ${buttonPress.pressType.toUpperCase()} (strategy: ${buttonPress.strategy})`);
         await this._onButtonPress(buttonPress.button, buttonPress.pressType);
@@ -115,6 +118,21 @@ class TuyaE000BoundCluster extends BoundCluster {
     }
 
     return null;
+  }
+
+  _buttonDedupKey(buttonPress, data, cmdId) {
+    const dataHex = data?.toString?.('hex') || 'no-data';
+    return `${buttonPress.button}:${buttonPress.pressType}:${cmdId ?? 'na'}:${dataHex}`;
+  }
+
+  _cleanupButtonDedup(now) {
+    if (this._lastButtonPressByKey.size <= 64) {return;}
+    const cutoff = now - 5000;
+    for (const [key, timestamp] of this._lastButtonPressByKey) {
+      if (timestamp < cutoff) {
+        this._lastButtonPressByKey.delete(key);
+      }
+    }
   }
 
   /**

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -315,6 +315,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
     // Forum fix Ronny_M/Cam/Hartmut: 2s was too aggressive, blocking legitimate presses
     this._buttonTriggerProtection = {
       lastTrigger: 0,
+      lastByButton: {},
       minInterval: 500, // v5.5.805: Reduced from 2000ms to 500ms - fixes button not responding
       hourlyPattern: false, // Track hourly x:30 pattern
       hourlyPatternCount: 0 // v5.5.805: Only block after 2 consecutive hourly patterns
@@ -1151,12 +1152,19 @@ class ButtonDevice extends AutoAdaptiveDevice {
         this._buttonTriggerProtection.hourlyPatternCount = 0;
       }
 
-      // v5.5.805: Minimum interval protection - 500ms
-      if (timeSinceLastTrigger < this._buttonTriggerProtection.minInterval && timeSinceLastTrigger > 0) {
-        this.log(`[ANTI-TRIGGER] Debounced (${timeSinceLastTrigger}ms < ${this._buttonTriggerProtection.minInterval}ms)`);
+      // v5.5.805/v10.1.3: Minimum interval protection per button.
+      // Multi-gang remotes may legitimately send different buttons close together.
+      if (!this._buttonTriggerProtection.lastByButton) {
+        this._buttonTriggerProtection.lastByButton = {};
+      }
+      const lastForButton = this._buttonTriggerProtection.lastByButton[button] || 0;
+      const timeSinceLastButton = now - lastForButton;
+      if (timeSinceLastButton < this._buttonTriggerProtection.minInterval && timeSinceLastButton > 0) {
+        this.log(`[ANTI-TRIGGER] Debounced button ${button} (${timeSinceLastButton}ms < ${this._buttonTriggerProtection.minInterval}ms)`);
         return;
       }
 
+      this._buttonTriggerProtection.lastByButton[button] = now;
       this._buttonTriggerProtection.lastTrigger = now;
     }
 

--- a/lib/devices/TuyaUnifiedDevice.js
+++ b/lib/devices/TuyaUnifiedDevice.js
@@ -1038,7 +1038,7 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
     if (data.datapoints && Array.isArray(data.datapoints)) {
       this.log(`[TUYA-PROCESS] ℹ️ Legacy datapoints array with ${data.datapoints.length} DPs`);
       for (const dp of data.datapoints) {
-        this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+        this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
       }
       return;
     }
@@ -1070,7 +1070,7 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
    * @returns {*} Parsed value
    */
   _parseDataValue(dpValue) {
-    if (!dpValue || !dpValue.data) {return null;}
+    if (!dpValue || dpValue.data === undefined || dpValue.data === null) {return null;}
 
     const dataTypes = {
       raw: 0,     // Raw bytes

--- a/lib/devices/UnifiedPlugBase.js
+++ b/lib/devices/UnifiedPlugBase.js
@@ -617,7 +617,7 @@ class UnifiedPlugBase extends TuyaZigbeeDevice {
     if (data.dpValues && Buffer.isBuffer(data.dpValues)) {
       this._parseTuyaRawFrame(Buffer.concat([Buffer.alloc(2), data.dpValues]));
     } else if (data.dp !== undefined) {
-      this._handleDP(data.dp, data.value || data.data);
+      this._handleDP(data.dp, data.value ?? data.data);
     }
   }
 

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -2882,12 +2882,12 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       // Handle different data formats
       if (data.datapoints) {
         for (const dp of data.datapoints) {
-          this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+          this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
         }
       } else if (data.dp !== undefined) {
-        this._handleDP(data.dp, data.value || data.data);
+        this._handleDP(data.dp, data.value ?? data.data);
       } else if (data.dpId !== undefined) {
-        this._handleDP(data.dpId, data.dpValue || data.data);
+        this._handleDP(data.dpId, data.dpValue ?? data.data);
       }
     } catch (err) {
       this.log('[TUYA-DP] Parse error:', err.message);
@@ -4135,7 +4135,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       if (Array.isArray(status)) {
         // Array of datapoints: [{dp: 1, value: 230}, {dp: 2, value: 65}]
         for (const item of status) {
-          const dp = item.dp || item.dpId || item.id;
+          const dp = item.dp ?? item.dpId ?? item.id;
           const value = item.value !== undefined ? item.value : item.data;
           if (dp !== undefined && value !== undefined) {
             this._handleDP(dp, value);
@@ -4145,7 +4145,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
         // Object with datapoints property
         if (status.datapoints) {
           for (const dp of status.datapoints) {
-            this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+            this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
           }
         }
         // Object with numeric keys (DP IDs)
@@ -4157,7 +4157,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
         }
         // Single DP object
         if (status.dp !== undefined || status.dpId !== undefined) {
-          const dp = status.dp || status.dpId;
+          const dp = status.dp ?? status.dpId;
           const value = status.value !== undefined ? status.value : status.data;
           this._handleDP(dp, value);
         }

--- a/lib/devices/UnifiedSwitchBase.js
+++ b/lib/devices/UnifiedSwitchBase.js
@@ -341,7 +341,7 @@ class UnifiedSwitchBase extends TuyaZigbeeDevice {
     if (data.dp !== undefined && data.value !== undefined) {
       this._handleDP(data.dp, data.value);
     } else if (data.dpId !== undefined) {
-      this._handleDP(data.dpId, data.value || data.data);
+      this._handleDP(data.dpId, data.value ?? data.data);
     } else if (Buffer.isBuffer(data) && data.length >= 5) {
       // Parse raw Tuya frame: [seq:2][dp:1][type:1][len:2][data:len]
       const dp = data[2];

--- a/lib/tuya/TS0601_EMERGENCY_FIX.js
+++ b/lib/tuya/TS0601_EMERGENCY_FIX.js
@@ -148,8 +148,8 @@ async function applyTS0601EmergencyFix(device, zclNode) {
       receivedDataReports++;
       device.log(`   📦 [EMERGENCY] dataReport #${receivedDataReports} received:`, JSON.stringify(data));
 
-      const dp = data.dpId || data.dp;
-      const value = data.dpValue || data.data;
+      const dp = data.dpId ?? data.dp;
+      const value = data.dpValue ?? data.data;
 
       const mapping = dpMappings[dp];
       if (mapping) {

--- a/lib/tuya/TuyaEF00Manager.js
+++ b/lib/tuya/TuyaEF00Manager.js
@@ -9,6 +9,7 @@ const LocalTuyaEntityHandler = require('./LocalTuyaEntityHandler');
 const { logUnknownDP, autoMapUnknownDP } = require('../utils/UnknownDPLogger');
 const DiagnosticLogger = require('../diagnostics/DiagnosticLogger');
 const TuyaTimeSyncFormats = require('./TuyaTimeSyncFormats');
+const IntelligentFrameAnalyzer = require('../zigbee/IntelligentFrameAnalyzer');
 
 // v5.5.39: Import TuyaBoundCluster for receiving DP reports
 let TuyaBoundCluster;
@@ -963,7 +964,7 @@ class TuyaEF00Manager extends EventEmitter {
     try {
       if (!data) {return;}
 
-      const dp = data.dpId || data.dp;
+      const dp = data.dpId ?? data.dp;
       const value = data.dpValue ?? data.data ?? data.value;
 
       if (dp !== undefined && value !== undefined) {
@@ -982,6 +983,11 @@ class TuyaEF00Manager extends EventEmitter {
     const mapping = this.dpMappings ? this.dpMappings[dp] : null;
 
     this._log(`[TUYA-PASSIVE] 📥 Processing DP${dp} = ${JSON.stringify(value)}`);
+
+    if (this._isRecentDuplicateDP(dp, value, { source: 'passive' })) {
+      this._log(`[TUYA-PASSIVE] ⏭️ Duplicate DP${dp} state suppressed`);
+      return;
+    }
 
     // v5.2.14: Store last data received for KPI
     this.device.setStoreValue('last_data_received', Date.now()).catch(() => { });
@@ -1084,6 +1090,60 @@ class TuyaEF00Manager extends EventEmitter {
         autoMapUnknownDP(this.device, dp, value);
       }
     }
+  }
+
+  _isRecentDuplicateDP(dp, value, options = {}) {
+    const dpId = Number(dp);
+    if (!Number.isInteger(dpId)) {return false;}
+
+    if (!this._dpStateDedup) {
+      this._dpStateDedup = new Map();
+      this._dpStateDedupCount = 0;
+    }
+
+    const now = Date.now();
+    const windowMs = options.windowMs ?? (this._isButtonLikeDP(dpId) ? 750 : 500);
+    const key = `${dpId}:${this._stableDPValue(value)}`;
+    const lastSeen = this._dpStateDedup.get(key);
+    this._dpStateDedup.set(key, now);
+
+    this._dpStateDedupCount += 1;
+    if (this._dpStateDedupCount % 100 === 0 || this._dpStateDedup.size > 500) {
+      const cutoff = now - Math.max(windowMs * 10, 5000);
+      for (const [cachedKey, seenAt] of this._dpStateDedup) {
+        if (seenAt < cutoff) {
+          this._dpStateDedup.delete(cachedKey);
+        }
+      }
+    }
+
+    return lastSeen !== undefined && now - lastSeen < windowMs;
+  }
+
+  _isButtonLikeDP(dp) {
+    const driverId = String(this.device?.driver?.id || '').toLowerCase();
+    if (!/button|remote|scene|switch_wireless/.test(driverId)) {return false;}
+
+    const mapping = this.dpMappings?.[dp] || this.device?.dpMappings?.[dp];
+    const capability = String(mapping?.capability || '');
+    return dp >= 1 && dp <= 8 || capability.startsWith('button');
+  }
+
+  _stableDPValue(value) {
+    if (Buffer.isBuffer(value)) {
+      return `buffer:${value.toString('hex')}`;
+    }
+    if (Array.isArray(value)) {
+      return `array:${Buffer.from(value).toString('hex')}`;
+    }
+    if (value && typeof value === 'object') {
+      try {
+        return JSON.stringify(value, Object.keys(value).sort());
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return `${typeof value}:${String(value)}`;
   }
 
   /**
@@ -2455,6 +2515,23 @@ class TuyaEF00Manager extends EventEmitter {
    */
   parseTuyaFrame(buffer) {
     try {
+      const decoded = this._getFrameAnalyzer().parse(1, 0xEF00, { Payload: buffer, CommandID: 0x00 }, {
+        source: 'tuya_ef00_manager',
+      });
+
+      if (decoded.datapoints?.length) {
+        for (const dp of decoded.datapoints) {
+          this._log(`[TUYA] 📊 Analyzer DP ${dp.dpId}: type=${dp.dpType}, value=${JSON.stringify(dp.value)}`);
+          this.handleDatapoint({
+            dp: dp.dpId,
+            datatype: dp.dpType,
+            length: dp.length,
+            data: dp.value,
+          });
+        }
+        return;
+      }
+
       // Tuya frame format: [status:1][seq:1][dp:1][type:1][len:2][data:len]
       let offset = 0;
 
@@ -2486,6 +2563,13 @@ class TuyaEF00Manager extends EventEmitter {
     } catch (err) {
       this._error('[TUYA] Frame parse failed:', err.message);
     }
+  }
+
+  _getFrameAnalyzer() {
+    if (!this._frameAnalyzer) {
+      this._frameAnalyzer = new IntelligentFrameAnalyzer(this.device);
+    }
+    return this._frameAnalyzer;
   }
 
   /**
@@ -2594,9 +2678,9 @@ class TuyaEF00Manager extends EventEmitter {
       return;
     }
 
-    const dp = data.dp || data.dpId || data.id;
-    let value = data.value || data.dpValue || data.data;  // v5.5.205: Changed to let for reassignment
-    const dpType = data.datatype || data.dpType || 'unknown';
+    const dp = data.dp ?? data.dpId ?? data.id;
+    let value = data.value ?? data.dpValue ?? data.data;  // v5.5.205: Changed to let for reassignment
+    const dpType = data.datatype ?? data.dpType ?? 'unknown';
 
     // v10.2.0: Try DP fragmentation reassembly before normal processing
     if (Buffer.isBuffer(value) && this._tryFragmentReassembly(dp, value)) {
@@ -2664,6 +2748,11 @@ class TuyaEF00Manager extends EventEmitter {
       }
     } else {
       this._log(`[TUYA-DP] 📦 DP${dp} received: value=${JSON.stringify(value)}, type=${dpType}`);
+    }
+
+    if (this._isRecentDuplicateDP(dp, value, { source: 'active' })) {
+      this._log(`[TUYA-DP] ⏭️ Duplicate DP${dp} state suppressed`);
+      return;
     }
 
     // v5.2.10: Store last data received timestamp for KPI

--- a/lib/tuya/TuyaZigbeeDevice.js
+++ b/lib/tuya/TuyaZigbeeDevice.js
@@ -6,6 +6,7 @@ const DiagnosticLogger = require('../diagnostics/DiagnosticLogger');
 const { trackTx, trackRx } = require('../utils/UniversalThrottleManager');
 const CapabilityMapCache = require('../utils/CapabilityMapCache');
 const DeviceTelemetryEstimator = require('../utils/DeviceTelemetryEstimator');
+const RawFrameDeduplicator = require('../zigbee/RawFrameDeduplicator');
 const { assertZCLNode, assertClusterSpecification } = require('../util');
 
 /**
@@ -204,32 +205,29 @@ class TuyaZigbeeDevice extends PhysicalButtonMixin(VirtualButtonMixin(ZigBeeDevi
       return;
     }
 
-    // L0: Duplicate frame debounce cache (5s window)
-    if (!this._frameDedupCache) this._frameDedupCache = new Map();
-    if (!this._frameDedupCount) this._frameDedupCount = 0;
+    // L0: Exact-payload duplicate filtering. Never dedupe by a short prefix:
+    // Tuya MCU devices often resend a full state map where only a later DP changed.
+    if (!this._rawFrameDeduplicator) {
+      this._rawFrameDeduplicator = new RawFrameDeduplicator({
+        defaultWindowMs: 500,
+        tuyaWindowMs: 750,
+        maxCacheSize: 500,
+      });
+    }
 
     this._diagLogger.info('Setting up Universal Raw Frame Fallback v5.13.2');
     const originalHandleFrame = this.node.handleFrame;
 
     this.node.handleFrame = (endpointId, clusterId, frame, meta) => {
-      // L0: Duplicate frame filtering
-      const cacheKey = `${endpointId}:${clusterId}:${meta?.cmdId || 0}:${frame?.slice?.(0, 4)?.toString('hex') || 'na'}`;
-      const now = Date.now();
-      const lastSeen = this._frameDedupCache.get(cacheKey);
-      if (lastSeen && (now - lastSeen) < 5000) return; // 5s debounce
-      this._frameDedupCache.set(cacheKey, now);
-      // v9.1.2: Cleanup old entries every 100 frames AND when map exceeds 500 entries
-      if (this._frameDedupCount++ % 100 === 0 || this._frameDedupCache.size > 500) {
-        for (const [k, v] of this._frameDedupCache) {
-          if (now - v > 10000) this._frameDedupCache.delete(k);
+      const duplicate = this._rawFrameDeduplicator.shouldSuppress(endpointId, clusterId, frame, meta);
+      if (duplicate.suppress) {
+        this.trackIncomingReport();
+        if (!this._rawFrameDuplicateCount) this._rawFrameDuplicateCount = 0;
+        this._rawFrameDuplicateCount += 1;
+        if (this._rawFrameDuplicateCount <= 5 || this._rawFrameDuplicateCount % 100 === 0) {
+          this.log(`[L0] Suppressed exact duplicate raw frame #${this._rawFrameDuplicateCount}: EP${endpointId} cluster=0x${Number(clusterId).toString(16).padStart(4, '0')} age=${duplicate.age}ms`);
         }
-        // Emergency: if still too large, clear half (oldest)
-        if (this._frameDedupCache.size > 500) {
-          const keys = [...this._frameDedupCache.keys()];
-          for (let i = 0; i < Math.floor(keys.length / 2); i++) {
-            this._frameDedupCache.delete(keys[i]);
-          }
-        }
+        return;
       }
 
       let handled = false;

--- a/lib/zigbee/RawFrameDeduplicator.js
+++ b/lib/zigbee/RawFrameDeduplicator.js
@@ -1,0 +1,130 @@
+'use strict';
+
+class RawFrameDeduplicator {
+  constructor(options = {}) {
+    this.defaultWindowMs = options.defaultWindowMs ?? 500;
+    this.tuyaWindowMs = options.tuyaWindowMs ?? 750;
+    this.maxCacheSize = options.maxCacheSize ?? 500;
+    this.cache = new Map();
+    this.count = 0;
+  }
+
+  shouldSuppress(endpointId, clusterId, frame, meta = {}) {
+    const now = Date.now();
+    const numericCluster = Number(clusterId);
+    const windowMs = this._windowForCluster(numericCluster);
+    const key = this.makeKey(endpointId, numericCluster, frame, meta);
+    const lastSeen = this.cache.get(key);
+
+    this.cache.set(key, now);
+    this._cleanup(now, windowMs);
+
+    return {
+      suppress: lastSeen !== undefined && now - lastSeen < windowMs,
+      key,
+      windowMs,
+      age: lastSeen === undefined ? null : now - lastSeen,
+    };
+  }
+
+  makeKey(endpointId, clusterId, frame, meta = {}) {
+    const commandId = RawFrameDeduplicator.commandId(frame, meta);
+    const payload = RawFrameDeduplicator.extractPayload(frame);
+    const payloadKey = payload
+      ? payload.toString('hex')
+      : RawFrameDeduplicator.stableValue(frame).slice(0, 1024);
+    return `${endpointId || 1}:${clusterId}:${commandId ?? 'na'}:${payloadKey}`;
+  }
+
+  _windowForCluster(clusterId) {
+    if (clusterId === 0xEF00 || clusterId === 0xE000) {
+      return this.tuyaWindowMs;
+    }
+    return this.defaultWindowMs;
+  }
+
+  _cleanup(now, windowMs) {
+    this.count += 1;
+    if (this.count % 100 !== 0 && this.cache.size <= this.maxCacheSize) {
+      return;
+    }
+
+    const cutoff = now - Math.max(windowMs * 10, 5000);
+    for (const [key, seenAt] of this.cache) {
+      if (seenAt < cutoff) {
+        this.cache.delete(key);
+      }
+    }
+
+    if (this.cache.size > this.maxCacheSize) {
+      const keys = [...this.cache.keys()];
+      for (let i = 0; i < Math.ceil(keys.length / 2); i += 1) {
+        this.cache.delete(keys[i]);
+      }
+    }
+  }
+
+  static commandId(frame, meta = {}) {
+    const value = frame?.cmdId ?? frame?.commandId ?? frame?.CommandID ??
+      frame?.command?.id ?? meta?.cmdId ?? meta?.commandId ?? meta?.CommandID;
+    if (value === undefined || value === null) {
+      return null;
+    }
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : String(value);
+  }
+
+  static extractPayload(frame) {
+    if (Buffer.isBuffer(frame)) {
+      return frame;
+    }
+
+    const candidates = [
+      frame?.data,
+      frame?.payload,
+      frame?.Payload,
+      frame?.Data,
+      frame?.raw,
+      frame?.command?.data,
+      frame?.command?.payload,
+    ];
+
+    for (const candidate of candidates) {
+      if (Buffer.isBuffer(candidate)) {
+        return candidate;
+      }
+      if (Array.isArray(candidate)) {
+        return Buffer.from(candidate);
+      }
+      if (typeof candidate === 'string' && /^(0x)?[0-9a-fA-F]+$/.test(candidate)) {
+        return Buffer.from(candidate.replace(/^0x/i, ''), 'hex');
+      }
+    }
+
+    return null;
+  }
+
+  static stableValue(value) {
+    if (Buffer.isBuffer(value)) {
+      return `buffer:${value.toString('hex')}`;
+    }
+    if (Array.isArray(value)) {
+      return `array:${Buffer.from(value).toString('hex')}`;
+    }
+    if (value && typeof value === 'object') {
+      const sorted = {};
+      for (const key of Object.keys(value).sort()) {
+        const item = value[key];
+        sorted[key] = Buffer.isBuffer(item) ? `buffer:${item.toString('hex')}` : item;
+      }
+      try {
+        return JSON.stringify(sorted);
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return String(value);
+  }
+}
+
+module.exports = RawFrameDeduplicator;

--- a/test/critical/raw-advertisement-state.test.js
+++ b/test/critical/raw-advertisement-state.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('assert');
+const RawFrameDeduplicator = require('../../lib/zigbee/RawFrameDeduplicator');
+const TuyaEF00Manager = require('../../lib/tuya/TuyaEF00Manager');
+const IntelligentFrameAnalyzer = require('../../lib/zigbee/IntelligentFrameAnalyzer');
+
+const testApi = global.describe && global.it ? global : require('node:test');
+const { describe, it } = testApi;
+
+function createDevice() {
+  return {
+    destroyed: false,
+    _destroyed: false,
+    driver: { id: 'button_wireless_4' },
+    homey: {
+      app: {},
+      setTimeout: () => ({ unref() {} }),
+      clearTimeout: () => {},
+    },
+    dpMappings: {
+      30: { capability: 'custom_zero' },
+      31: { capability: 'custom_false' },
+      32: { capability: 'custom_repeat' },
+    },
+    log: () => {},
+    error: () => {},
+    getData: () => ({ id: 'test-device' }),
+    getSetting: () => null,
+    getSettings: () => ({}),
+    setStoreValue: () => Promise.resolve(),
+    hasCapability: () => false,
+    addCapability: () => Promise.resolve(),
+    safeSetCapabilityValue: () => Promise.resolve(),
+  };
+}
+
+describe('raw advertisement and state-map handling', () => {
+  it('deduplicates only exact raw payloads, not same-prefix state maps', () => {
+    const dedup = new RawFrameDeduplicator({ defaultWindowMs: 1000, tuyaWindowMs: 1000 });
+    const first = { Payload: Buffer.from('00000102000400000001', 'hex'), CommandID: 0x02 };
+    const samePrefixDifferentDP = { Payload: Buffer.from('00000102000400000002', 'hex'), CommandID: 0x02 };
+
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, first).suppress, false);
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, first).suppress, true);
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, samePrefixDifferentDP).suppress, false);
+  });
+
+  it('preserves 0 and false DP values while suppressing unchanged repeats', async () => {
+    const manager = new TuyaEF00Manager(createDevice());
+    const reports = [];
+    manager.on('dpReport', report => reports.push(report));
+
+    await manager.handleDatapoint({ dp: 30, value: 0, dpType: 'value' });
+    await manager.handleDatapoint({ dp: 31, value: false, dpType: 'bool' });
+    await manager.handleDatapoint({ dp: 32, value: 7, dpType: 'enum' });
+    await manager.handleDatapoint({ dp: 32, value: 7, dpType: 'enum' });
+    await manager.handleDatapoint({ dp: 32, value: 8, dpType: 'enum' });
+
+    assert.deepStrictEqual(
+      reports.map(report => [report.dpId, report.value]),
+      [[30, 0], [31, false], [32, 7], [32, 8]]
+    );
+  });
+
+  it('extracts changed values from full EF00 state maps with ZCL/Tuya headers', () => {
+    const analyzer = new IntelligentFrameAnalyzer(createDevice());
+    const payload = Buffer.from([
+      0x09, 0x42, 0x01, 0x00, 0x00,
+      0x01, 0x01, 0x00, 0x01, 0x00,
+      0x02, 0x02, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    const decoded = analyzer.parse(1, 0xEF00, { Payload: payload, CommandID: 0x02 });
+
+    assert.deepStrictEqual(
+      decoded.datapoints.map(dp => [dp.dpId, dp.value]),
+      [[1, false], [2, 0]]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Replace the L0 raw-frame debounce with exact-payload deduplication so full-state advertisement maps are not dropped when only a later DP changes.
- Preserve `0` and `false` datapoint values across EF00/bound/unified paths, including active and passive reports.
- Add DP-level repeat suppression for unchanged full-state floods while letting changed DPs through, plus safer per-button dedupe for E000/TS0044/Moes-style multi-gang remotes.
- Add regression coverage for raw full-state maps, EF00 header extraction, and false/zero values.

## Cross-source context
- Homey Zigbee docs: bound/server clusters and group/broadcast behavior mean reports can arrive without a clean app-level init path, especially for sleepy devices.
- ZHA Tuya discussion/source: Tuya battery DPs can be report-only and not readable; Tuya MCU devices also use time-sync/request flows and several manufacturer variants.
- User/forum/GitHub context: button flows, battery question marks, TS0601/EF00 unknown-state paths, raw fallback, and “same prefix but changed full-state map” regressions.

## Validation
- `node --check lib/zigbee/RawFrameDeduplicator.js lib/tuya/TuyaEF00Manager.js lib/tuya/TuyaZigbeeDevice.js lib/clusters/TuyaE000BoundCluster.js lib/devices/ButtonDevice.js test/critical/raw-advertisement-state.test.js`
- `npx mocha test\critical\raw-advertisement-state.test.js --timeout 10000 --exit`
- `npx mocha test\critical\forum-routing-regressions.test.js --timeout 10000 --exit`
- `npx mocha test\button-flow-runtime-routing.test.js test\dynamic-dp-auto-discovery.test.js --timeout 10000 --exit`
- `npm test -- --timeout 10000 --exit`
- `npm run precommit`
- `npm run precommit:full`
- `npm run check:athom`
- Git pre-commit hook: passed, including security scanner and publish-size gate
- Git pre-push hook: passed, including Athom server requirements and publish payload size gate

## Notes
- `precommit:full` still reports historical warning noise from the broad static audit, but exits successfully.
- `check:athom` still reports the known `api`/`.homeyignore *.md` warnings, but says the app is ready to push and should not cause Processing failed.