### PR TITLE
fix(stable): sanitize auto-heal manifests

### DIFF
--- a/.github/workflows/tuya-auto-repair.yml
+++ b/.github/workflows/tuya-auto-repair.yml
@@ -35,8 +35,17 @@ jobs:
       - name: Run Master Self-Heal Engine
         run: node scripts/maintenance/master-self-heal.js --ci
 
+      - name: Sanitize Generated Manifest Before Validation
+        run: npm run fix:generated-flow-args
+
       - name: Validate App.json
         run: npm run validate || npx homey app validate
+
+      - name: Sanitize Generated Manifest After Validation
+        run: npm run fix:generated-flow-args
+
+      - name: Validate Sanitized Homey Guidelines
+        run: npm run check:homey-guidelines
 
       - name: Commit Auto-Repairs
         if: github.event_name != 'pull_request'

--- a/app.json
+++ b/app.json
@@ -24649,11 +24649,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -24675,11 +24670,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -24703,11 +24693,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -24729,11 +24714,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -24757,11 +24737,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24783,11 +24758,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24811,11 +24781,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24837,11 +24802,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24865,11 +24825,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24891,11 +24846,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24919,11 +24869,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -24945,11 +24890,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -24973,11 +24913,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -24999,11 +24934,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25027,11 +24957,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25053,11 +24978,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25081,11 +25001,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25107,11 +25022,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25141,11 +25051,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25167,11 +25072,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25195,11 +25095,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25221,11 +25116,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25249,11 +25139,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25275,11 +25160,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25321,11 +25201,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25365,11 +25240,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -25411,11 +25281,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -25437,11 +25302,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25465,11 +25325,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25491,11 +25346,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25519,11 +25369,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25545,11 +25390,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25573,11 +25413,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25599,11 +25434,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25627,11 +25457,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25653,11 +25478,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25681,11 +25501,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25707,11 +25522,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25735,11 +25545,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25761,11 +25566,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -25789,11 +25589,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25816,11 +25611,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -25842,11 +25632,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -41663,11 +41448,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -41689,11 +41469,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -41717,11 +41492,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -41743,11 +41513,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -41771,11 +41536,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -41797,11 +41557,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -41825,11 +41580,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -41851,11 +41601,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -41879,11 +41624,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -41905,11 +41645,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -52504,11 +52239,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -52531,11 +52261,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_1gang"
           }
         ],
         "titleFormatted": {
@@ -52557,11 +52282,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_1gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_1gang"
           }
         ],
@@ -52796,11 +52516,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52822,11 +52537,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52850,11 +52560,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52876,11 +52581,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52904,11 +52604,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_2gang"
           }
         ],
         "titleFormatted": {
@@ -52930,11 +52625,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_2gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_2gang"
           }
         ],
@@ -52958,11 +52648,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -52984,11 +52669,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53012,11 +52692,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53038,11 +52713,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53066,11 +52736,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53092,11 +52757,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53120,11 +52780,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53146,11 +52801,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_3gang"
           }
         ],
@@ -53174,11 +52824,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_3gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_3gang"
           }
         ],
         "titleFormatted": {
@@ -53200,11 +52845,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53228,11 +52868,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53254,11 +52889,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53282,11 +52912,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53308,11 +52933,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53336,11 +52956,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53362,11 +52977,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53390,11 +53000,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53416,11 +53021,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -53444,11 +53044,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53471,11 +53066,6 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
-            "filter": "driver_id=switch_4gang"
           }
         ],
         "titleFormatted": {
@@ -53497,11 +53087,6 @@
           {
             "type": "device",
             "name": "device",
-            "filter": "driver_id=switch_4gang"
-          },
-          {
-            "name": "device",
-            "type": "device",
             "filter": "driver_id=switch_4gang"
           }
         ],
