### PR TITLE
[codex] Add Zemismart boiler switch routing

### DIFF
--- a/data/fingerprints.json
+++ b/data/fingerprints.json
@@ -405,5 +405,152 @@
       1
     ],
     "notes": "TS004F rotary knob routed away from generic button/switch drivers"
+  },
+  "_TZE204_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "dps": {
+      "1": {
+        "name": "state",
+        "capability": "onoff"
+      },
+      "6": {
+        "name": "current",
+        "capability": "measure_current",
+        "smartDivisor": true
+      },
+      "7": {
+        "name": "power",
+        "capability": "measure_power",
+        "smartDivisor": true
+      },
+      "8": {
+        "name": "voltage",
+        "capability": "measure_voltage",
+        "smartDivisor": true
+      },
+      "9": {
+        "name": "energy",
+        "capability": "meter_power",
+        "smartDivisor": true
+      },
+      "12": {
+        "name": "temperature",
+        "capability": "measure_temperature",
+        "smartDivisor": true
+      }
+    },
+    "notes": "Hubitat-compatible Zemismart TS0601 rzdkn5rx 1-gang/boiler switch route."
+  },
+  "_TZE28C100000_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "dps": {
+      "1": {
+        "name": "state",
+        "capability": "onoff"
+      },
+      "6": {
+        "name": "current",
+        "capability": "measure_current",
+        "smartDivisor": true
+      },
+      "7": {
+        "name": "power",
+        "capability": "measure_power",
+        "smartDivisor": true
+      },
+      "8": {
+        "name": "voltage",
+        "capability": "measure_voltage",
+        "smartDivisor": true
+      },
+      "9": {
+        "name": "energy",
+        "capability": "meter_power",
+        "smartDivisor": true
+      },
+      "12": {
+        "name": "temperature",
+        "capability": "measure_temperature",
+        "smartDivisor": true
+      }
+    },
+    "notes": "Homey forum 26439 #5484 exact Zemismart ZN-LRL1E/30A water boiler switch manufacturer code."
+  },
+  "_TZE28C1000000_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "dps": {
+      "1": {
+        "name": "state",
+        "capability": "onoff"
+      },
+      "6": {
+        "name": "current",
+        "capability": "measure_current",
+        "smartDivisor": true
+      },
+      "7": {
+        "name": "power",
+        "capability": "measure_power",
+        "smartDivisor": true
+      },
+      "8": {
+        "name": "voltage",
+        "capability": "measure_voltage",
+        "smartDivisor": true
+      },
+      "9": {
+        "name": "energy",
+        "capability": "meter_power",
+        "smartDivisor": true
+      },
+      "12": {
+        "name": "temperature",
+        "capability": "measure_temperature",
+        "smartDivisor": true
+      }
+    },
+    "notes": "Normalized TZE28C1000000 prefix sibling for Homey forum 26439 #5484 Zemismart boiler switch."
   }
 }

