### PR TITLE
[codex] fix TS0014 wall switch button listeners

### DIFF
--- a/data/fingerprints.json
+++ b/data/fingerprints.json
@@ -149,6 +149,40 @@
     ],
     "notes": "Homey forum TS0044 4-button remote (_TZ3000_u3nv1jwk): route to E000/DP-capable button driver."
   },
+  "_TZ3000_mrduubod": {
+    "driverId": "wall_switch_4gang_1way",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0014"
+    ],
+    "capabilities": [
+      "onoff",
+      "onoff.gang2",
+      "onoff.gang3",
+      "onoff.gang4",
+      "button.1",
+      "button.2",
+      "button.3",
+      "button.4"
+    ],
+    "clusters": [
+      0,
+      3,
+      4,
+      5,
+      6,
+      57344,
+      57345
+    ],
+    "endpoints": [
+      1,
+      2,
+      3,
+      4
+    ],
+    "notes": "Homey forum #2099 / Johan #1413 Moes TS0014 4-gang switch: use wall_switch_4gang_1way, ignore false Basic powerSource=battery."
+  },
   "_TZE284_ne4pikwm": {
     "driverId": "radiator_valve",
     "type": "trv",

--- a/drivers/wall_switch_2gang_1way/device.js
+++ b/drivers/wall_switch_2gang_1way/device.js
@@ -13,7 +13,12 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
 
   get mainsPowered() { return true; }
 
-  get gangCount() { return 1; }
+  get gangCount() { return 2; }
+
+  get switchCapabilities() {
+    const { subDeviceId } = this.getData();
+    return subDeviceId ? ['onoff'] : super.switchCapabilities;
+  }
 
   get dpMappings() {
     const { subDeviceId } = this.getData();
@@ -39,6 +44,7 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
         this._gangNumber = 1;
         this.log('[WALL-2G] Initializing Primary Device (Gang 1)');
       }
+      this._isSubDevice = Boolean(subDeviceId);
       await super.onNodeInit({ zclNode });
       await this.initVirtualButtons();
       this.log(`[WALL-2G] v9.7.3 - Unified initialization complete for Gang ${this._gangNumber}`);
@@ -49,7 +55,7 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Filter physical button triggers to only process the gang assigned to this device.
    */
   triggerButtonPress(button, type = 'single', countOrOptions = {}, options = {}) {
-    if (this._gangNumber !== undefined && button !== this._gangNumber) {
+    if (this._isSubDevice && this._gangNumber !== undefined && button !== this._gangNumber) {
       return; // Ignore events for other gangs
     }
     const tokens = typeof countOrOptions === 'number'
@@ -65,7 +71,7 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Map UI commands to the correct Zigbee/Tuya gang.
    */
   _setGangOnOff(gang, value) {
-    const targetGang = this._gangNumber || gang;
+    const targetGang = this._isSubDevice ? this._gangNumber : gang;
     return super._setGangOnOff(targetGang, value);
   }
 

--- a/drivers/wall_switch_3gang_1way/device.js
+++ b/drivers/wall_switch_3gang_1way/device.js
@@ -13,7 +13,12 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
 
   get mainsPowered() { return true; }
 
-  get gangCount() { return 1; }
+  get gangCount() { return 3; }
+
+  get switchCapabilities() {
+    const { subDeviceId } = this.getData();
+    return subDeviceId ? ['onoff'] : super.switchCapabilities;
+  }
 
   get dpMappings() {
     const { subDeviceId } = this.getData();
@@ -41,6 +46,7 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
       } else {
         this._gangNumber = 1;
       }
+      this._isSubDevice = Boolean(subDeviceId);
       this.log(`[WALL-3G] Initializing ${this._gangNumber > 1 ? 'Sub' : 'Primary'} Device (Gang ${this._gangNumber})`);
       await super.onNodeInit({ zclNode });
       await this.initVirtualButtons();
@@ -52,7 +58,7 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Filter physical button triggers to only process the gang assigned to this device.
    */
   triggerButtonPress(button, type = 'single', countOrOptions = {}, options = {}) {
-    if (this._gangNumber !== undefined && button !== this._gangNumber) {
+    if (this._isSubDevice && this._gangNumber !== undefined && button !== this._gangNumber) {
       return; // Ignore events for other gangs
     }
     const tokens = typeof countOrOptions === 'number'
@@ -68,7 +74,7 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Map UI commands to the correct Zigbee/Tuya gang.
    */
   _setGangOnOff(gang, value) {
-    const targetGang = this._gangNumber || gang;
+    const targetGang = this._isSubDevice ? this._gangNumber : gang;
     return super._setGangOnOff(targetGang, value);
   }
 

--- a/drivers/wall_switch_4gang_1way/device.js
+++ b/drivers/wall_switch_4gang_1way/device.js
@@ -13,7 +13,12 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
 
   get mainsPowered() { return true; }
 
-  get gangCount() { return 1; }
+  get gangCount() { return 4; }
+
+  get switchCapabilities() {
+    const { subDeviceId } = this.getData();
+    return subDeviceId ? ['onoff'] : super.switchCapabilities;
+  }
 
   get dpMappings() {
     const { subDeviceId } = this.getData();
@@ -45,6 +50,7 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
       } else {
         this._gangNumber = 1;
       }
+      this._isSubDevice = Boolean(subDeviceId);
       this.log(`[WALL-4G] Initializing ${this._gangNumber > 1 ? 'Sub' : 'Primary'} Device (Gang ${this._gangNumber})`);
       await super.onNodeInit({ zclNode });
       await this.initVirtualButtons();
@@ -56,7 +62,7 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Filter physical button triggers to only process the gang assigned to this device.
    */
   triggerButtonPress(button, type = 'single', countOrOptions = {}, options = {}) {
-    if (this._gangNumber !== undefined && button !== this._gangNumber) {
+    if (this._isSubDevice && this._gangNumber !== undefined && button !== this._gangNumber) {
       return; // Ignore events for other gangs
     }
     const tokens = typeof countOrOptions === 'number'
@@ -72,7 +78,7 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
    * Map UI commands to the correct Zigbee/Tuya gang.
    */
   _setGangOnOff(gang, value) {
-    const targetGang = this._gangNumber || gang;
+    const targetGang = this._isSubDevice ? this._gangNumber : gang;
     return super._setGangOnOff(targetGang, value);
   }
 

--- a/drivers/wall_switch_4gang_1way/driver.compose.json
+++ b/drivers/wall_switch_4gang_1way/driver.compose.json
@@ -21,10 +21,7 @@
     "approximation": {
       "usageOn": 100,
       "usageOff": 1
-    },
-    "batteries": [
-      "CR2032"
-    ]
+    }
   },
   "platforms": [
     "local"
@@ -115,7 +112,9 @@
           3,
           4,
           5,
-          6
+          6,
+          57344,
+          57345
         ]
       },
       "3": {
@@ -124,7 +123,9 @@
           3,
           4,
           5,
-          6
+          6,
+          57344,
+          57345
         ]
       },
       "4": {
@@ -133,7 +134,9 @@
           3,
           4,
           5,
-          6
+          6,
+          57344,
+          57345
         ]
       }
     },
@@ -374,14 +377,6 @@
       "maintenanceAction": true,
       "getable": false,
       "setable": false
-    },
-    "measure_battery": {
-      "title": {
-        "en": "Battery",
-        "fr": "Batterie",
-        "nl": "Batterij",
-        "de": "Batterie"
-      }
     }
   }
 }

