### PR TITLE
[codex] Fix SmartLife WiFi DP handling

### DIFF
--- a/docs/reports/FORUM_SMARTLIFE_CLOUD_REFERENCE_2026-07-02.md
+++ b/docs/reports/FORUM_SMARTLIFE_CLOUD_REFERENCE_2026-07-02.md
@@ -1,0 +1,35 @@
+# Forum Smart Life Cloud Reference - 2026-07-02
+
+Source: https://community.homey.app/t/app-tuya-smart-life-smart-living/146735
+
+## Scope
+
+This Homey forum topic is for the official/cloud "Tuya - Smart Life. Smart Living" app, created on 2025-12-11 and last active in the fetched dump on 2026-06-27. It is not the native Zigbee support thread, but it contains useful cross-app signals for Tuya DP handling, pairing UX, raw commands, scaling, and offline diagnostics.
+
+## Timeline Signals
+
+- 2025-12-11 to 2025-12-13: users reported QR/login repair after Homey update/reboot, lights returning `[2001] 2001`, and devices becoming unavailable. Forum replies identify Tuya 2001 as device offline.
+- 2025-12-13 to 2026-01-23: unsupported or "unknown" devices repeatedly needed raw code/DP visibility: circuit breaker/meter, fan speed, CO2 detector, face-recognition access panel, power strip, cat feeder, and IR scenes.
+- 2026-02-14 to 2026-04-19: repeated energy/power scale complaints on power plugs and sockets. Users compare Tuya Cloud values against Homey values and mention tenfold/large kWh discrepancies.
+- 2026-03-18 to 2026-05-28: users ask how to discover which DP/code controls device actions and how to drive scene-like attributes from flows.
+- 2026-06-13 to 2026-06-21: an air conditioner reported ambient temperature as `205`; follow-up suggests divisor/scaling problems and later user reset/re-pair fixed it.
+- 2026-06-16: fan coil device exposed only temperature when added as unknown; requested heat/cool/ventilation and fan speed mode.
+- 2026-06-27: Pi-hole/DNS blocking can allow pairing but leave devices "not connected" in Homey while still working in Smart Life.
+
+## Cross-App Actions Applied
+
+- Classified Tuya cloud `2001` errors as reachability/offline, not unknown crashes.
+- Removed hidden `this.homey` timer dependencies from SmartLife QR polling and local TCP heartbeat/reconnect logic.
+- Hardened cloud/auth logging so Homey logger objects do not break circuit breaker logging.
+- Activated generic WiFi raw DP hooks and Flow cards:
+  - raw DP updates now populate `discovered_dps`;
+  - `wifi_generic_dp_changed` triggers with DP and value tokens;
+  - `wifi_generic_set_dp` can send bool, number, string, and JSON values.
+- Added configurable WiFi fan speed raw range. Default remains `0..100`, but devices requiring `1..6` can now set min/max without a dedicated driver rewrite.
+- Reused the same DP hook to revive existing WiFi water tank monitor custom DP handling.
+
+## Non-Goals
+
+- This does not clone the official cloud app or its cloud credentials.
+- This does not add native support for every cloud-only WiFi category from the thread.
+- Gmail crash-log processing was not available in this run; OAuth remained blocked in prior attempts.

--- a/drivers/wifi_fan/device.js
+++ b/drivers/wifi_fan/device.js
@@ -7,13 +7,32 @@ class WiFiFanDevice extends TuyaLocalDevice {
   // does not add a false measure_battery capability (fixes false-battery reports).
   get mainsPowered() { return true; }
 
+  _getFanSpeedRange() {
+    const min = Number(this.getSetting?.('fan_speed_min'));
+    const max = Number(this.getSetting?.('fan_speed_max'));
+    if (Number.isFinite(min) && Number.isFinite(max) && max > min) {
+      return { min, max };
+    }
+    return { min: 0, max: 100 };
+  }
+
   get dpMappings() {
     return {
       '1':  { capability: 'onoff', writable: true, transform: (v) => !!v, reverseTransform: (v) => !!v },
       '2':  { capability: null },
       '3':  { capability: 'dim', writable: true,
-        transform: (v) => Math.max(0, Math.min(1, v / 100)),
-        reverseTransform: (v) => Math.round(v * 100) },
+        transform: (v) => {
+          const val = Number(v);
+          if (!Number.isFinite(val)) return 0;
+          const { min, max } = this._getFanSpeedRange();
+          return Math.max(0, Math.min(1, (val - min) / (max - min)));
+        },
+        reverseTransform: (v) => {
+          const val = Number(v);
+          const { min, max } = this._getFanSpeedRange();
+          if (!Number.isFinite(val)) return min;
+          return Math.round(min + (Math.max(0, Math.min(1, val)) * (max - min)));
+        } },
       '4':  { capability: null },
       '6':  { capability: null },
       '8':  { capability: null },

--- a/drivers/wifi_fan/driver.compose.json
+++ b/drivers/wifi_fan/driver.compose.json
@@ -100,6 +100,28 @@
               }
             }
           ]
