### PR TITLE
[codex] harden TS0014 publish metadata sync

### DIFF
--- a/.github/workflows/auto-fix-and-publish.yml
+++ b/.github/workflows/auto-fix-and-publish.yml
@@ -87,15 +87,35 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
-          for path in drivers lib app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .cursorrules AI_INSTRUCTIONS.md package.json package-lock.json; do
-            [ -e "$path" ] && git add "$path"
-          done
+          restore_volatile_artifacts() {
+            for path in .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots .homeybuild; do
+              git restore -- "$path" 2>/dev/null || true
+            done
+          }
+          stage_auto_fix_paths() {
+            for path in drivers lib app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .cursorrules AI_INSTRUCTIONS.md package.json package-lock.json; do
+              [ -e "$path" ] && git add "$path"
+            done
+          }
+          restore_volatile_artifacts
+          stage_auto_fix_paths
           if ! git diff --staged --quiet; then
             git commit -m "🤖 auto-fix-all: automated fixes [skip ci]"
             BRANCH="${GITHUB_REF_NAME:-master}"
+            restore_volatile_artifacts
+            if ! git diff --quiet || ! git diff --cached --quiet; then
+              echo "::group::Remaining tracked changes before rebase"
+              git status --short
+              echo "::endgroup::"
+              echo "::error::Uncommitted tracked changes remain before rebase"
+              exit 1
+            fi
             git fetch origin "$BRANCH"
-            git pull --rebase origin "$BRANCH"
+            if ! git merge-base --is-ancestor "origin/$BRANCH" HEAD; then
+              git rebase "origin/$BRANCH"
+            else
+              echo "origin/$BRANCH is already an ancestor of HEAD; skipping rebase"
+            fi
             git push origin HEAD:"refs/heads/$BRANCH"
             git fetch origin "$BRANCH"
             git merge-base --is-ancestor HEAD "origin/$BRANCH" || {

--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -390,6 +390,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          restore_volatile_artifacts() {
+            for path in .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots .homeybuild; do
+              git restore -- "$path" 2>/dev/null || true
+            done
+          }
+          stage_publish_metadata() {
+            for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs package.json package-lock.json; do
+              [ -e "$path" ] && git add "$path"
+            done
+          }
           node scripts/maintenance/sanitize-manifest.cjs app.json .homeybuild/app.json || true
           node <<'NODE'
           const fs = require('fs');
@@ -416,16 +426,34 @@ jobs:
             }
           }
           NODE
-          git restore -- .github/state diagnostics screenshots screenshots-debug promote-screenshots push-promote-screenshots 2>/dev/null || true
-          for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs package.json package-lock.json; do
-            [ -e "$path" ] && git add "$path"
-          done
+          restore_volatile_artifacts
+          stage_publish_metadata
           VER=$(node -p "require('./app.json').version" 2>/dev/null || echo "${{ steps.info.outputs.version }}")
           D=$(ls -d drivers/*/ 2>/dev/null | wc -l)
           F=$(grep -rohE '"_T[A-Za-z0-9_]+"' drivers/*/driver.compose.json 2>/dev/null | sort -uf | wc -l || echo 0)
           git diff --cached --quiet || git commit -m "v${VER}: ${D} drivers, ${F} FPs [skip ci]"
+          restore_volatile_artifacts
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "::group::Tracked changes after publish metadata commit"
+            git status --short
+            echo "::endgroup::"
+            stage_publish_metadata
+            git diff --cached --quiet || git commit -m "chore(master): sync generated publish metadata [skip ci]"
+          fi
+          restore_volatile_artifacts
+          if ! git diff --quiet || ! git diff --cached --quiet; then
+            echo "::group::Remaining tracked changes before rebase"
+            git status --short
+            echo "::endgroup::"
+            echo "::error::Uncommitted tracked changes remain before rebase"
+            exit 1
+          fi
           git fetch origin master
