### PR TITLE
fix(ci): harden master manifest sanitization

### DIFF
--- a/.github/workflows/auto-fix-and-publish.yml
+++ b/.github/workflows/auto-fix-and-publish.yml
@@ -87,7 +87,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
+          for path in drivers lib app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .cursorrules AI_INSTRUCTIONS.md package.json package-lock.json; do
+            [ -e "$path" ] && git add "$path"
+          done
           if ! git diff --staged --quiet; then
             git commit -m "🤖 auto-fix-all: automated fixes [skip ci]"
             BRANCH="${GITHUB_REF_NAME:-master}"

--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -286,11 +286,14 @@ jobs:
           }
           GATE
 
+      - name: Normalize Homey manifest before validation
+        run: npm run fix:generated-flow-args
+
       - name: Official Homey validator
         run: npx homey app validate --level publish
 
       - name: Sanitize generated manifest after validation
-        run: node scripts/maintenance/sanitize-manifest.cjs app.json .homeybuild/app.json
+        run: npm run fix:generated-flow-args && npm run check:homey-guidelines
 
       # ─────────────────────────────────────────────────────────────
       # 6. PUBLISH
@@ -413,7 +416,10 @@ jobs:
             }
           }
           NODE
-          git add -A
+          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
+          for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md package.json package-lock.json; do
+            [ -e "$path" ] && git add "$path"
+          done
           VER=$(node -p "require('./app.json').version" 2>/dev/null || echo "${{ steps.info.outputs.version }}")
           D=$(ls -d drivers/*/ 2>/dev/null | wc -l)
           F=$(grep -rohE '"_T[A-Za-z0-9_]+"' drivers/*/driver.compose.json 2>/dev/null | sort -uf | wc -l || echo 0)

--- a/.github/workflows/bug-report-auto-pr.yml
+++ b/.github/workflows/bug-report-auto-pr.yml
@@ -82,7 +82,10 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
-          git add -A
+          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
+          for path in drivers lib app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .cursorrules AI_INSTRUCTIONS.md package.json package-lock.json; do
+            [ -e "$path" ] && git add "$path"
+          done
           git diff --cached --quiet && echo "No changes" && exit 0
           git commit -m "fix: auto-fix for #${ISSUE} — ${{ steps.bug.outputs.summary }}"
           git push origin "$BRANCH"

--- a/.github/workflows/daily-maintenance.yml
+++ b/.github/workflows/daily-maintenance.yml
@@ -179,7 +179,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
+          for path in drivers lib app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .cursorrules AI_INSTRUCTIONS.md package.json package-lock.json; do
+            [ -e "$path" ] && git add "$path"
+          done
           if git diff --cached --quiet; then
             echo "✅ No changes to commit"
           else

--- a/.github/workflows/nightly-auto-process.yml
+++ b/.github/workflows/nightly-auto-process.yml
@@ -119,8 +119,14 @@ jobs:
           node scripts/automation/fix-empty-catches.js --verbose
         continue-on-error: true
 
+      - name: Normalize Homey manifest before validation
+        run: npm run fix:generated-flow-args
+
       - name: 📦 Validate Homey App
         run: npx homey app validate --level publish
+
+      - name: Normalize Homey manifest after validation
+        run: npm run fix:generated-flow-args && npm run check:homey-guidelines
 
       - name: 🎯 Zero-Defect Ultimate Validation (v8.0.0)
         continue-on-error: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,9 @@ jobs:
       - name: Diagnostic history gate
         run: npm run check:diag-history
 
+      - name: Normalize generated Flow manifest before validation
+        run: npm run fix:generated-flow-args
+
       - name: Validate (npx)
         run: npx homey app validate --level publish
 
@@ -203,7 +206,10 @@ jobs:
         run: |
           git config --local user.name "github-actions[bot]"
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -A
+          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
+          for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md package.json package-lock.json; do
+            [ -e "$path" ] && git add "$path"
+          done
           D=$(ls -d drivers/*/ 2>/dev/null | wc -l)
           F=$(grep -rohE '"_T[A-Za-z0-9_]+"' drivers/*/driver.compose.json 2>/dev/null | sort -uf | wc -l || true)
           git diff --cached --quiet || git commit -m "v${{ steps.bump.outputs.version }}: ${D} drivers, ${F} fingerprints [skip ci]"

--- a/.github/workflows/unified-ci.yml
+++ b/.github/workflows/unified-ci.yml
@@ -76,8 +76,14 @@ jobs:
           console.log('✅ Dual-Layer: PASS — Zéro AggregateError');
           GATE
 
+      - name: Normalize Homey manifest before validation
+        run: npm run fix:generated-flow-args
+
       - name: 🏠 Homey Validate
         run: npx homey app validate --level publish
+
+      - name: Normalize Homey manifest after validation
+        run: npm run fix:generated-flow-args && npm run check:homey-guidelines
       
       - name: 🛡️ Fleetwood Integrity & Manifest Gateway
         run: node scripts/PRE_COMMIT_CHECKS.js

--- a/.github/workflows/verified-publish-and-diagnostics.yml
+++ b/.github/workflows/verified-publish-and-diagnostics.yml
@@ -82,11 +82,14 @@ jobs:
 
           echo "✅ Patterns de crash critiques vérifiés et absents."
 
+      - name: Normalize Homey manifest before validation
+        run: npm run fix:generated-flow-args
+
       - name: Validate App Manifest
         run: npx homey app validate --level=publish
 
       - name: Sanitize generated manifest after validation
-        run: node scripts/maintenance/sanitize-manifest.cjs app.json .homeybuild/app.json
+        run: npm run fix:generated-flow-args && npm run check:homey-guidelines
 
   # 2. Analyse des Diagnostics (Simulation du dump email)
   analyze-diagnostics:

--- a/scripts/maintenance/master-self-heal.js
+++ b/scripts/maintenance/master-self-heal.js
@@ -27,6 +27,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const { sanitizeManifestFile } = require('./sanitize-manifest.cjs');
 
 const ROOT = process.cwd();
 const DRIVERS_DIR = path.join(ROOT, 'drivers');
@@ -78,6 +79,51 @@ function safeWrite(file, content) {
   }
   fs.writeFileSync(file, content, 'utf8');
   return true;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// RULE 13: GENERATED MANIFEST SANITIZATION
+// Keeps Homey-generated app.json artifacts from reintroducing Flow/device arg,
+// button option, and compiled titleFormatted regressions.
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function rule_generatedManifestSanitize() {
+  log('\n📋 Rule 13: Generated Manifest Sanitization');
+  const appPath = path.join(ROOT, 'app.json');
+  let changes = 0;
+  let status = 0;
+
+  try {
+    status = sanitizeManifestFile(appPath, {
+      dryRun: DRY,
+      onChanges: count => { changes = count; },
+    });
+  } catch (e) {
+    report.errors.push({
+      rule: 'generated-manifest-sanitize',
+      file: appPath,
+      error: e.message,
+    });
+    log(`  → app.json sanitization crashed: ${e.message}`);
+    return;
+  }
+
+  if (status !== 0) {
+    report.errors.push({
+      rule: 'generated-manifest-sanitize',
+      file: appPath,
+      error: 'sanitize-manifest failed for app.json',
+    });
+    log('  → app.json sanitization failed');
+    return;
+  }
+
+  if (changes > 0) {
+    addFix('generated-manifest-sanitize', appPath, `Sanitized ${changes} generated Homey manifest artifact(s)`);
+    log(`  ✅ ${DRY ? 'Would sanitize' : 'Sanitized'} ${changes} app.json generated artifact(s)`);
+  } else {
+    log('  → app.json already clean');
+  }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -551,6 +597,7 @@ async function main() {
   rule_energyBatteries();
   rule_dualBatteryCleanup();
   rule_energyApproximationCleanup();
+  rule_generatedManifestSanitize();
 
   // DETECTION RULES (report only, manual fixes recommended)
   rule_flowCardTryCatch();
@@ -567,7 +614,7 @@ async function main() {
   log('  SELF-HEAL REPORT');
   log('═══════════════════════════════════════════════════════════════════════');
 
-  const autoFixed = ['sdk3-phantom-methods', 'fingerprint-case', 'probe-dedup-static', 'energy-batteries', 'dual-battery-cleanup', 'energy-approximation-cleanup'];
+  const autoFixed = ['sdk3-phantom-methods', 'fingerprint-case', 'probe-dedup-static', 'energy-batteries', 'dual-battery-cleanup', 'energy-approximation-cleanup', 'generated-manifest-sanitize'];
   const manualReview = Object.keys(report.rules).filter(r => !autoFixed.includes(r));
 
   let totalAutoFixes = 0;

--- a/scripts/maintenance/sanitize-manifest.cjs
+++ b/scripts/maintenance/sanitize-manifest.cjs
@@ -107,7 +107,10 @@ function stripDeviceTitleFormatted(manifest) {
   return stripped;
 }
 
-function sanitizeManifestFile(manifestPath) {
+function sanitizeManifestFile(manifestPath, options = {}) {
+  const opts = options && typeof options === 'object' ? options : {};
+  const dryRun = opts.dryRun === true || process.env.DRY_RUN === 'true';
+  const onChanges = typeof opts.onChanges === 'function' ? opts.onChanges : null;
   const label = path.relative(APP_ROOT, manifestPath).replace(/\\/g, '/') || manifestPath;
   if (!fs.existsSync(manifestPath)) {
     log(`No ${label} found — nothing to sanitize.`);
@@ -186,8 +189,13 @@ function sanitizeManifestFile(manifestPath) {
   }
 
   if (changes > 0) {
-    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
-    log(`${label}: wrote ${changes} change(s).`);
+    if (onChanges) onChanges(changes);
+    if (dryRun) {
+      log(`${label}: dry-run would write ${changes} change(s).`);
+    } else {
+      fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+      log(`${label}: wrote ${changes} change(s).`);
+    }
   } else {
     log(`${label}: manifest already clean — no changes.`);
   }


### PR DESCRIPTION
## Summary
- Add DRY_RUN-aware manifest sanitization to master self-heal so diagnostic runs cannot mutate app.json.
- Run generated Flow manifest normalization before/after Homey validation in master CI/publish workflows.
- Replace broad git add -A staging in high-risk automation with explicit source path staging and generated diagnostic/artifact restores.

## Cross-source context
- Mirrors the stable-v5 auto-heal protection added after the duplicate Flow arg regression.
- GitHub issue #428 remains routed/tested as soil_sensor; latest open issue review did not require a new driver patch here.
- Gmail connector still requires reauthentication, so mailbox-only crash emails could not be read directly in this session.

## Verification
- node --check scripts/maintenance/sanitize-manifest.cjs
- node --check scripts/maintenance/master-self-heal.js
- YAML parse for 8 touched workflows
- DRY_RUN=true node scripts/maintenance/master-self-heal.js --ci (app.json hash preserved)
- npm run fix:generated-flow-args; npm run validate:publish; npm run fix:generated-flow-args; npm run check:homey-guidelines
- npm run precommit
- npx mocha test/critical/soil-myd45weu-routing.test.js --timeout 10000 --exit
- npm test -- --timeout 10000 --exit