--- a/drivers/boiler_switch_energy/device.js
+++ b/drivers/boiler_switch_energy/device.js
@@ -14,6 +14,8 @@ class BoilerSwitchEnergyDevice extends PhysicalButtonMixin(VirtualButtonMixin(Un
 
   get mainsPowered() { return true; }
 
+  get gangCount() { return 1; }
+
   get dpMappings() {
     return {
       ...super.dpMappings,
@@ -28,11 +30,20 @@ class BoilerSwitchEnergyDevice extends PhysicalButtonMixin(VirtualButtonMixin(Un
   }
 
   async onNodeInit({ zclNode }) {
-    if (this._initialized) return;
-    this._initialized = true;
+    if (this._initialized || this._initializing) return;
+    this._initializing = true;
 
-    await super.onNodeInit({ zclNode });
-    this.log('[BoilerSwitchEnergy] Initialized');
+    try {
+      await super.onNodeInit({ zclNode });
+      await this.removeCapability('measure_battery').catch(() => {});
+      await this.removeCapability('alarm_battery').catch(() => {});
+      await this.initPhysicalButtonDetection?.(zclNode);
+      await this.initVirtualButtons?.();
+      this._initialized = true;
+      this.log('[BoilerSwitchEnergy] Initialized with mains-safe energy and button handling');
+    } finally {
+      this._initializing = false;
+    }
   }
 
   onDeleted() {

--- a/drivers/boiler_switch_energy/driver.compose.json
+++ b/drivers/boiler_switch_energy/driver.compose.json
@@ -46,7 +46,10 @@
     },
     "manufacturerName": [
       "_hybrid_boiler_switch_energy_needs_device_assignment",
-      "_HYBRID_BOILER_SWITCH_ENERGY_NEEDS_DEVICE_ASSIGNMENT"
+      "_HYBRID_BOILER_SWITCH_ENERGY_NEEDS_DEVICE_ASSIGNMENT",
+      "_TZE204_rzdkn5rx",
+      "_TZE28C100000_rzdkn5rx",
+      "_TZE28C1000000_rzdkn5rx"
     ]
   },
   "images": {

--- a/lib/DeviceFingerprintDB.js
+++ b/lib/DeviceFingerprintDB.js
@@ -48,6 +48,9 @@ const FINGERPRINT_DB = {
   // ─────────────────────────────────────────────────────────────────────────
   '_TZE200_amp6tsvy|TS0601': { driver: 'switch_2gang', protocol: 'tuya_dp', dpProfile: 'MULTIGANG', notes: '2G DP switch' },
   '_TZE204_amp6tsvy|TS0601': { driver: 'switch_2gang', protocol: 'tuya_dp', dpProfile: 'MULTIGANG', notes: '2G DP switch' },
+  '_TZE204_rzdkn5rx|TS0601': { driver: 'boiler_switch_energy', protocol: 'tuya_dp', dpProfile: 'BOILER_SWITCH_ENERGY', powerSource: 'mains', dp: { 1: 'onoff', 6: 'measure_current', 7: 'measure_power', 8: 'measure_voltage', 9: 'meter_power', 12: 'measure_temperature' }, notes: 'Hubitat Moes/Zemismart wall-switch driver; Homey forum 26439 #5484 Zemismart ZN-LRL1E/boiler switch variant' },
+  '_TZE28C100000_rzdkn5rx|TS0601': { driver: 'boiler_switch_energy', protocol: 'tuya_dp', dpProfile: 'BOILER_SWITCH_ENERGY', powerSource: 'mains', dp: { 1: 'onoff', 6: 'measure_current', 7: 'measure_power', 8: 'measure_voltage', 9: 'meter_power', 12: 'measure_temperature' }, notes: 'Homey forum 26439 #5484 exact manufacturer code for Zemismart ZN-LRL1E/30A water boiler switch' },
+  '_TZE28C1000000_rzdkn5rx|TS0601': { driver: 'boiler_switch_energy', protocol: 'tuya_dp', dpProfile: 'BOILER_SWITCH_ENERGY', powerSource: 'mains', dp: { 1: 'onoff', 6: 'measure_current', 7: 'measure_power', 8: 'measure_voltage', 9: 'meter_power', 12: 'measure_temperature' }, notes: 'Homey forum 26439 #5484 normalized TZE28C1000000 prefix sibling for Zemismart boiler switch' },
 
   // ─────────────────────────────────────────────────────────────────────────
   // CLIMATE SENSORS

--- a/lib/tuya/fingerprints.json
+++ b/lib/tuya/fingerprints.json
@@ -13088,5 +13088,59 @@
       }
     },
     "notes": "Nedis/ne4pikwm compatible radiator valve variant."
+  },
+  "_TZE204_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "notes": "Hubitat-compatible Zemismart TS0601 rzdkn5rx 1-gang/boiler switch route."
+  },
+  "_TZE28C100000_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "notes": "Homey forum 26439 #5484 exact Zemismart ZN-LRL1E/30A water boiler switch manufacturer code."
+  },
+  "_TZE28C1000000_rzdkn5rx": {
+    "driverId": "boiler_switch_energy",
+    "type": "switch",
+    "powerSource": "mains",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "onoff",
+      "measure_power",
+      "measure_voltage",
+      "measure_current",
+      "meter_power",
+      "measure_temperature",
+      "button.1"
+    ],
+    "notes": "Normalized TZE28C1000000 prefix sibling for Homey forum 26439 #5484 Zemismart boiler switch."
   }
 }