--- a/lib/DeviceFingerprintDB.js
+++ b/lib/DeviceFingerprintDB.js
@@ -35,6 +35,7 @@ const FINGERPRINT_DB = {
   '_TZ3000_hafsqare|TS0003': { driver: 'wall_switch_3gang_1way', protocol: 'zcl', dpProfile: null, notes: 'BSEED 3G ZCL-only' },
   '_TZ3000_e98krvvk|TS0003': { driver: 'wall_switch_3gang_1way', protocol: 'zcl', dpProfile: null, notes: 'BSEED 3G ZCL-only' },
   '_TZ3000_iedbgyxt|TS0004': { driver: 'wall_switch_4gang_1way', protocol: 'zcl', dpProfile: null, notes: 'BSEED 4G ZCL-only' },
+  '_TZ3000_mrduubod|TS0014': { driver: 'wall_switch_4gang_1way', protocol: 'zcl', dpProfile: null, endpoints: [1, 2, 3, 4], powerSource: 'mains', notes: 'Homey forum #2099 / Johan #1413 Moes TS0014 4-gang: ZCL OnOff endpoints with 0xE000/0xE001; Basic may report battery incorrectly' },
   '_TZ3002_pzao9ls1|TS0726': { driver: 'wall_switch_4gang_1way', protocol: 'zcl', dpProfile: null, notes: 'BSEED 4G TS0726 broadcast bug - uses writeAttributes (Hartmut_Dunker forum)' },
   '_TZ3000_ovyaisip|TS0001': { driver: 'wall_switch_1gang_1way', protocol: 'zcl', dpProfile: null, notes: 'Johan #1045 NovaDigital 1-gang switch; keep away from climate fallback' },
   '_TZ3000_pk8tgtdb|TS0001': { driver: 'wall_switch_1gang_1way', protocol: 'zcl', dpProfile: null, notes: 'Johan #1048 1-gang switch; keep away from climate fallback' },

--- a/lib/mixins/PhysicalButtonMixin.js
+++ b/lib/mixins/PhysicalButtonMixin.js
@@ -51,6 +51,12 @@ const DEVICE_PROFILES = {
     appCommandWindow: 2000, doubleClickWindow: 500, longPressThreshold: 800,
     protocol: 'zcl_only', customClusters: [0xE000, 0xE001], brand: 'BSEED'
   },
+  '_TZ3000_mrduubod': {
+    appCommandWindow: 2000, doubleClickWindow: 500, longPressThreshold: 800,
+    protocol: 'zcl_only', customClusters: [0xE000, 0xE001], brand: 'Moes/BSEED',
+    productId: 'TS0014', gangCount: 4, buttonCount: 4,
+    perEndpointControl: true, requiresExplicitBinding: true, source: 'homey_forum_2099'
+  },
   // v5.8.1: BSEED 2-gang (Pieter_Pessers forum report)
   '_TZ3000_l9brjwau': { 
     appCommandWindow: 2000, doubleClickWindow: 500, longPressThreshold: 800,

--- a/lib/mixins/VirtualButtonMixin.js
+++ b/lib/mixins/VirtualButtonMixin.js
@@ -239,18 +239,24 @@ const VirtualButtonMixin = (Base) => {
         }
       }
 
-      // v6.0.0: Auto-registration for asymmetric scene buttons
-      // If a device has button.X but no physical listener, VirtualButtonMixin can handle it
-      // v9.0.88: Skip if ButtonDevice already registered listeners (prevents double-trigger)
-      const hasButtonDevice = typeof this.triggerButtonPress === 'function';
-      if (!hasButtonDevice) {
+      // v6.0.0: Auto-registration for asymmetric scene buttons.
+      // ButtonDevice owns a dedicated router; mixed switch/button devices still
+      // need listeners for Homey's button.N UI controls.
+      const hasDedicatedButtonCapabilityRouter = typeof this._registerButtonCapabilityListeners === 'function';
+      if (!hasDedicatedButtonCapabilityRouter) {
         for (let i = 1; i <= 8; i++) {
           const cap = `button.${i}`;
           if (this.hasCapability(cap)) {
              this.registerCapabilityListener(cap, async () => {
                this.log(`[VIRTUAL-BTN] 🔘 Asymmetric button.${i} pressed`);
-               this._triggerPhysicalFlow?.(i, 'single'); // Treat as physical single press
+               if (typeof this.triggerButtonPress === 'function') {
+                 await this.triggerButtonPress(i, 'single', 1, { source: 'virtual' });
+               } else {
+                 await this._triggerPhysicalFlow?.(i, 'single', { source: 'virtual', _internalTrigger: true });
+               }
+               return true;
              });
+             this.log(`[VIRTUAL-BTN] ✅ ${cap} (scene trigger)`);
           }
         }
       }

--- a/test/button-flow-runtime-routing.test.js
+++ b/test/button-flow-runtime-routing.test.js
@@ -87,11 +87,32 @@ describe('button flow runtime routing guards', function() {
   });
 
   it('keeps wall-switch button filters away from missing super trigger handlers', function() {
-    for (const driverId of ['wall_switch_2gang_1way', 'wall_switch_3gang_1way', 'wall_switch_4gang_1way']) {
+    const expectedGangCounts = {
+      wall_switch_2gang_1way: 2,
+      wall_switch_3gang_1way: 3,
+      wall_switch_4gang_1way: 4,
+    };
+
+    for (const [driverId, gangCount] of Object.entries(expectedGangCounts)) {
       const source = read(`drivers/${driverId}/device.js`);
 
       assert.doesNotMatch(source, /super\.triggerButtonPress/);
+      assert.match(source, new RegExp(`get gangCount\\(\\) \\{ return ${gangCount}; \\}`));
+      assert.match(source, /get switchCapabilities\(\)/);
+      assert.match(source, /this\._isSubDevice = Boolean\(subDeviceId\)/);
+      assert.match(source, /if \(this\._isSubDevice && this\._gangNumber !== undefined && button !== this\._gangNumber\)/);
+      assert.match(source, /const targetGang = this\._isSubDevice \? this\._gangNumber : gang/);
       assert.match(source, /_triggerPhysicalFlow\(button, type, \{ \.\.\.tokens, _internalTrigger: true \}\)/);
     }
+  });
+
+  it('registers button.N virtual listeners for mixed switch/button devices', function() {
+    const source = read('lib/mixins/VirtualButtonMixin.js');
+
+    assert.match(source, /const hasDedicatedButtonCapabilityRouter = typeof this\._registerButtonCapabilityListeners === 'function'/);
+    assert.doesNotMatch(source, /const hasButtonDevice = typeof this\.triggerButtonPress === 'function'/);
+    assert.match(source, /this\.registerCapabilityListener\(cap, async \(\) =>/);
+    assert.match(source, /await this\.triggerButtonPress\(i, 'single', 1, \{ source: 'virtual' \}\)/);
+    assert.match(source, /await this\._triggerPhysicalFlow\?\.\(i, 'single', \{ source: 'virtual', _internalTrigger: true \}\)/);
   });
 });

--- a/test/critical/forum-routing-regressions.test.js
+++ b/test/critical/forum-routing-regressions.test.js
@@ -261,11 +261,33 @@ describe('forum routing regressions', () => {
     const runtimeDb = require('../../lib/tuya/DeviceFingerprintDB');
 
     assert.strictEqual(runtimeDb.getDriverId('_TZ3000_kfu8zapd', 'TS004F'), 'button_wireless_4');
+    assert.strictEqual(runtimeDb.getDriverId('_TZ3000_mrduubod', 'TS0014'), 'wall_switch_4gang_1way');
     assert.strictEqual(runtimeDb.getDriverId('_TZ3002_pzao9ls1', 'TS0726'), 'wall_switch_4gang_1way');
     assert.strictEqual(runtimeDb.getDriverId('_TZE200_8ygsuhe1', 'TS0601'), 'air_quality_comprehensive');
+
+    const switchProfile = runtimeDb.getFingerprint('_TZ3000_mrduubod', 'TS0014');
+    assert.strictEqual(switchProfile.driverId, 'wall_switch_4gang_1way');
+    assert.strictEqual(switchProfile.powerSource, 'mains');
+    assert.deepStrictEqual(switchProfile.modelIds, ['TS0014']);
 
     const profile = runtimeDb.getFingerprint('_TZE200_8ygsuhe1', 'TS0601');
     assert.strictEqual(profile.driverId, 'air_quality_comprehensive');
     assert.deepStrictEqual(profile.modelIds, ['TS0601']);
+  });
+
+  it('keeps Moes TS0014 4-gang switch UI and endpoint metadata complete', () => {
+    const compose = composeDriver('wall_switch_4gang_1way');
+
+    assertDriverClaims('wall_switch_4gang_1way', '_TZ3000_mrduubod');
+    assertDriverHasProductId('wall_switch_4gang_1way', 'TS0014');
+    for (const cap of ['onoff', 'onoff.gang2', 'onoff.gang3', 'onoff.gang4', 'button.1', 'button.2', 'button.3', 'button.4']) {
+      assert(compose.capabilities.includes(cap), `wall_switch_4gang_1way must expose ${cap}`);
+    }
+    assert(!compose.energy?.batteries, 'Moes TS0014 wall switch must not publish static battery metadata');
+    assert(!compose.capabilitiesOptions?.measure_battery, 'Moes TS0014 wall switch must not expose stale battery options');
+    for (const endpointId of ['1', '2', '3', '4']) {
+      assert(compose.zigbee.endpoints[endpointId].clusters.includes(57344), `endpoint ${endpointId} must include Tuya 0xE000`);
+      assert(compose.zigbee.endpoints[endpointId].clusters.includes(57345), `endpoint ${endpointId} must include Tuya 0xE001`);
+    }
   });
 });