-          git pull --rebase origin master
+          if ! git merge-base --is-ancestor origin/master HEAD; then
+            git rebase origin/master
+          else
+            echo "origin/master is already an ancestor of HEAD; skipping rebase"
+          fi
           git push origin HEAD:refs/heads/master
           git fetch origin master
           git merge-base --is-ancestor HEAD origin/master || {

--- a/drivers/wall_switch_2gang_1way/device.js
+++ b/drivers/wall_switch_2gang_1way/device.js
@@ -16,12 +16,12 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
   get gangCount() { return 2; }
 
   get switchCapabilities() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     return subDeviceId ? ['onoff'] : super.switchCapabilities;
   }
 
   get dpMappings() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     const mappings = { ...super.dpMappings };
     
     // v9.7.3: For sub-devices, map the specific Tuya DP to the 'onoff' capability
@@ -36,7 +36,7 @@ class WallSwitch2Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
     await this.removeCapability('measure_battery').catch(() => {});
     await this.removeCapability('alarm_battery').catch(() => {});
     await this._safeInvoke(async () => {
-      const { subDeviceId } = this.getData();
+      const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
       if (subDeviceId === 'secondSwitch') {
         this._gangNumber = 2;
         this.log('[WALL-2G] Initializing Sub-Device (Gang 2)');

--- a/drivers/wall_switch_3gang_1way/device.js
+++ b/drivers/wall_switch_3gang_1way/device.js
@@ -16,12 +16,12 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
   get gangCount() { return 3; }
 
   get switchCapabilities() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     return subDeviceId ? ['onoff'] : super.switchCapabilities;
   }
 
   get dpMappings() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     const mappings = { ...super.dpMappings };
     
     // v9.7.3: For sub-devices, map the specific Tuya DP to the 'onoff' capability
@@ -38,7 +38,7 @@ class WallSwitch3Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
     await this.removeCapability('measure_battery').catch(() => {});
     await this.removeCapability('alarm_battery').catch(() => {});
     await this._safeInvoke(async () => {
-      const { subDeviceId } = this.getData();
+      const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
       if (subDeviceId === 'secondSwitch') {
         this._gangNumber = 2;
       } else if (subDeviceId === 'thirdSwitch') {

--- a/drivers/wall_switch_4gang_1way/device.js
+++ b/drivers/wall_switch_4gang_1way/device.js
@@ -16,12 +16,12 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
   get gangCount() { return 4; }
 
   get switchCapabilities() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     return subDeviceId ? ['onoff'] : super.switchCapabilities;
   }
 
   get dpMappings() {
-    const { subDeviceId } = this.getData();
+    const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
     const mappings = { ...super.dpMappings };
     
     // v9.7.3: For sub-devices, map the specific Tuya DP to the 'onoff' capability
@@ -40,7 +40,7 @@ class WallSwitch4Gang1WayDevice extends PhysicalButtonMixin(VirtualButtonMixin(U
     await this.removeCapability('measure_battery').catch(() => {});
     await this.removeCapability('alarm_battery').catch(() => {});
     await this._safeInvoke(async () => {
-      const { subDeviceId } = this.getData();
+      const { subDeviceId } = (typeof this.getData === 'function' && this.getData()) || {};
       if (subDeviceId === 'secondSwitch') {
         this._gangNumber = 2;
       } else if (subDeviceId === 'thirdSwitch') {


### PR DESCRIPTION
## Summary
- harden 2/3/4-gang wall switch getters so Homey can query sub-device capabilities before full init
- make master auto-publish bot commits clean volatile artifacts and avoid dirty rebase failures
- apply the same clean-rebase guard to auto-fix publish retries

## Verification
- node --check wall_switch 2/3/4-gang drivers
- npm run check:yaml
- npm run check:button-flows
- npx mocha test/button-flow-runtime-routing.test.js test/critical/forum-routing-regressions.test.js --timeout 10000 --exit
- npm run precommit
- npm run validate:publish
- npm run build
- npm run prepare-publish