### PR TITLE
[codex] include generated stats in publish bot sync

### DIFF
--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -396,7 +396,7 @@ jobs:
             done
           }
           stage_publish_metadata() {
-            for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs package.json package-lock.json; do
+            for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .github/scripts/_stats.json package.json package-lock.json; do
               [ -e "$path" ] && git add "$path"
             done
           }


### PR DESCRIPTION
## Summary
- include .github/scripts/_stats.json in the auto-publish bot metadata allowlist
- fixes the remaining dirty-worktree rebase failure observed after v9.0.163 was published and verified in test

## Verification
- npm run check:yaml
- pre-commit hook
- pre-push gate