@@ -57615,11 +57200,6 @@
             "filter": "driver_id=wall_dimmer_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_dimmer_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57766,11 +57346,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57884,11 +57459,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -57932,11 +57502,6 @@
           "fr": "Définir le type d'interrupteur externe"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -57990,11 +57555,6 @@
             "filter": "driver_id=wall_switch_1gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_1gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58031,11 +57591,6 @@
           "nl": "Stel LED-indicator modus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58083,11 +57638,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58143,11 +57693,6 @@
             "filter": "driver_id=wall_switch_2gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58189,11 +57734,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_2gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58440,11 +57980,6 @@
             "filter": "driver_id=wall_switch_3gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58486,11 +58021,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58546,11 +58076,6 @@
             "filter": "driver_id=wall_switch_3gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58592,11 +58117,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_3gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -58897,11 +58417,6 @@
             "filter": "driver_id=wall_switch_4gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -58943,11 +58458,6 @@
           "fr": "Définir le comportement à la mise sous tension"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
           {
             "type": "device",
             "name": "device",
@@ -59003,11 +58513,6 @@
             "filter": "driver_id=wall_switch_4gang_1way"
           },
           {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
-          {
             "name": "mode",
             "type": "dropdown",
             "values": [
@@ -59049,11 +58554,6 @@
           "nl": "Stel scènemodus in"
         },
         "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=wall_switch_4gang_1way"
-          },
           {
             "type": "device",
             "name": "device",

--- a/scripts/maintenance/master-self-heal.js
+++ b/scripts/maintenance/master-self-heal.js
@@ -27,6 +27,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { sanitizeManifestFile } = require('./sanitize-manifest.cjs');
 
 const ROOT = process.cwd();
 const DRIVERS_DIR = path.join(ROOT, 'drivers');
@@ -78,6 +79,33 @@ function safeWrite(file, content) {
   }
   fs.writeFileSync(file, content, 'utf8');
   return true;
+}
+
+function rule_sanitizeGeneratedManifest() {
+  log('\n📋 Rule 13: Generated Manifest Sanitization');
+  const appPath = path.join(ROOT, 'app.json');
+  let changes = 0;
+
+  const status = sanitizeManifestFile(appPath, {
+    dryRun: DRY,
+    onChanges: count => { changes = count; },
+  });
+  if (status !== 0) {
+    report.errors.push({
+      rule: 'generated-manifest-sanitize',
+      file: appPath,
+      error: 'sanitize-manifest failed for app.json',
+    });
+    log('  → app.json sanitization failed');
+    return;
+  }
+
+  if (changes > 0) {
+    addFix('generated-manifest-sanitize', appPath, `Sanitized ${changes} generated Homey manifest artifact(s)`);
+    log(`  ✅ ${DRY ? 'Would sanitize' : 'Sanitized'} ${changes} app.json generated artifact(s)`);
+  } else {
+    log('  → app.json already clean');
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -551,6 +579,7 @@ async function main() {
   rule_energyBatteries();
   rule_dualBatteryCleanup();
   rule_energyApproximationCleanup();
+  rule_sanitizeGeneratedManifest();
 
   // DETECTION RULES (report only, manual fixes recommended)
   rule_flowCardTryCatch();
@@ -567,7 +596,7 @@ async function main() {
   log('  SELF-HEAL REPORT');
   log('═══════════════════════════════════════════════════════════════════════');
 
-  const autoFixed = ['sdk3-phantom-methods', 'fingerprint-case', 'probe-dedup-static', 'energy-batteries', 'dual-battery-cleanup', 'energy-approximation-cleanup'];
+  const autoFixed = ['sdk3-phantom-methods', 'fingerprint-case', 'probe-dedup-static', 'energy-batteries', 'dual-battery-cleanup', 'energy-approximation-cleanup', 'generated-manifest-sanitize'];
   const manualReview = Object.keys(report.rules).filter(r => !autoFixed.includes(r));
 
   let totalAutoFixes = 0;

--- a/scripts/maintenance/sanitize-manifest.cjs
+++ b/scripts/maintenance/sanitize-manifest.cjs
@@ -112,7 +112,9 @@ function dedupeFlowArgs(manifest) {
   return stripped;
 }
 
-function sanitizeManifestFile(manifestPath) {
+function sanitizeManifestFile(manifestPath, options = {}) {
+  const dryRun = options.dryRun === true;
+  const onChanges = typeof options.onChanges === 'function' ? options.onChanges : null;
   const label = path.relative(APP_ROOT, manifestPath).replace(/\\/g, '/') || manifestPath;
   if (!fs.existsSync(manifestPath)) {
     log(`No ${label} found - nothing to sanitize.`);
@@ -164,8 +166,13 @@ function sanitizeManifestFile(manifestPath) {
   }
 
   if (changes > 0) {
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-    log(`${label}: wrote ${changes} change(s).`);
+    if (onChanges) onChanges(changes);
+    if (dryRun) {
+      log(`${label}: dry-run would write ${changes} change(s).`);
+    } else {
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+      log(`${label}: wrote ${changes} change(s).`);
+    }
   } else {
     log(`${label}: manifest already clean - no changes.`);
   }


### PR DESCRIPTION
## Summary
- Remove the 100 duplicate generated \\device\\ Flow args reintroduced by stable auto-heal commit 93a5b02931.
- Run \\ix:generated-flow-args\\ before and after \\homey app validate\\ in Tuya Auto-Repair CI, because Homey validation regenerates \\pp.json\\ and can re-add generated duplicate args.
- Call the shared manifest sanitizer from \\master-self-heal.js\\ so local/CI self-heal runs keep the root manifest clean.

## Root cause
The post-merge stable auto-heal workflow committed the Homey-generated \\pp.json\\ after validation without a final sanitizer pass. That reintroduced 100 duplicate \\device\\ Flow args even though publish workflows later sanitize their publish payloads.

## Validation
- \\
ode --check scripts/maintenance/master-self-heal.js\\
- \\
ode --check scripts/maintenance/sanitize-manifest.cjs\\
- duplicate Flow arg scan: 0 duplicates
- \\
pm run fix:generated-flow-args; npm run validate; npm run fix:generated-flow-args; npm run check:homey-guidelines\\ (Homey publish validation passed; guidelines 229 drivers / 2507 flow cards / 0 errors / 0 warnings)
- \\
pm run precommit\\
- \\
pm test -- --timeout 10000 --exit\\ (43 passing)