### PR TITLE
fix(ci): skip volatile self-heal report commits

### DIFF
--- a/.github/workflows/tuya-auto-repair.yml
+++ b/.github/workflows/tuya-auto-repair.yml
@@ -47,6 +47,10 @@ jobs:
       - name: Validate Sanitized Homey Guidelines
         run: npm run check:homey-guidelines
 
+      - name: Drop Volatile Self-Heal Report
+        if: github.event_name != 'pull_request'
+        run: git restore -- .github/state/self-heal-report.json 2>/dev/null || true
+
       - name: Commit Auto-Repairs
         if: github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v4
@@ -55,4 +59,4 @@ jobs:
           branch: ${{ github.head_ref || github.ref_name }}
           commit_user_name: "TuyaBot"
           commit_user_email: "bot@tuya-zigbee.local"
-          file_pattern: "drivers/*/driver.compose.json app.json .github/state/*.json"
+          file_pattern: "drivers/*/driver.compose.json app.json"


### PR DESCRIPTION
## Summary
- Restore the volatile self-heal report before auto-commit on stable auto-repair runs.
- Remove .github/state/*.json from the auto-commit file pattern so timestamp-only report changes no longer create [skip ci] commits.

## Root cause
After #456, Tuya Auto-Repair CI correctly sanitized app.json, but still committed .github/state/self-heal-report.json because the report timestamp changes every run.

## Validation
- Confirmed prior auto-heal commit 0d29ae9c08 changed only .github/state/self-heal-report.json.
- npm run precommit