### PR TITLE
fix(stable): harden raw state advertisements

### DIFF
--- a/app.json
+++ b/app.json
@@ -24649,11 +24649,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -24675,11 +24670,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -24703,11 +24693,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -24729,11 +24714,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -24757,11 +24737,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24783,11 +24758,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24811,11 +24781,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24837,11 +24802,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24865,11 +24825,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24891,11 +24846,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24919,11 +24869,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24945,11 +24890,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24973,11 +24913,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -24999,11 +24934,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25027,11 +24957,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25053,11 +24978,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25081,11 +25001,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25107,11 +25022,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25141,11 +25051,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25167,11 +25072,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25195,11 +25095,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25221,11 +25116,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25249,11 +25139,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25275,11 +25160,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25321,11 +25201,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25365,11 +25240,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25411,11 +25281,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25437,11 +25302,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25465,11 +25325,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25491,11 +25346,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25519,11 +25369,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25545,11 +25390,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25573,11 +25413,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25599,11 +25434,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25627,11 +25457,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25653,11 +25478,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25681,11 +25501,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25707,11 +25522,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25735,11 +25545,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25761,11 +25566,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25789,11 +25589,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25816,11 +25611,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25842,11 +25632,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -41663,11 +41448,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -41689,11 +41469,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -41717,11 +41492,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -41743,11 +41513,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -41771,11 +41536,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -41797,11 +41557,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -41825,11 +41580,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -41851,11 +41601,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -41879,11 +41624,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -41905,11 +41645,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -52504,11 +52239,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -52531,11 +52261,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -52557,11 +52282,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -52796,11 +52516,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52822,11 +52537,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52850,11 +52560,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52876,11 +52581,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52904,11 +52604,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52930,11 +52625,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52958,11 +52648,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -52984,11 +52669,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53012,11 +52692,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53038,11 +52713,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53066,11 +52736,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53092,11 +52757,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53120,11 +52780,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53146,11 +52801,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53174,11 +52824,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53200,11 +52845,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53228,11 +52868,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53254,11 +52889,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53282,11 +52912,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53308,11 +52933,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53336,11 +52956,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53362,11 +52977,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53390,11 +53000,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53416,11 +53021,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53444,11 +53044,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53471,11 +53066,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53497,11 +53087,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -57615,11 +57200,6 @@
             "filter": "driver_id=wall_dimmer_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_dimmer_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57766,11 +57346,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57884,11 +57459,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57932,11 +57502,6 @@
           "fr": "Définir le type d'interrupteur externe"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -57990,11 +57555,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58031,11 +57591,6 @@
           "nl": "Stel LED-indicator modus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58083,11 +57638,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58143,11 +57693,6 @@
             "filter": "driver_id=wall_switch_2gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58189,11 +57734,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58440,11 +57980,6 @@
             "filter": "driver_id=wall_switch_3gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58486,11 +58021,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58546,11 +58076,6 @@
             "filter": "driver_id=wall_switch_3gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58592,11 +58117,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58897,11 +58417,6 @@
             "filter": "driver_id=wall_switch_4gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58943,11 +58458,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -59003,11 +58513,6 @@
             "filter": "driver_id=wall_switch_4gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -59049,11 +58554,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
           {
             "type": "device",
             "name": "device",

--- a/drivers/button_wireless_4/device.js
+++ b/drivers/button_wireless_4/device.js
@@ -287,6 +287,8 @@ class Button4GangDevice extends ButtonDevice {
       : resolvePressType(pressType, '4G');
     const count = type === 'multi' ? 3 : type === 'double' ? 2 : 1;
 
+    if (this._isDeduped(btn, `flow_${type}`, 750)) return;
+
     if (typeof this.triggerButtonPress === 'function') {
       await this.triggerButtonPress(btn, type, count, { source: 'physical' });
       return;
@@ -317,10 +319,10 @@ class Button4GangDevice extends ButtonDevice {
   /**
    * v10.1.1: Debounce helper for E000 onOff commands
    */
-  _isDeduped(ep, cmd) {
+  _isDeduped(ep, cmd, windowMs = 500) {
     const now = Date.now();
     const key = `${ep}_${cmd}`;
-    if (now - (this._e000Dedup?.[key] || 0) < 500) return true;
+    if (now - (this._e000Dedup?.[key] || 0) < windowMs) return true;
     if (!this._e000Dedup) this._e000Dedup = {};
     this._e000Dedup[key] = now;
     return false;

--- a/lib/clusters/TuyaBoundCluster.js
+++ b/lib/clusters/TuyaBoundCluster.js
@@ -292,7 +292,7 @@ class TuyaBoundCluster extends BoundCluster {
     };
 
     // dpValues can be Buffer or array
-    let dpValues = payload.dpValues || payload.data || payload.dp;
+    let dpValues = payload.dpValues ?? payload.data ?? payload.dp;
 
     if (!dpValues) {
       this.log('⚠️ No dpValues in payload');

--- a/lib/clusters/TuyaE000BoundCluster.js
+++ b/lib/clusters/TuyaE000BoundCluster.js
@@ -50,6 +50,7 @@ class TuyaE000BoundCluster extends BoundCluster {
     this._device = device;
     this._frameLog = []; // v5.5.796: Store frames for debugging
     this._lastButtonPress = 0; // v5.5.796: Debounce
+    this._lastButtonPressByKey = new Map();
   }
 
   /**
@@ -96,17 +97,19 @@ class TuyaE000BoundCluster extends BoundCluster {
     this._storeFrame(frame, meta, rawFrame);
 
     try {
-      // v5.5.796: Debounce rapid duplicate frames (within 200ms)
-      const now = Date.now();
-      if (now - this._lastButtonPress < 200) {
-        this.log('⏭️ Debounced duplicate frame');
-        return null;
-      }
-
       // Parse button press from frame using multiple strategies
       const buttonPress = this._parseButtonPress(frame, rawFrame, cmdId);
       
       if (buttonPress && typeof this._onButtonPress === 'function') {
+        const now = Date.now();
+        const key = this._buttonDedupKey(buttonPress, data, cmdId);
+        const lastSeen = this._lastButtonPressByKey.get(key) || 0;
+        if (now - lastSeen < 300) {
+          this.log(`⏭️ Debounced duplicate button frame (${key})`);
+          return null;
+        }
+        this._lastButtonPressByKey.set(key, now);
+        this._cleanupButtonDedup(now);
         this._lastButtonPress = now;
         this.log(`🔘 Button ${buttonPress.button} ${buttonPress.pressType.toUpperCase()} (strategy: ${buttonPress.strategy})`);
         await this._onButtonPress(buttonPress.button, buttonPress.pressType);
@@ -118,6 +121,21 @@ class TuyaE000BoundCluster extends BoundCluster {
     }
 
     return null;
+  }
+
+  _buttonDedupKey(buttonPress, data, cmdId) {
+    const dataHex = data?.toString?.('hex') || 'no-data';
+    return `${buttonPress.button}:${buttonPress.pressType}:${cmdId ?? 'na'}:${dataHex}`;
+  }
+
+  _cleanupButtonDedup(now) {
+    if (this._lastButtonPressByKey.size <= 64) {return;}
+    const cutoff = now - 5000;
+    for (const [key, timestamp] of this._lastButtonPressByKey) {
+      if (timestamp < cutoff) {
+        this._lastButtonPressByKey.delete(key);
+      }
+    }
   }
 
   /**

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -281,6 +281,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
     // Forum fix Ronny_M/Cam/Hartmut: 2s was too aggressive, blocking legitimate presses
     this._buttonTriggerProtection = {
       lastTrigger: 0,
+      lastByButton: {},
       minInterval: 500, // v5.5.805: Reduced from 2000ms to 500ms - fixes button not responding
       hourlyPattern: false, // Track hourly x:30 pattern
       hourlyPatternCount: 0 // v5.5.805: Only block after 2 consecutive hourly patterns
@@ -1081,6 +1082,20 @@ class ButtonDevice extends AutoAdaptiveDevice {
     // v5.5.430: GLOBAL DEBOUNCE - Prevent random ghost triggers
     const now = Date.now();
     if (!this._lastTriggerTime) this._lastTriggerTime = {};
+    if (!this._buttonTriggerProtection) {
+      this._buttonTriggerProtection = {
+        lastTrigger: 0,
+        lastByButton: {},
+        minInterval: 500,
+        hourlyPattern: false,
+        hourlyPatternCount: 0,
+      };
+    } else {
+      this._buttonTriggerProtection.lastTrigger = this._buttonTriggerProtection.lastTrigger || 0;
+      this._buttonTriggerProtection.lastByButton = this._buttonTriggerProtection.lastByButton || {};
+      this._buttonTriggerProtection.minInterval = this._buttonTriggerProtection.minInterval || 500;
+      this._buttonTriggerProtection.hourlyPatternCount = this._buttonTriggerProtection.hourlyPatternCount || 0;
+    }
 
     // v5.7.14: Bidirectional deduplication - virtual <-> physical
     if (this._virtualPhysicalDedup) {
@@ -1117,12 +1132,19 @@ class ButtonDevice extends AutoAdaptiveDevice {
         this._buttonTriggerProtection.hourlyPatternCount = 0;
       }
 
-      // v5.5.805: Minimum interval protection - 500ms
-      if (timeSinceLastTrigger < this._buttonTriggerProtection.minInterval && timeSinceLastTrigger > 0) {
-        this.log(`[ANTI-TRIGGER] Debounced (${timeSinceLastTrigger}ms < ${this._buttonTriggerProtection.minInterval}ms)`);
+      // v5.5.805/v10.1.3: Minimum interval protection per button.
+      // Multi-gang remotes may legitimately send different buttons close together.
+      if (!this._buttonTriggerProtection.lastByButton) {
+        this._buttonTriggerProtection.lastByButton = {};
+      }
+      const lastForButton = this._buttonTriggerProtection.lastByButton[button] || 0;
+      const timeSinceLastButton = now - lastForButton;
+      if (timeSinceLastButton < this._buttonTriggerProtection.minInterval && timeSinceLastButton > 0) {
+        this.log(`[ANTI-TRIGGER] Debounced button ${button} (${timeSinceLastButton}ms < ${this._buttonTriggerProtection.minInterval}ms)`);
         return;
       }
 
+      this._buttonTriggerProtection.lastByButton[button] = now;
       this._buttonTriggerProtection.lastTrigger = now;
     }
 

--- a/lib/devices/TuyaUnifiedDevice.js
+++ b/lib/devices/TuyaUnifiedDevice.js
@@ -1038,7 +1038,7 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
     if (data.datapoints && Array.isArray(data.datapoints)) {
       this.log(`[TUYA-PROCESS] ℹ️ Legacy datapoints array with ${data.datapoints.length} DPs`);
       for (const dp of data.datapoints) {
-        this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+        this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
       }
       return;
     }
@@ -1070,7 +1070,7 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
    * @returns {*} Parsed value
    */
   _parseDataValue(dpValue) {
-    if (!dpValue || !dpValue.data) return null;
+    if (!dpValue || dpValue.data === undefined || dpValue.data === null) {return null;}
 
     const dataTypes = {
       raw: 0,     // Raw bytes

--- a/lib/devices/UnifiedPlugBase.js
+++ b/lib/devices/UnifiedPlugBase.js
@@ -601,7 +601,7 @@ class UnifiedPlugBase extends TuyaZigbeeDevice {
     if (data.dpValues && Buffer.isBuffer(data.dpValues)) {
       this._parseTuyaRawFrame(Buffer.concat([Buffer.alloc(2), data.dpValues]));
     } else if (data.dp !== undefined) {
-      this._handleDP(data.dp, data.value || data.data);
+      this._handleDP(data.dp, data.value ?? data.data);
     }
   }
 

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -2854,12 +2854,12 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       // Handle different data formats
       if (data.datapoints) {
         for (const dp of data.datapoints) {
-          this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+          this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
         }
       } else if (data.dp !== undefined) {
-        this._handleDP(data.dp, data.value || data.data);
+        this._handleDP(data.dp, data.value ?? data.data);
       } else if (data.dpId !== undefined) {
-        this._handleDP(data.dpId, data.dpValue || data.data);
+        this._handleDP(data.dpId, data.dpValue ?? data.data);
       }
     } catch (err) {
       this.log('[TUYA-DP] Parse error:', err.message);
@@ -4099,7 +4099,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       if (Array.isArray(status)) {
         // Array of datapoints: [{dp: 1, value: 230}, {dp: 2, value: 65}]
         for (const item of status) {
-          const dp = item.dp || item.dpId || item.id;
+          const dp = item.dp ?? item.dpId ?? item.id;
           const value = item.value !== undefined ? item.value : item.data;
           if (dp !== undefined && value !== undefined) {
             this._handleDP(dp, value);
@@ -4109,7 +4109,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
         // Object with datapoints property
         if (status.datapoints) {
           for (const dp of status.datapoints) {
-            this._handleDP(dp.dp || dp.dpId, dp.value || dp.data);
+            this._handleDP(dp.dp ?? dp.dpId, dp.value ?? dp.data);
           }
         }
         // Object with numeric keys (DP IDs)
@@ -4121,7 +4121,7 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
         }
         // Single DP object
         if (status.dp !== undefined || status.dpId !== undefined) {
-          const dp = status.dp || status.dpId;
+          const dp = status.dp ?? status.dpId;
           const value = status.value !== undefined ? status.value : status.data;
           this._handleDP(dp, value);
         }

--- a/lib/devices/UnifiedSwitchBase.js
+++ b/lib/devices/UnifiedSwitchBase.js
@@ -341,7 +341,7 @@ class UnifiedSwitchBase extends TuyaZigbeeDevice {
     if (data.dp !== undefined && data.value !== undefined) {
       this._handleDP(data.dp, data.value);
     } else if (data.dpId !== undefined) {
-      this._handleDP(data.dpId, data.value || data.data);
+      this._handleDP(data.dpId, data.value ?? data.data);
     } else if (Buffer.isBuffer(data) && data.length >= 5) {
       // Parse raw Tuya frame: [seq:2][dp:1][type:1][len:2][data:len]
       const dp = data[2];

--- a/lib/tuya/TS0601_EMERGENCY_FIX.js
+++ b/lib/tuya/TS0601_EMERGENCY_FIX.js
@@ -148,8 +148,8 @@ async function applyTS0601EmergencyFix(device, zclNode) {
       receivedDataReports++;
       device.log(`   📦 [EMERGENCY] dataReport #${receivedDataReports} received:`, JSON.stringify(data));
 
-      const dp = data.dpId || data.dp;
-      const value = data.dpValue || data.data;
+      const dp = data.dpId ?? data.dp;
+      const value = data.dpValue ?? data.data;
 
       const mapping = dpMappings[dp];
       if (mapping) {

--- a/lib/tuya/TuyaEF00Manager.js
+++ b/lib/tuya/TuyaEF00Manager.js
@@ -7,6 +7,7 @@ const { getTuyaProfile } = require('./TuyaProfiles');
 const { getModelId, getManufacturer } = require('../helpers/DeviceDataHelper');
 const LocalTuyaEntityHandler = require('./LocalTuyaEntityHandler');
 const { logUnknownDP, autoMapUnknownDP } = require('../utils/UnknownDPLogger');
+const IntelligentFrameAnalyzer = require('../zigbee/IntelligentFrameAnalyzer');
 
 // v5.5.39: Import TuyaBoundCluster for receiving DP reports
 let TuyaBoundCluster;
@@ -581,7 +582,7 @@ class TuyaEF00Manager extends EventEmitter {
     try {
       if (!data) return;
 
-      const dp = data.dpId || data.dp;
+      const dp = data.dpId ?? data.dp;
       const value = data.dpValue ?? data.data ?? data.value;
 
       if (dp !== undefined && value !== undefined) {
@@ -600,6 +601,11 @@ class TuyaEF00Manager extends EventEmitter {
     const mapping = this.dpMappings ? this.dpMappings[dp] : null;
 
     this._log(`[TUYA-PASSIVE] 📥 Processing DP${dp} = ${JSON.stringify(value)}`);
+
+    if (this._isRecentDuplicateDP(dp, value, { source: 'passive' })) {
+      this._log(`[TUYA-PASSIVE] ⏭️ Duplicate DP${dp} state suppressed`);
+      return;
+    }
 
     // v5.2.14: Store last data received for KPI
     this.device.setStoreValue('last_data_received', Date.now()).catch(() => { });
@@ -665,6 +671,60 @@ class TuyaEF00Manager extends EventEmitter {
         autoMapUnknownDP(this.device, dp, value);
       }
     }
+  }
+
+  _isRecentDuplicateDP(dp, value, options = {}) {
+    const dpId = Number(dp);
+    if (!Number.isInteger(dpId)) {return false;}
+
+    if (!this._dpStateDedup) {
+      this._dpStateDedup = new Map();
+      this._dpStateDedupCount = 0;
+    }
+
+    const now = Date.now();
+    const windowMs = options.windowMs ?? (this._isButtonLikeDP(dpId) ? 750 : 500);
+    const key = `${dpId}:${this._stableDPValue(value)}`;
+    const lastSeen = this._dpStateDedup.get(key);
+    this._dpStateDedup.set(key, now);
+
+    this._dpStateDedupCount += 1;
+    if (this._dpStateDedupCount % 100 === 0 || this._dpStateDedup.size > 500) {
+      const cutoff = now - Math.max(windowMs * 10, 5000);
+      for (const [cachedKey, seenAt] of this._dpStateDedup) {
+        if (seenAt < cutoff) {
+          this._dpStateDedup.delete(cachedKey);
+        }
+      }
+    }
+
+    return lastSeen !== undefined && now - lastSeen < windowMs;
+  }
+
+  _isButtonLikeDP(dp) {
+    const driverId = String(this.device?.driver?.id || '').toLowerCase();
+    if (!/button|remote|scene|switch_wireless/.test(driverId)) {return false;}
+
+    const mapping = this.dpMappings?.[dp] || this.device?.dpMappings?.[dp];
+    const capability = String(mapping?.capability || '');
+    return dp >= 1 && dp <= 8 || capability.startsWith('button');
+  }
+
+  _stableDPValue(value) {
+    if (Buffer.isBuffer(value)) {
+      return `buffer:${value.toString('hex')}`;
+    }
+    if (Array.isArray(value)) {
+      return `array:${Buffer.from(value).toString('hex')}`;
+    }
+    if (value && typeof value === 'object') {
+      try {
+        return JSON.stringify(value, Object.keys(value).sort());
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return `${typeof value}:${String(value)}`;
   }
 
   /**
@@ -1803,6 +1863,23 @@ class TuyaEF00Manager extends EventEmitter {
    */
   parseTuyaFrame(buffer) {
     try {
+      const decoded = this._getFrameAnalyzer().parse(1, 0xEF00, { Payload: buffer, CommandID: 0x00 }, {
+        source: 'tuya_ef00_manager',
+      });
+
+      if (decoded.datapoints?.length) {
+        for (const dp of decoded.datapoints) {
+          this._log(`[TUYA] 📊 Analyzer DP ${dp.dpId}: type=${dp.dpType}, value=${JSON.stringify(dp.value)}`);
+          this.handleDatapoint({
+            dp: dp.dpId,
+            datatype: dp.dpType,
+            length: dp.length,
+            data: dp.value,
+          });
+        }
+        return;
+      }
+
       // Tuya frame format: [status:1][seq:1][dp:1][type:1][len:2][data:len]
       let offset = 0;
 
@@ -1834,6 +1911,13 @@ class TuyaEF00Manager extends EventEmitter {
     } catch (err) {
       this._error('[TUYA] Frame parse failed:', err.message);
     }
+  }
+
+  _getFrameAnalyzer() {
+    if (!this._frameAnalyzer) {
+      this._frameAnalyzer = new IntelligentFrameAnalyzer(this.device);
+    }
+    return this._frameAnalyzer;
   }
 
   /**
@@ -1925,9 +2009,9 @@ class TuyaEF00Manager extends EventEmitter {
       return;
     }
 
-    const dp = data.dp || data.dpId || data.id;
-    let value = data.value || data.dpValue || data.data;  // v5.5.205: Changed to let for reassignment
-    const dpType = data.datatype || data.dpType || 'unknown';
+    const dp = data.dp ?? data.dpId ?? data.id;
+    let value = data.value ?? data.dpValue ?? data.data;  // v5.5.205: Changed to let for reassignment
+    const dpType = data.datatype ?? data.dpType ?? 'unknown';
 
     // v9.0.48 FIX BUG 5 (diag c913ed27) : DÉDUPLICATION des DPs traités plusieurs fois.
     // TuyaEF00Manager écoute le cluster tuya via 4 chemins (boundListener, response,
@@ -2001,6 +2085,11 @@ class TuyaEF00Manager extends EventEmitter {
       }
     } else {
       this._log(`[TUYA-DP] 📦 DP${dp} received: value=${JSON.stringify(value)}, type=${dpType}`);
+    }
+
+    if (this._isRecentDuplicateDP(dp, value, { source: 'active' })) {
+      this._log(`[TUYA-DP] ⏭️ Duplicate DP${dp} state suppressed`);
+      return;
     }
 
     // v5.2.10: Store last data received timestamp for KPI
@@ -2409,5 +2498,4 @@ module.exports.TIME_SYNC_COMMANDS = TIME_SYNC_COMMANDS;
 module.exports.TUYA_EPOCH_OFFSET = TUYA_EPOCH_OFFSET;
 module.exports.ZIGBEE_EPOCH_OFFSET = ZIGBEE_EPOCH_OFFSET;
 module.exports.TIMEZONE_OFFSETS = TIMEZONE_OFFSETS;
-
 

--- a/lib/tuya/TuyaZigbeeDevice.js
+++ b/lib/tuya/TuyaZigbeeDevice.js
@@ -4,6 +4,7 @@ const { ZigBeeDevice } = require('homey-zigbeedriver');
 const DiagnosticLogsCollector = require('../diagnostics/DiagnosticLogsCollector');
 const { trackTx, trackRx } = require('../utils/UniversalThrottleManager');
 const DeviceTelemetryEstimator = require('../utils/DeviceTelemetryEstimator');
+const RawFrameDeduplicator = require('../zigbee/RawFrameDeduplicator');
 
 /**
  * TuyaZigbeeDevice - Base class for all Tuya Zigbee devices
@@ -72,9 +73,30 @@ class TuyaZigbeeDevice extends ZigBeeDeviceWithDiagnostics {
     if (this.node._rawFrameFallbackInjected) return;
 
     this.log('🛡️ [RX/TX] Setup Universal Raw Frame Fallback v5.13.2');
+    // L0: Exact-payload duplicate filtering. Never dedupe by a short prefix:
+    // Tuya MCU devices often resend a full state map where only a later DP changed.
+    if (!this._rawFrameDeduplicator) {
+      this._rawFrameDeduplicator = new RawFrameDeduplicator({
+        defaultWindowMs: 500,
+        tuyaWindowMs: 750,
+        maxCacheSize: 500,
+      });
+    }
+
     const originalHandleFrame = this.node.handleFrame;
     
     this.node.handleFrame = (endpointId, clusterId, frame, meta) => {
+      const duplicate = this._rawFrameDeduplicator.shouldSuppress(endpointId, clusterId, frame, meta);
+      if (duplicate.suppress) {
+        this.trackIncomingReport();
+        if (!this._rawFrameDuplicateCount) this._rawFrameDuplicateCount = 0;
+        this._rawFrameDuplicateCount += 1;
+        if (this._rawFrameDuplicateCount <= 5 || this._rawFrameDuplicateCount % 100 === 0) {
+          this.log(`[L0] Suppressed exact duplicate raw frame #${this._rawFrameDuplicateCount}: EP${endpointId} cluster=0x${Number(clusterId).toString(16).padStart(4, '0')} age=${duplicate.age}ms`);
+        }
+        return;
+      }
+
       let handled = false;
       
       // 1. Standardized driver-level hook: onZigBeeMessage (uppercase B)

--- a/lib/zigbee/IntelligentFrameAnalyzer.js
+++ b/lib/zigbee/IntelligentFrameAnalyzer.js
@@ -1,0 +1,292 @@
+'use strict';
+
+const IntelligentDPAutoDiscovery = require('../sensors/IntelligentDPAutoDiscovery');
+
+const CLUSTER_NAMES = {
+  0x0001: 'genPowerCfg',
+  0x0006: 'genOnOff',
+  0x0008: 'genLevelCtrl',
+  0x000A: 'genTime',
+  0x0400: 'msIlluminanceMeasurement',
+  0x0402: 'msTemperatureMeasurement',
+  0x0405: 'msRelativeHumidity',
+  0x0406: 'msOccupancySensing',
+  0x0500: 'ssIasZone',
+  0xEF00: 'tuya'
+};
+
+const ONOFF_COMMANDS = {
+  0x00: 'off',
+  0x01: 'on',
+  0x02: 'toggle',
+  0x40: 'offWithEffect',
+  0x41: 'onWithRecallGlobalScene',
+  0x42: 'onWithTimedOff'
+};
+
+class IntelligentFrameAnalyzer {
+  constructor(device) {
+    this.device = device;
+    this.frameCount = 0;
+  }
+
+  analyze(frame, meta = {}) {
+    if (arguments.length >= 4) {
+      return this.parse(arguments[0], arguments[1], arguments[2], arguments[3]);
+    }
+    return this.parse(meta.endpointId, meta.clusterId, frame, meta);
+  }
+
+  parse(endpointId, clusterId, frame, meta = {}) {
+    const decoded = this._decode(endpointId, clusterId, frame, meta, 'rx');
+    this._feedDiscovery(decoded);
+    return decoded;
+  }
+
+  recordTx(endpointId, clusterId, frame, meta = {}) {
+    const decoded = this._decode(endpointId, clusterId, frame, meta, 'tx');
+    this._feedDiscovery(decoded);
+    return decoded;
+  }
+
+  recordFrame(frame, direction = 'rx', meta = {}) {
+    const decoded = this._decode(
+      frame?.endpointId ?? frame?.endpoint ?? meta.endpointId,
+      frame?.clusterId ?? frame?.cluster ?? meta.clusterId,
+      frame,
+      meta,
+      direction
+    );
+    this._feedDiscovery(decoded);
+    return decoded;
+  }
+
+  _decode(endpointId, clusterId, frame, meta, direction) {
+    this.frameCount += 1;
+    const numericClusterId = this._numberFromAny(clusterId ?? frame?.clusterId ?? frame?.cluster);
+    const numericEndpoint = this._numberFromAny(endpointId ?? frame?.endpointId ?? frame?.endpoint);
+    const commandId = this._numberFromAny(frame?.CommandID ?? frame?.commandId ?? frame?.cmd ?? meta?.commandId);
+    const payload = frame?.Payload ?? frame?.payload ?? frame?.data ?? frame?.Data ?? frame?.raw ?? meta?.payload;
+    const rawBuffer = Buffer.isBuffer(payload) ? payload : Buffer.isBuffer(frame) ? frame : null;
+    const commandName = this._commandName(numericClusterId, commandId, frame);
+    const datapoints = this._extractTuyaDatapoints(frame, payload, numericClusterId);
+    const attributes = this._extractAttributes(frame, payload, numericClusterId);
+
+    return {
+      type: datapoints.length ? 'tuya_dp' : attributes.length ? 'zcl_attribute' : commandName || 'zigbee_frame',
+      direction,
+      endpoint: numericEndpoint || 1,
+      clusterId: numericClusterId,
+      clusterHex: numericClusterId !== null ? `0x${numericClusterId.toString(16)}` : undefined,
+      clusterName: CLUSTER_NAMES[numericClusterId] || undefined,
+      commandId: commandId === null ? undefined : commandId,
+      commandName,
+      seqNum: frame?.seqNum ?? frame?.transactionSequenceNumber ?? frame?.sequence ?? meta?.sequence,
+      attributes,
+      datapoints,
+      dpId: datapoints[0]?.dpId,
+      dpType: datapoints[0]?.dpType,
+      value: datapoints[0]?.value,
+      rawLength: rawBuffer ? rawBuffer.length : undefined,
+      rawPrefix: rawBuffer ? rawBuffer.toString('hex', 0, Math.min(rawBuffer.length, 12)) : undefined,
+      lqi: meta?.lqi,
+      timestamp: Date.now()
+    };
+  }
+
+  _feedDiscovery(decoded) {
+    if (!decoded) {return;}
+    const discovery = this._getDiscovery();
+    if (!discovery || typeof discovery.recordFrame !== 'function') {return;}
+
+    try {
+      discovery.recordFrame(decoded, decoded.direction || 'rx', {
+        source: 'intelligent_frame_analyzer',
+        endpoint: decoded.endpoint,
+        clusterId: decoded.clusterId,
+        commandId: decoded.commandId,
+        timestamp: decoded.timestamp
+      });
+    } catch (err) {
+      this.device?.log?.(`[IFA] Discovery feed skipped: ${err.message}`);
+    }
+  }
+
+  _getDiscovery() {
+    if (this.device?._dpAutoDiscovery) {return this.device._dpAutoDiscovery;}
+    if (this.device?._discovery) {return this.device._discovery;}
+    if (!this.device) {return null;}
+
+    try {
+      this.device._dpAutoDiscovery = new IntelligentDPAutoDiscovery(this.device);
+      return this.device._dpAutoDiscovery;
+    } catch (err) {
+      this.device?.log?.(`[IFA] Discovery init skipped: ${err.message}`);
+      return null;
+    }
+  }
+
+  _commandName(clusterId, commandId, frame) {
+    if (frame?.commandName) {return frame.commandName;}
+    if (clusterId === 0x0006 && commandId !== null && ONOFF_COMMANDS[commandId]) {return ONOFF_COMMANDS[commandId];}
+    if (clusterId === 0xEF00) {return 'tuyaData';}
+    return undefined;
+  }
+
+  _extractAttributes(frame, payload, clusterId) {
+    const attributes = [];
+    const push = (id, value) => {
+      if (id === undefined || id === null) {return;}
+      attributes.push({
+        id,
+        idHex: typeof id === 'number' ? `0x${id.toString(16)}` : String(id),
+        value
+      });
+    };
+
+    const source = frame?.attributes || frame?.Attributes || payload?.attributes || payload?.Attributes;
+    if (Array.isArray(source)) {
+      for (const attr of source) {push(attr.id ?? attr.attrId ?? attr.attributeId, attr.value ?? attr.attrData);}
+    } else if (source && typeof source === 'object') {
+      for (const [id, value] of Object.entries(source)) {push(id, value);}
+    }
+
+    if (clusterId === 0x0006 && frame?.commandName && !attributes.length) {
+      push('command', frame.commandName);
+    }
+
+    return attributes;
+  }
+
+  _extractTuyaDatapoints(frame, payload, clusterId) {
+    const datapoints = [];
+    const push = item => {
+      if (!item) {return;}
+      const dpId = Number(item.dpId ?? item.dp ?? item.id);
+      if (!Number.isInteger(dpId) || dpId <= 0 || dpId > 255) {return;}
+      datapoints.push({
+        dpId,
+        dpType: item.dpType ?? item.datatype ?? item.dataType ?? item.type ?? 'unknown',
+        value: item.value ?? item.dpValue ?? item.data ?? item.rawValue,
+        length: item.length ?? item.len
+      });
+    };
+
+    if (Array.isArray(frame?.datapoints)) {frame.datapoints.forEach(push);}
+    if (Array.isArray(frame?.dpValues)) {frame.dpValues.forEach(push);}
+    if (Array.isArray(frame?.dps)) {frame.dps.forEach(push);}
+    if (frame?.dpId !== undefined || frame?.dp !== undefined) {push(frame);}
+
+    if (payload && typeof payload === 'object' && !Buffer.isBuffer(payload)) {
+      if (Array.isArray(payload.datapoints)) {payload.datapoints.forEach(push);}
+      if (Array.isArray(payload.dpValues)) {payload.dpValues.forEach(push);}
+      if (Array.isArray(payload.dps)) {payload.dps.forEach(push);}
+      if (payload.dpId !== undefined || payload.dp !== undefined) {push(payload);}
+    }
+
+    if (Buffer.isBuffer(payload) && (clusterId === 0xEF00 || datapoints.length === 0)) {
+      const parsed = this._parseTuyaPayload(payload);
+      parsed.forEach(push);
+    }
+
+    const deduped = new Map();
+    for (const dp of datapoints) {
+      const key = `${dp.dpId}:${dp.dpType}:${this._stableValue(dp.value)}`;
+      deduped.set(key, dp);
+    }
+    return [...deduped.values()].slice(0, 16);
+  }
+
+  _parseTuyaPayload(buffer) {
+    let best = null;
+    for (const offset of [0, 1, 2, 3, 4, 5, 6]) {
+      const parsed = this._parseTuyaTLV(buffer, offset);
+      if (!parsed.length) {continue;}
+      const score = this._scoreTuyaTLVOffset(parsed, offset);
+      if (!best || score > best.score) {
+        best = { parsed, score };
+      }
+    }
+    return best?.parsed || [];
+  }
+
+  _scoreTuyaTLVOffset(parsed, offset) {
+    if (typeof IntelligentDPAutoDiscovery._scoreTuyaTLVOffset === 'function') {
+      return IntelligentDPAutoDiscovery._scoreTuyaTLVOffset(parsed, offset);
+    }
+
+    if (parsed.some(dp => dp.length <= 0)) {
+      return -1000 + parsed.length - offset;
+    }
+
+    let score = parsed.length * 20 - offset;
+    for (const dp of parsed) {
+      if (dp.dpId >= 1 && dp.dpId <= 128) {score += 5;}
+      if (dp.dpType >= 0 && dp.dpType <= 5) {score += 5;}
+      if (dp.length >= 0 && dp.length <= 64) {score += 5;}
+      if ((dp.dpType === 1 || dp.dpType === 4 || dp.dpType === 5) && dp.length === 1) {score += 3;}
+      if (dp.dpType === 2 && (dp.length === 1 || dp.length === 2 || dp.length === 4)) {score += 3;}
+    }
+    if (offset >= 4 && offset <= 6) {score += 3;}
+    return score;
+  }
+
+  _parseTuyaTLV(buffer, startOffset) {
+    const datapoints = [];
+    let offset = startOffset;
+
+    while (offset + 4 <= buffer.length) {
+      const dpId = buffer.readUInt8(offset);
+      const dpType = buffer.readUInt8(offset + 1);
+      const len = buffer.readUInt16BE(offset + 2);
+      if (dpId <= 0 || dpType > 5 || len > 64 || offset + 4 + len > buffer.length) {
+        return datapoints;
+      }
+
+      const data = buffer.slice(offset + 4, offset + 4 + len);
+      datapoints.push({ dpId, dpType, length: len, value: this._decodeTuyaValue(dpType, data) });
+      offset += 4 + len;
+    }
+
+    return datapoints;
+  }
+
+  _decodeTuyaValue(dpType, data) {
+    if (!Buffer.isBuffer(data)) {return data;}
+    if (dpType === 1) {return data[0] === 1;}
+    if (dpType === 2 || dpType === 4) {
+      if (data.length === 1) {return data.readUInt8(0);}
+      if (data.length === 2) {return data.readUInt16BE(0);}
+      if (data.length >= 4) {return data.readInt32BE(0);}
+    }
+    if (dpType === 3) {return data.toString('utf8');}
+    if (dpType === 5 && data.length === 1) {return data.readUInt8(0);}
+    return { kind: 'buffer', length: data.length, hexPrefix: data.toString('hex', 0, Math.min(data.length, 8)) };
+  }
+
+  _numberFromAny(value) {
+    if (value === undefined || value === null) {return null;}
+    if (typeof value === 'number' && Number.isFinite(value)) {return value;}
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (/^0x/i.test(trimmed)) {return parseInt(trimmed, 16);}
+      const numeric = Number(trimmed);
+      return Number.isFinite(numeric) ? numeric : null;
+    }
+    return null;
+  }
+
+  _stableValue(value) {
+    if (Buffer.isBuffer(value)) {return `buffer:${value.length}:${value.toString('hex', 0, Math.min(value.length, 8))}`;}
+    if (value && typeof value === 'object') {
+      try {
+        return JSON.stringify(value);
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return String(value);
+  }
+}
+
+module.exports = IntelligentFrameAnalyzer;

--- a/lib/zigbee/RawFrameDeduplicator.js
+++ b/lib/zigbee/RawFrameDeduplicator.js
@@ -1,0 +1,130 @@
+'use strict';
+
+class RawFrameDeduplicator {
+  constructor(options = {}) {
+    this.defaultWindowMs = options.defaultWindowMs ?? 500;
+    this.tuyaWindowMs = options.tuyaWindowMs ?? 750;
+    this.maxCacheSize = options.maxCacheSize ?? 500;
+    this.cache = new Map();
+    this.count = 0;
+  }
+
+  shouldSuppress(endpointId, clusterId, frame, meta = {}) {
+    const now = Date.now();
+    const numericCluster = Number(clusterId);
+    const windowMs = this._windowForCluster(numericCluster);
+    const key = this.makeKey(endpointId, numericCluster, frame, meta);
+    const lastSeen = this.cache.get(key);
+
+    this.cache.set(key, now);
+    this._cleanup(now, windowMs);
+
+    return {
+      suppress: lastSeen !== undefined && now - lastSeen < windowMs,
+      key,
+      windowMs,
+      age: lastSeen === undefined ? null : now - lastSeen,
+    };
+  }
+
+  makeKey(endpointId, clusterId, frame, meta = {}) {
+    const commandId = RawFrameDeduplicator.commandId(frame, meta);
+    const payload = RawFrameDeduplicator.extractPayload(frame);
+    const payloadKey = payload
+      ? payload.toString('hex')
+      : RawFrameDeduplicator.stableValue(frame).slice(0, 1024);
+    return `${endpointId || 1}:${clusterId}:${commandId ?? 'na'}:${payloadKey}`;
+  }
+
+  _windowForCluster(clusterId) {
+    if (clusterId === 0xEF00 || clusterId === 0xE000) {
+      return this.tuyaWindowMs;
+    }
+    return this.defaultWindowMs;
+  }
+
+  _cleanup(now, windowMs) {
+    this.count += 1;
+    if (this.count % 100 !== 0 && this.cache.size <= this.maxCacheSize) {
+      return;
+    }
+
+    const cutoff = now - Math.max(windowMs * 10, 5000);
+    for (const [key, seenAt] of this.cache) {
+      if (seenAt < cutoff) {
+        this.cache.delete(key);
+      }
+    }
+
+    if (this.cache.size > this.maxCacheSize) {
+      const keys = [...this.cache.keys()];
+      for (let i = 0; i < Math.ceil(keys.length / 2); i += 1) {
+        this.cache.delete(keys[i]);
+      }
+    }
+  }
+
+  static commandId(frame, meta = {}) {
+    const value = frame?.cmdId ?? frame?.commandId ?? frame?.CommandID ??
+      frame?.command?.id ?? meta?.cmdId ?? meta?.commandId ?? meta?.CommandID;
+    if (value === undefined || value === null) {
+      return null;
+    }
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : String(value);
+  }
+
+  static extractPayload(frame) {
+    if (Buffer.isBuffer(frame)) {
+      return frame;
+    }
+
+    const candidates = [
+      frame?.data,
+      frame?.payload,
+      frame?.Payload,
+      frame?.Data,
+      frame?.raw,
+      frame?.command?.data,
+      frame?.command?.payload,
+    ];
+
+    for (const candidate of candidates) {
+      if (Buffer.isBuffer(candidate)) {
+        return candidate;
+      }
+      if (Array.isArray(candidate)) {
+        return Buffer.from(candidate);
+      }
+      if (typeof candidate === 'string' && /^(0x)?[0-9a-fA-F]+$/.test(candidate)) {
+        return Buffer.from(candidate.replace(/^0x/i, ''), 'hex');
+      }
+    }
+
+    return null;
+  }
+
+  static stableValue(value) {
+    if (Buffer.isBuffer(value)) {
+      return `buffer:${value.toString('hex')}`;
+    }
+    if (Array.isArray(value)) {
+      return `array:${Buffer.from(value).toString('hex')}`;
+    }
+    if (value && typeof value === 'object') {
+      const sorted = {};
+      for (const key of Object.keys(value).sort()) {
+        const item = value[key];
+        sorted[key] = Buffer.isBuffer(item) ? `buffer:${item.toString('hex')}` : item;
+      }
+      try {
+        return JSON.stringify(sorted);
+      } catch (err) {
+        return String(value);
+      }
+    }
+    return String(value);
+  }
+}
+
+module.exports = RawFrameDeduplicator;

--- a/test/critical/raw-advertisement-state.test.js
+++ b/test/critical/raw-advertisement-state.test.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const assert = require('assert');
+const RawFrameDeduplicator = require('../../lib/zigbee/RawFrameDeduplicator');
+const TuyaEF00Manager = require('../../lib/tuya/TuyaEF00Manager');
+const IntelligentFrameAnalyzer = require('../../lib/zigbee/IntelligentFrameAnalyzer');
+
+const testApi = global.describe && global.it ? global : require('node:test');
+const { describe, it } = testApi;
+
+function createDevice() {
+  return {
+    destroyed: false,
+    _destroyed: false,
+    driver: { id: 'button_wireless_4' },
+    homey: {
+      app: {},
+      setTimeout: () => ({ unref() {} }),
+      clearTimeout: () => {},
+    },
+    dpMappings: {
+      30: { capability: 'custom_zero' },
+      31: { capability: 'custom_false' },
+      32: { capability: 'custom_repeat' },
+    },
+    log: () => {},
+    error: () => {},
+    getData: () => ({ id: 'test-device' }),
+    getSetting: () => null,
+    getSettings: () => ({}),
+    setStoreValue: () => Promise.resolve(),
+    hasCapability: () => false,
+    addCapability: () => Promise.resolve(),
+    safeSetCapabilityValue: () => Promise.resolve(),
+  };
+}
+
+describe('raw advertisement and state-map handling', () => {
+  it('deduplicates only exact raw payloads, not same-prefix state maps', () => {
+    const dedup = new RawFrameDeduplicator({ defaultWindowMs: 1000, tuyaWindowMs: 1000 });
+    const first = { Payload: Buffer.from('00000102000400000001', 'hex'), CommandID: 0x02 };
+    const samePrefixDifferentDP = { Payload: Buffer.from('00000102000400000002', 'hex'), CommandID: 0x02 };
+
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, first).suppress, false);
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, first).suppress, true);
+    assert.strictEqual(dedup.shouldSuppress(1, 0xEF00, samePrefixDifferentDP).suppress, false);
+  });
+
+  it('preserves 0 and false DP values while suppressing unchanged repeats', async () => {
+    const manager = new TuyaEF00Manager(createDevice());
+    const reports = [];
+    manager.on('dpReport', report => reports.push(report));
+
+    await manager.handleDatapoint({ dp: 30, value: 0, dpType: 'value' });
+    await manager.handleDatapoint({ dp: 31, value: false, dpType: 'bool' });
+    await manager.handleDatapoint({ dp: 32, value: 7, dpType: 'enum' });
+    await manager.handleDatapoint({ dp: 32, value: 7, dpType: 'enum' });
+    await manager.handleDatapoint({ dp: 32, value: 8, dpType: 'enum' });
+
+    assert.deepStrictEqual(
+      reports.map(report => [report.dpId, report.value]),
+      [[30, 0], [31, false], [32, 7], [32, 8]]
+    );
+  });
+
+  it('extracts changed values from full EF00 state maps with ZCL/Tuya headers', () => {
+    const analyzer = new IntelligentFrameAnalyzer(createDevice());
+    const payload = Buffer.from([
+      0x09, 0x42, 0x01, 0x00, 0x00,
+      0x01, 0x01, 0x00, 0x01, 0x00,
+      0x02, 0x02, 0x00, 0x04, 0x00, 0x00, 0x00, 0x00,
+    ]);
+
+    const decoded = analyzer.parse(1, 0xEF00, { Payload: payload, CommandID: 0x02 });
+
+    assert.deepStrictEqual(
+      decoded.datapoints.map(dp => [dp.dpId, dp.value]),
+      [[1, false], [2, 0]]
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Port the raw advertisement/state-map hardening from master to `stable-v5` without changing app identity/version metadata.
- Add exact raw payload deduplication, EF00 full-state parsing, DP repeat suppression, and safer per-button dedupe for E000/TS0044/Moes-style remotes.
- Preserve `0` and `false` datapoint values across stable unified/Tuya paths.
- Add `IntelligentFrameAnalyzer` with a stable-compatible TLV offset scorer, plus raw advertisement regression tests.
- Clean generated duplicate `device` Flow args in stable `app.json`; this fixes the stable Homey guidelines gate from 100 duplicate-arg errors to 0 errors.

## Validation
- `node --check lib/zigbee/RawFrameDeduplicator.js`
- `node --check lib/zigbee/IntelligentFrameAnalyzer.js`
- `node --check lib/tuya/TuyaEF00Manager.js`
- `node --check lib/tuya/TuyaZigbeeDevice.js`
- `node --check lib/clusters/TuyaE000BoundCluster.js`
- `npx mocha test\critical\raw-advertisement-state.test.js --timeout 10000 --exit`
- `npx mocha test\critical\forum-routing-regressions.test.js --timeout 10000 --exit`
- `npx mocha test\button-flow-runtime-routing.test.js test\dynamic-dp-auto-discovery.test.js --timeout 10000 --exit` (`dynamic-dp-auto-discovery` does not exist on stable; button routing tests passed)
- `npm test -- --timeout 10000 --exit` (43 passing)
- `npm run precommit` (passes; Homey guidelines 229 drivers / 2507 flow cards / 0 errors / 0 warnings)

## Notes
- Stable does not have the newer `check:athom`, `check:yaml`, or `security-scanner.js` scripts from master.
- Fingerprint catalog still reports known stable warning/collision noise, but exits successfully with 0 errors.