+        },
+        {
+          "id": "fan_speed_min",
+          "type": "number",
+          "label": {
+            "en": "Fan speed DP minimum"
+          },
+          "hint": {
+            "en": "Raw DP value for 0% speed. Keep 0 for percentage-based fans; use 1 for fans that expect 1-6."
+          },
+          "value": 0
+        },
+        {
+          "id": "fan_speed_max",
+          "type": "number",
+          "label": {
+            "en": "Fan speed DP maximum"
+          },
+          "hint": {
+            "en": "Raw DP value for 100% speed. Keep 100 for percentage-based fans; use 6 for fans that expect 1-6."
+          },
+          "value": 100
         }
       ]
     }

--- a/drivers/wifi_generic/device.js
+++ b/drivers/wifi_generic/device.js
@@ -1,5 +1,7 @@
 'use strict';
 const TuyaLocalDevice = require('../../lib/tuya-local/TuyaLocalDevice');
+const { stringifyDPValue } = require('../../lib/tuya-local/DPValueParser');
+
 class WiFiGenericDevice extends TuyaLocalDevice {
   get dpMappings() {
     return {
@@ -11,10 +13,40 @@ class WiFiGenericDevice extends TuyaLocalDevice {
     this.log('[WIFI-GENERIC] Generic Tuya WiFi device ready');
   }
 
-  _processDPUpdate(dps) {
-    super._processDPUpdate(dps);
+  async _processDPUpdate(dps) {
+    await super._processDPUpdate(dps);
     this.log('[WIFI-GENERIC] Raw DPs:', JSON.stringify(dps));
-    this.setSettings({ discovered_dps: JSON.stringify(dps) }).catch(() => {});
+
+    const discovered = this._mergeDiscoveredDPs(dps);
+    if (discovered.changed) {
+      this.setSettings({ discovered_dps: JSON.stringify(discovered.value) }).catch(() => {});
+    }
+
+    const triggers = Object.entries(dps || {}).map(([dp, value]) => {
+      return this.triggerFlowCard('wifi_generic_dp_changed', {
+        dp: String(dp),
+        value: stringifyDPValue(value),
+      }).catch(() => false);
+    });
+    await Promise.all(triggers);
+  }
+
+  _mergeDiscoveredDPs(dps) {
+    let current = {};
+    try {
+      current = JSON.parse(this.getSetting?.('discovered_dps') || '{}') || {};
+    } catch (_) {
+      current = {};
+    }
+
+    let changed = false;
+    for (const [dp, value] of Object.entries(dps || {})) {
+      if (!Object.prototype.hasOwnProperty.call(current, dp)) {
+        current[dp] = value;
+        changed = true;
+      }
+    }
+    return { changed, value: current };
   }
 
 

--- a/drivers/wifi_generic/driver.flow.compose.json
+++ b/drivers/wifi_generic/driver.flow.compose.json
@@ -72,6 +72,12 @@
               "title": {
                 "en": "String"
               }
+            },
+            {
+              "id": "json",
+              "title": {
+                "en": "JSON"
+              }
             }
           ]
         }

--- a/drivers/wifi_generic/driver.js
+++ b/drivers/wifi_generic/driver.js
@@ -1,5 +1,7 @@
 'use strict';
 const TuyaLocalDriver = require('../../lib/tuya-local/TuyaLocalDriver');
+const { parseDPValue } = require('../../lib/tuya-local/DPValueParser');
+
 class WiFiGenericDriver extends TuyaLocalDriver {
   /**
    * v7.0.12: Defensive getDeviceById override to prevent crashes during deserialization.
@@ -14,26 +16,30 @@ class WiFiGenericDriver extends TuyaLocalDriver {
     }
   }
 
-async onInit() {
+  async onInit() {
     await super.onInit();
-    if (this._flowCardsRegistered) {return;}
-    this._flowCardsRegistered = true;
+    if (this._wifiGenericFlowCardsRegistered) {return;}
+    this._wifiGenericFlowCardsRegistered = true;
 
-    
-    if (this._flowCardsRegistered) {return;}
-    this._flowCardsRegistered = true;
+    try {
+      const setDpCard = this.homey.flow.getActionCard('wifi_generic_set_dp');
+      setDpCard.registerRunListener(async (args) => {
+        if (!args.device || typeof args.device._setDP !== 'function') {
+          throw new Error('No WiFi generic device selected');
+        }
+        const dp = Number.isFinite(Number(args.dp)) ? Number(args.dp) : String(args.dp || '').trim();
+        if (dp === '') {
+          throw new Error('DP number is required');
+        }
+        const value = parseDPValue(args.value, args.type);
+        await args.device._setDP(dp, value);
+        return true;
+      });
+    } catch (err) {
+      this.log(`[WIFI-GENERIC-DRV] DP action card unavailable: ${err.message}`);
+    }
 
-    
     this.log('[WIFI-GENERIC-DRV] Generic WiFi driver initialized');
-    // v5.13.3: Flow card handlers
-
-  
-  
-  
-  
-  
-  
-  
   }
 }
 module.exports = WiFiGenericDriver;

--- a/drivers/wifi_water_tank_monitor/device.js
+++ b/drivers/wifi_water_tank_monitor/device.js
@@ -23,7 +23,7 @@ class WiFiWaterTankMonitorDevice extends TuyaLocalDevice {
 
   async _processDPUpdate(dps) {
     if (this._destroyed) return;
-    super._processDPUpdate(dps);
+    await super._processDPUpdate(dps);
     this.log('[WIFI-TANK] Raw DPs:', JSON.stringify(dps));
     
     // DP 1 - liquid_state
@@ -68,19 +68,19 @@ class WiFiWaterTankMonitorDevice extends TuyaLocalDevice {
         const val = newSettings[key];
         switch (key) {
           case 'installation_height': // DP19
-            await this.set({ dps: 19, set: val });
+            await this._setDP(19, val);
             this.log(`[WIFI-TANK] Sent DP19 installation_height = ${val}mm`);
             break;
           case 'liquid_depth_max': // DP21
-            await this.set({ dps: 21, set: val });
+            await this._setDP(21, val);
             this.log(`[WIFI-TANK] Sent DP21 liquid_depth_max = ${val}mm`);
             break;
           case 'max_set': // DP7
-            await this.set({ dps: 7, set: val });
+            await this._setDP(7, val);
             this.log(`[WIFI-TANK] Sent DP7 max_set = ${val}%`);
             break;
           case 'min_set': // DP8
-            await this.set({ dps: 8, set: val });
+            await this._setDP(8, val);
             this.log(`[WIFI-TANK] Sent DP8 min_set = ${val}%`);
             break;
         }

--- a/lib/tuya-local/DPValueParser.js
+++ b/lib/tuya-local/DPValueParser.js
@@ -1,0 +1,51 @@
+'use strict';
+
+function parseBoolean(value) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return value !== 0;
+  const normalized = String(value).trim().toLowerCase();
+  if (['true', '1', 'on', 'yes', 'y', 'open', 'enabled'].includes(normalized)) return true;
+  if (['false', '0', 'off', 'no', 'n', 'closed', 'disabled'].includes(normalized)) return false;
+  throw new Error(`Invalid boolean DP value: ${value}`);
+}
+
+function parseDPValue(value, type = 'string') {
+  const selectedType = String(type || 'string').toLowerCase();
+
+  if (selectedType === 'bool' || selectedType === 'boolean') {
+    return parseBoolean(value);
+  }
+
+  if (selectedType === 'number') {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      throw new Error(`Invalid numeric DP value: ${value}`);
+    }
+    return number;
+  }
+
+  if (selectedType === 'json') {
+    try {
+      return JSON.parse(String(value));
+    } catch (err) {
+      throw new Error(`Invalid JSON DP value: ${err.message}`);
+    }
+  }
+
+  return value === undefined || value === null ? '' : String(value);
+}
+
+function stringifyDPValue(value) {
+  if (value === undefined) return '';
+  if (typeof value === 'string') return value;
+  try {
+    return JSON.stringify(value);
+  } catch (_err) {
+    return String(value);
+  }
+}
+
+module.exports = {
+  parseDPValue,
+  stringifyDPValue,
+};

--- a/lib/tuya-local/TuyaCloudAPI.js
+++ b/lib/tuya-local/TuyaCloudAPI.js
@@ -13,12 +13,18 @@ const ENDPOINTS = {
   in: 'https://openapi.tuyain.com',
 };
 
+function createLogger(log) {
+  if (typeof log === 'function') return log;
+  if (log && typeof log.log === 'function') return (...args) => log.log(...args);
+  return () => {};
+}
+
 class TuyaCloudAPI {
   constructor({ accessId, accessKey, region = 'eu', log }) {
     this.endpoint = ENDPOINTS[region] || ENDPOINTS.eu;
     this.accessId = accessId;
     this.accessKey = accessKey;
-    this.log = log || console;
+    this.log = createLogger(log);
     this.tokenInfo = { access_token: '', refresh_token: '', uid: '', expire: 0 };
 
     // v9.0.40 TITAN: Circuit breaker for fault tolerance
@@ -99,10 +105,7 @@ class TuyaCloudAPI {
     const bodyStr = body ? JSON.stringify(body) : '';
     const contentHash = crypto.createHash('sha256').update(bodyStr).digest('hex');
     const headers = `client_id:${  this.accessId  }\n`;
-    let url = path;
-    if (params && Object.keys(params).length) {
-      url += `?${  Object.entries(params).map(([k, v]) => `${k  }=${  v}`).join('&')}`;
-    }
+    const url = TuyaCloudAPI._buildSignedPath(path, params);
     const stringToSign = `${method.toUpperCase()  }\n${  contentHash  }\n${  headers  }\n${  url}`;
     const message = this.accessId + accessToken + timestamp + nonce + stringToSign;
     const sign = crypto.createHmac('sha256', this.accessKey).update(message).digest('hex').toUpperCase();
@@ -117,8 +120,7 @@ class TuyaCloudAPI {
   async _rawRequest(method, path, params, body) {
     const timestamp = Date.now().toString();
     const { sign, nonce } = this._sign(method, path, params, body, timestamp);
-    const url = new URL(this.endpoint + path);
-    if (params) {Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));}
+    const url = new URL(this.endpoint + TuyaCloudAPI._buildSignedPath(path, params));
     return new Promise((resolve, reject) => {
       const options = {
         method,
@@ -137,7 +139,21 @@ class TuyaCloudAPI {
       const req = https.request(options, (res) => {
         let data = '';
         res.on('data', chunk => data += chunk);
-        res.on('end', () => { try { resolve(JSON.parse(data)); } catch { resolve({ success: false }); } });
+        res.on('end', () => {
+          if (!data) {
+            resolve({ success: false, code: res.statusCode, msg: `Empty Tuya response (${res.statusCode})` });
+            return;
+          }
+          try {
+            const parsed = JSON.parse(data);
+            if (parsed && parsed.success === false && !parsed.msg && parsed.code) {
+              parsed.msg = TuyaCloudAPI.describeError(parsed.code);
+            }
+            resolve(parsed);
+          } catch (err) {
+            resolve({ success: false, code: res.statusCode, msg: `Invalid Tuya JSON response: ${err.message}` });
+          }
+        });
       });
       // v9.0.40: 15s timeout to prevent hanging requests
       req.setTimeout(15000, () => {
@@ -151,6 +167,20 @@ class TuyaCloudAPI {
 
   async _get(path, params) { return this._request('GET', path, params); }
   async _post(path, body) { return this._request('POST', path, null, body); }
+
+  static describeError(code) {
+    const normalized = String(code);
+    if (normalized === '2001') return 'Device offline or not reachable in Tuya cloud';
+    return `Tuya API error ${normalized}`;
+  }
+
+  static _buildSignedPath(path, params) {
+    const url = new URL(`http://localhost${path}`);
+    Object.entries(params || {})
+      .sort(([a], [b]) => a.localeCompare(b))
+      .forEach(([key, value]) => url.searchParams.set(key, String(value)));
+    return `${url.pathname}${url.search}`;
+  }
 }
 
 module.exports = TuyaCloudAPI;

--- a/lib/tuya-local/TuyaLocalClient.js
+++ b/lib/tuya-local/TuyaLocalClient.js
@@ -194,8 +194,8 @@ class TuyaLocalClient extends EventEmitter {
 
   _startHeartbeat() {
     this._stopHeartbeat();
-    // v9.0.40: Use native setInterval (no homey dependency required)
-    this._heartbeatTimer = this.homey.setInterval(() => {
+    // Use native timers: this transport helper is not a Homey object.
+    this._heartbeatTimer = globalThis.setInterval(() => {
       if (this._destroyed) return;
       if (!this._connected || !this._device) {return;}
       this._missedHeartbeats++;
@@ -209,6 +209,7 @@ class TuyaLocalClient extends EventEmitter {
       }
       try { this._device.refresh({ schema: true }); } catch (e) { this._log('[TUYA-TCP] Heartbeat refresh failed:', e.message); }
     }, this._heartbeatInterval);
+    this._heartbeatTimer.unref?.();
   }
 
   _stopHeartbeat() {
@@ -265,10 +266,7 @@ class TuyaLocalClient extends EventEmitter {
     if (wait > 0) {await new Promise((r) => globalThis.setTimeout(r, wait));}
     try {
       // v9.0.40: Command timeout to prevent queue stall
-      const result = await Promise.race([
-        cmd.fn(),
-        new Promise((_, reject) => this.homey.setTimeout(() => { if (this._destroyed) return; reject(new Error('Command timeout')); }, this._commandTimeout))
-      ]);
+      const result = await this._withTimeout(cmd.fn(), this._commandTimeout, 'Command timeout');
       this._lastCommandTime = Date.now();
       cmd.resolve(result);
     } catch (err) {
@@ -335,12 +333,13 @@ class TuyaLocalClient extends EventEmitter {
     this.emit('connection-state', this._connectionState);
     const delay = Math.min(this._reconnectDelay, this._maxReconnectDelay);
     this._log(`[TUYA-TCP] Reconnecting in ${  delay / 1000  }s... (attempt ${this._totalReconnects})`);
-    this._reconnectTimer = this.homey.setTimeout(async () => {
+    this._reconnectTimer = globalThis.setTimeout(async () => {
       if (this._destroyed) return;
       this._reconnectTimer = null;
       this._reconnectDelay = Math.min(this._reconnectDelay * 1.5, this._maxReconnectDelay);
       await this.connect();
     }, delay);
+    this._reconnectTimer.unref?.();
   }
 
   _clearReconnect() {
@@ -375,6 +374,21 @@ class TuyaLocalClient extends EventEmitter {
       cmd.reject(new Error(reason));
     }
     this._commandBusy = false;
+  }
+
+  _withTimeout(promise, timeoutMs, message) {
+    let timer = null;
+    return Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = globalThis.setTimeout(() => {
+          reject(new Error(this._destroyed ? 'Device destroyed' : message));
+        }, timeoutMs);
+        timer.unref?.();
+      })
+    ]).finally(() => {
+      if (timer) clearTimeout(timer);
+    });
   }
 
   async destroy() {

--- a/lib/tuya-local/TuyaLocalDevice.js
+++ b/lib/tuya-local/TuyaLocalDevice.js
@@ -279,12 +279,22 @@ class TuyaLocalDevice extends Homey.Device {
       this._dpCache.updateFromDps(data.dps);
     }
 
+    try {
+      await this._processDPUpdate(data.dps);
+    } catch (err) {
+      this.error('[TUYA-TCP] Raw DP hook failed:', err.message || err);
+    }
+
     for (const cap of this.capabilityMap) {
       if (data.dps[cap.dp] !== undefined) {
         const value = cap.fromDevice ? cap.fromDevice(data.dps[cap.dp]) : data.dps[cap.dp];
         await this.safeSetCapabilityValue(cap.capability, value).catch(this.error);
       }
     }
+  }
+
+  async _processDPUpdate(_dps) {
+    // Optional subclass hook for generic/raw DP drivers.
   }
 
   async _setDP(dp, value) {

--- a/lib/tuya-local/TuyaSmartLifeAuth.js
+++ b/lib/tuya-local/TuyaSmartLifeAuth.js
@@ -18,11 +18,24 @@ const REGIONS = {
 const TUYA_CLIENT_ID = 'HA_3y9q4ak7g4ephrvfoju';
 const TUYA_SCHEMA = 'smartlife';
 
+function createLogger(log) {
+  if (typeof log === 'function') return log;
+  if (log && typeof log.log === 'function') return (...args) => log.log(...args);
+  return () => {};
+}
+
+function sleep(ms) {
+  return new Promise(resolve => {
+    const timer = globalThis.setTimeout(resolve, ms);
+    timer.unref?.();
+  });
+}
+
 class TuyaSmartLifeAuth {
   constructor({ region = 'eu', log } = {}) {
     this.region = region;
     this.endpoint = (REGIONS[region] || REGIONS.eu).endpoint;
-    this.log = log || console;
+    this.log = createLogger(log);
     this.tokenInfo = null;
     this.userCode = null;
     this.qrCode = null;
@@ -78,7 +91,9 @@ class TuyaSmartLifeAuth {
         if (res.result.endpoint) {this.endpoint = res.result.endpoint;}
         return { success: true, tokenInfo: this.tokenInfo };
       }
-      await new Promise(r => this.homey.setTimeout(r, 3000));
+      const elapsed = Date.now() - start;
+      const remaining = Math.max(0, maxWaitMs - elapsed);
+      await sleep(Math.min(3000, Math.max(25, remaining)));
     }
     return { success: false, error: 'QR code scan timeout' };
   }

--- a/lib/utils/ErrorClassifier.js
+++ b/lib/utils/ErrorClassifier.js
@@ -27,6 +27,9 @@ function classifyError(err) {
 
   // Reachability errors
   if (msg.includes('could not reach device') ||
+      msg.includes('[2001]') ||
+      msg === '2001' ||
+      msg.includes('tuya error: 2001') ||
       msg.includes('timeout') ||
       msg.includes('econnreset') ||
       msg.includes('epipe') ||

--- a/test/critical/smartlife-wifi-regressions.test.js
+++ b/test/critical/smartlife-wifi-regressions.test.js
@@ -1,0 +1,143 @@
+'use strict';
+
+/* global describe, it */
+
+const assert = require('assert');
+const Module = require('module');
+
+const originalLoad = Module._load;
+Module._load = function loadWithHomeyMock(request, parent, isMain) {
+  if (request === 'homey') {
+    return {
+      Device: class {},
+      Driver: class {},
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const { parseDPValue, stringifyDPValue } = require('../../lib/tuya-local/DPValueParser');
+const TuyaLocalClient = require('../../lib/tuya-local/TuyaLocalClient');
+const TuyaLocalDevice = require('../../lib/tuya-local/TuyaLocalDevice');
+const TuyaCloudAPI = require('../../lib/tuya-local/TuyaCloudAPI');
+const TuyaSmartLifeAuth = require('../../lib/tuya-local/TuyaSmartLifeAuth');
+const { ERROR_CATEGORY, classifyError } = require('../../lib/utils/ErrorClassifier');
+const WiFiFanDevice = require('../../drivers/wifi_fan/device');
+const WiFiGenericDevice = require('../../drivers/wifi_generic/device');
+
+describe('SmartLife/Tuya WiFi regressions', () => {
+  it('parses raw DP flow values including JSON payloads', () => {
+    assert.strictEqual(parseDPValue('on', 'bool'), true);
+    assert.strictEqual(parseDPValue('42.5', 'number'), 42.5);
+    assert.deepStrictEqual(parseDPValue('{"scene":33}', 'json'), { scene: 33 });
+    assert.strictEqual(stringifyDPValue({ scene: 33 }), '{"scene":33}');
+  });
+
+  it('classifies Tuya cloud 2001 as reachability/offline', () => {
+    assert.strictEqual(classifyError(new Error('[2001] 2001')), ERROR_CATEGORY.REACHABILITY);
+    assert.strictEqual(classifyError(new Error('Tuya error: 2001')), ERROR_CATEGORY.REACHABILITY);
+  });
+
+  it('builds sorted Tuya cloud query paths for signing and requests', () => {
+    assert.strictEqual(
+      TuyaCloudAPI._buildSignedPath('/v1.0/test', { z: 'last value', a: 'first value' }),
+      '/v1.0/test?a=first+value&z=last+value'
+    );
+  });
+
+  it('keeps QR polling independent from Homey timer APIs', async () => {
+    const auth = new TuyaSmartLifeAuth({ log: () => {} });
+    auth.qrCode = 'qr-token';
+    auth.userCode = 'user-code';
+    let calls = 0;
+    auth._request = async () => {
+      calls++;
+      return { success: false, msg: 'pending' };
+    };
+
+    const result = await auth.pollQRLogin(35);
+
+    assert.strictEqual(result.success, false);
+    assert.match(result.error, /timeout/i);
+    assert(calls >= 1);
+  });
+
+  it('keeps local TCP heartbeat independent from Homey timer APIs', async () => {
+    let refreshes = 0;
+    const client = new TuyaLocalClient({
+      id: 'device-id',
+      key: 'local-key',
+      heartbeatInterval: 5,
+      log: () => {},
+    });
+    client._connected = true;
+    client._device = {
+      refresh: () => { refreshes++; },
+      disconnect: async () => {},
+      removeAllListeners: () => {},
+    };
+
+    client._startHeartbeat();
+    await new Promise(resolve => setTimeout(resolve, 20));
+    await client.destroy();
+
+    assert(refreshes >= 1);
+  });
+
+  it('settles command timeouts even after the local client is destroyed', async () => {
+    const client = new TuyaLocalClient({ log: () => {}, commandTimeout: 5 });
+    client._destroyed = true;
+
+    await assert.rejects(
+      client._withTimeout(new Promise(() => {}), 5, 'Command timeout'),
+      /Device destroyed/
+    );
+  });
+
+  it('calls the raw DP hook from TuyaLocalDevice data handling', async () => {
+    const device = Object.create(TuyaLocalDevice.prototype);
+    const dps = { 1: true, 25: '{"scene":33}' };
+    let seen = null;
+
+    Object.defineProperty(device, 'capabilityMap', { value: [] });
+    device._destroyed = false;
+    device._dpCache = null;
+    device.log = () => {};
+    device.error = () => {};
+    device._processDPUpdate = async value => { seen = value; };
+
+    await TuyaLocalDevice.prototype._onData.call(device, { dps });
+
+    assert.deepStrictEqual(seen, dps);
+  });
+
+  it('tracks generic WiFi discovered DP keys without rewriting known subsets', () => {
+    const device = Object.create(WiFiGenericDevice.prototype);
+    device.getSetting = () => '{"1":true}';
+
+    assert.deepStrictEqual(device._mergeDiscoveredDPs({ 1: false, 2: 'new' }), {
+      changed: true,
+      value: { 1: true, 2: 'new' },
+    });
+
+    device.getSetting = () => '{"1":true,"2":"old"}';
+    assert.deepStrictEqual(device._mergeDiscoveredDPs({ 2: 'new' }), {
+      changed: false,
+      value: { 1: true, 2: 'old' },
+    });
+  });
+
+  it('supports fan speed ranges such as Tuya 1-6 instead of only percentages', () => {
+    const fan = Object.create(WiFiFanDevice.prototype);
+    fan.getSetting = key => ({ fan_speed_min: 1, fan_speed_max: 6 }[key]);
+
+    const speed = fan.dpMappings['3'];
+
+    assert.strictEqual(speed.reverseTransform(0), 1);
+    assert.strictEqual(speed.reverseTransform(1), 6);
+    assert.strictEqual(speed.transform(1), 0);
+    assert.strictEqual(speed.transform(6), 1);
+    assert.strictEqual(speed.transform(undefined), 0);
+    assert.strictEqual(speed.reverseTransform(undefined), 1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a dated Smart Life cloud forum reference from topic 146735 and folds the user-facing findings into WiFi/SmartLife hardening.
- Fixes SmartLife/Tuya WiFi crash paths around timer usage, QR login polling, Tuya cloud error parsing, and 2001/offline classification.
- Restores generic WiFi raw DP flow support with bool/number/string/JSON parsing, raw DP change triggers, configurable 1-6 fan speed mapping, and water tank raw DP settings fixes.

## Validation
- `node --check` on touched JS files
- JSON parse checks for `app.json` and touched compose files
- `npx mocha test\\critical\\smartlife-wifi-regressions.test.js --timeout 5000`
- targeted dynamic-DP/device telemetry regression run
- `npm run check:button-flows`
- `npm run check:fingerprint-catalog`
- `npm run validate:publish`
- `npm run build`
- `npm test`
- `npm run precommit`
- pre-push gate during `git push`