### PR DESCRIPTION
## What changed
- Restored Homey capability listeners for mixed switch/button devices exposing `button.N` capabilities, without double-registering pure `ButtonDevice` routers.
- Fixed 2/3/4-gang 1-way wall switch runtime gang handling so the parent device controls and triggers all gangs while sub-devices stay pinned to their assigned gang.
- Added the exact `_TZ3000_mrduubod|TS0014` Moes/BSEED route and runtime fingerprint metadata as mains-powered.
- Completed the 4-gang endpoint metadata with `0xE000/0xE001` on endpoints 2-4 and removed stale static battery metadata.

## Root cause
The forum #2099 device was correctly paired as `wall_switch_4gang_1way`, but `VirtualButtonMixin` skipped `button.1`..`button.4` listeners when a class had `triggerButtonPress()`. This mixed switch driver had no alternate `button.N` capability router, so Homey raised `Missing Capability Listener: Button 1`. The same driver also reported `gangCount = 1` and forced primary-device commands through gang 1.

## Validation
- `npx mocha test\\button-flow-runtime-routing.test.js test\\critical\\forum-routing-regressions.test.js --timeout 10000 --exit`
- `npm run check:button-flows`
- `npm run validate:publish`
- `npm run check:homey-guidelines`
- `npm test -- --timeout 10000 --exit`
- `npm run precommit`
- `npm run build && npm run prepare-publish`
- pre-push gate passed