--- a/test/critical/forum-routing-regressions.test.js
+++ b/test/critical/forum-routing-regressions.test.js
@@ -236,6 +236,22 @@ describe('forum routing regressions', () => {
     assert.strictEqual(CompoundFingerprintDB.lookup('HOBEIAN', 'ZG-222Z')?.driver, 'water_leak_sensor');
     assert.strictEqual(RuntimeFingerprintDB.getDriverId('HOBEIAN', 'ZG-222Z'), 'water_leak_sensor');
 
+    for (const manufacturer of ['_TZE204_rzdkn5rx', '_TZE28C100000_rzdkn5rx', '_TZE28C1000000_rzdkn5rx']) {
+      assertDriverClaims('boiler_switch_energy', manufacturer);
+      assertDriverDoesNotClaim('switch_1gang', manufacturer);
+      assertDriverDoesNotClaim('generic_tuya', manufacturer);
+      assertFingerprint('data/fingerprints.json', manufacturer, 'boiler_switch_energy');
+      assertFingerprint('lib/tuya/fingerprints.json', manufacturer, 'boiler_switch_energy');
+      assert.strictEqual(CompoundFingerprintDB.lookup(manufacturer, 'TS0601')?.driver, 'boiler_switch_energy');
+      assert.strictEqual(RuntimeFingerprintDB.getDriverId(manufacturer, 'TS0601'), 'boiler_switch_energy');
+      assert.strictEqual(CompoundFingerprintDB.getDPMeaning(manufacturer, 'TS0601', 1).capability, 'onoff');
+    }
+    const boilerCompose = composeDriver('boiler_switch_energy');
+    assert(!boilerCompose.capabilities.includes('measure_battery'), 'boiler switch must not expose a phantom battery');
+    assert(!boilerCompose.energy?.batteries, 'boiler switch must not publish static battery metadata');
+    assert.match(read('drivers/boiler_switch_energy/device.js'), /initVirtualButtons/);
+    assert.match(read('drivers/boiler_switch_energy/device.js'), /this\._initializing = true[\s\S]+this\._initialized = true[\s\S]+finally/);
+
     assertDriverHasProductId('motion_sensor', 'SNZB-03');
     assert.strictEqual(CompoundFingerprintDB.lookup('eWeLink', 'SNZB-03')?.driver, 'motion_sensor');
     assert.strictEqual(RuntimeFingerprintDB.getDriverId('eWeLink', 'SNZB-03'), 'motion_sensor');


### PR DESCRIPTION
## Summary

- Routes recent Homey forum report `TS0601 / _TZE28C100000_rzdkn5rx` to `boiler_switch_energy` so the Zemismart water boiler/high-power switch exposes On/Off instead of pairing as generic.
- Adds sibling fingerprints `_TZE204_rzdkn5rx` from Hubitat research and `_TZE28C1000000_rzdkn5rx` to cover the existing TZE28C1000000-style prefix used in this project.
- Hardens `boiler_switch_energy` initialization with one-gang metadata, virtual/physical button setup, and mains-safe removal of battery capabilities.
- Adds regression coverage to keep these routes out of stale generic/switch fallbacks and prevent phantom battery UI.

## Sources

- Homey forum topic 26439 latest report: https://community.homey.app/t/app-pro-tuya-zigbee-app/26439
- Blakadder Zemismart ZN-LRL1E page: https://zigbee.blakadder.com/Zemismart_ZN-LRL1E.html
- Hubitat Moes/Zemismart TS0601 driver includes `_TZE204_rzdkn5rx`: https://github.com/martinkura-svk/Hubitat/blob/31ffd3e50b99dd3b7e2bc63ccb300545155feb2b/Moes%20ZigBee%20Wall%20Switch

## Validation

- `node --check drivers/boiler_switch_energy/device.js`
- JSON parse: `app.json`, `drivers/boiler_switch_energy/driver.compose.json`, `data/fingerprints.json`, `lib/tuya/fingerprints.json`
- `npx mocha test\critical\forum-routing-regressions.test.js --timeout 5000`
- `npm run check:fingerprint-catalog`
- `npm run check:button-flows`
- `npm run validate:publish`
- `npm run build`
- `npm test`
- `npm run precommit`
- git pre-push gate passed during `git push`