### PR TITLE
[codex] Skip daily promotion when version is already tested

### DIFF
--- a/.github/workflows/daily-promote-to-test.yml
+++ b/.github/workflows/daily-promote-to-test.yml
@@ -48,15 +48,29 @@ jobs:
           sleep 120
           echo "Done waiting"
 
+      - name: Check current version is already on test
+        id: precheck_test
+        env:
+          HOMEY_PAT: ${{ secrets.HOMEY_PAT }}
+        run: |
+          if node .github/scripts/verify-test-version.js; then
+            echo "already_test=true" >> "$GITHUB_OUTPUT"
+            echo "Current version is already on the Homey test channel; promotion tiers can be skipped."
+          else
+            echo "already_test=false" >> "$GITHUB_OUTPUT"
+            echo "Current version is not confirmed on test yet; running promotion tiers."
+          fi
+
       # Tier 1: Browser automation (Puppeteer) — the ONLY reliable method
       # Athom has no public API for draft→test, only the web UI works.
       - name: "Install Puppeteer"
         id: puppeteer_install
+        if: steps.precheck_test.outputs.already_test != 'true'
         continue-on-error: true
         run: npm install puppeteer --no-save
       - name: "Tier 1: Promote via Browser (Puppeteer)"
         id: puppeteer
-        if: steps.puppeteer_install.outcome == 'success'
+        if: steps.precheck_test.outputs.already_test != 'true' && steps.puppeteer_install.outcome == 'success'
         continue-on-error: true
         timeout-minutes: 5
         env:
@@ -67,7 +81,7 @@ jobs:
       # Tier 2: OAuth password grant (gets real access token)
       - name: "Tier 2: Promote via OAuth"
         id: oauth
-        if: steps.puppeteer.outcome != 'success'
+        if: steps.precheck_test.outputs.already_test != 'true' && steps.puppeteer.outcome != 'success'
         continue-on-error: true
         timeout-minutes: 5
         env:
@@ -82,7 +96,7 @@ jobs:
       # Tier 3: API attempt with PAT
       - name: "Tier 3: Promote via API (PAT)"
         id: api
-        if: steps.puppeteer.outcome != 'success' && steps.oauth.outcome != 'success'
+        if: steps.precheck_test.outputs.already_test != 'true' && steps.puppeteer.outcome != 'success' && steps.oauth.outcome != 'success'
         continue-on-error: true
         timeout-minutes: 5
         env:
@@ -92,7 +106,7 @@ jobs:
       # Tier 4: Retry Puppeteer after 30s
       - name: "Tier 4: Verify retry (Puppeteer)"
         id: retry
-        if: steps.puppeteer.outcome != 'success' && steps.oauth.outcome != 'success' && steps.api.outcome != 'success'
+        if: steps.precheck_test.outputs.already_test != 'true' && steps.puppeteer.outcome != 'success' && steps.oauth.outcome != 'success' && steps.api.outcome != 'success'
         continue-on-error: true
         timeout-minutes: 5
         env:
@@ -115,7 +129,9 @@ jobs:
 
       - name: Assert promotion result
         run: |
-          if [ "${{ steps.puppeteer.outcome }}" != "success" ] && \
+          if [ "${{ steps.precheck_test.outputs.already_test }}" = "true" ]; then
+            echo "Current version was already on test; no promotion tier was needed."
+          elif [ "${{ steps.puppeteer.outcome }}" != "success" ] && \
              [ "${{ steps.oauth.outcome }}" != "success" ] && \
              [ "${{ steps.api.outcome }}" != "success" ] && \
              [ "${{ steps.retry.outcome }}" != "success" ]; then
@@ -134,6 +150,7 @@ jobs:
           VER=$(node -p "require('./app.json').version" 2>/dev/null || echo "?")
           APP_ID=$(node -p "require('./app.json').id" 2>/dev/null || echo "com.dlnraja.tuya.zigbee")
           echo "## Draft to Test" >> $GITHUB_STEP_SUMMARY
+          echo "Precheck already on test: ${{ steps.precheck_test.outputs.already_test }}" >> $GITHUB_STEP_SUMMARY
           echo "v$VER | Puppeteer=${{ steps.puppeteer.outcome }} | OAuth=${{ steps.oauth.outcome }} | API=${{ steps.api.outcome }} | Retry=${{ steps.retry.outcome }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "[Test link](https://homey.app/a/$APP_ID/test/) | [Manage](https://tools.developer.homey.app/apps/app/$APP_ID/versions)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Adds a precheck to `Daily Draft to Test` so it exits early when the current app version is already confirmed on the Homey test channel.
- Skips Puppeteer/OAuth/API promotion tiers in that already-tested case, preventing historical `processing_failed` builds from creating noisy follow-up diagnostics.

## Diagnosis
- Live dashboard monitor shows latest build `#2536` / `v9.0.165` is `test`.
- The visible `processing_failed` build is historical: `#2533` / `v9.0.163`, `stateMeta=Bad Gateway`.
- The Daily workflow also confirmed `already-test #2536 v9.0.165 test`.

## Validation
- `python -c "import yaml..."` parse of `daily-promote-to-test.yml`
- `node scripts/ci/validate-github-actions-policy.js`
- `npm run precommit`
- pre-push gate during `git push`
