### PR TITLE
[codex] Report runtime diagnostic source failures

### DIFF
--- a/.github/scripts/collect-diagnostics.js
+++ b/.github/scripts/collect-diagnostics.js
@@ -9,6 +9,14 @@ const DDIR=path.join(ROOT,'drivers');
 const anonId=id=>id?crypto.createHash('sha256').update(id).digest('hex').slice(0,12):'unk';
 const loadJ=f=>{try{return JSON.parse(fs.readFileSync(f,'utf8'))}catch{return null}};
 const saveJ=(f,d)=>{const safe=privacy.redactObject(d);privacy.assertNoLeaks(safe,f);fs.mkdirSync(path.dirname(f),{recursive:true});fs.writeFileSync(f,JSON.stringify(safe,null,2))};
+function pushSourceIssues(summary,source,issues,level){
+  if(!Array.isArray(issues))return;
+  for(const issue of issues){
+    const msg=typeof issue==='string'?issue:(issue?.message||issue?.err||issue?.error||issue?.code);
+    if(!msg)continue;
+    summary.errors.push({err:privacy.redact(msg),source,level:level||issue?.level||'error',code:issue?.code||null});
+  }
+}
 
 function buildIdx(){
   const idx=new Map();
@@ -28,6 +36,12 @@ async function main(){
 
   // Source 1: Gmail diagnostics report
   const gmailR=loadJ(path.join(SD,'diagnostics-report.json'));
+  if(gmailR){
+    pushSourceIssues(summary,'gmail',gmailR.errors,'error');
+    if(gmailR.access?.gmail?.ok===false){
+      summary.sources.gmail_access='unavailable';
+    }
+  }
   if(gmailR?.diagnostics){
     summary.sources.gmail=gmailR.diagnostics.length;
     for(const d of gmailR.diagnostics){
@@ -39,6 +53,13 @@ async function main(){
 
   // Source 2: Homey device report (from homey-device-diagnostics.js)
   const homeyR=loadJ(path.join(SD,'homey-device-report.json'));
+  if(homeyR){
+    pushSourceIssues(summary,'homey_report',homeyR.errors,'error');
+    pushSourceIssues(summary,'homey_report',homeyR.warnings,'warning');
+    if(!homeyR.auth?.canListHomeys){
+      summary.sources.homey_runtime='unavailable';
+    }
+  }
   if(homeyR?.homeys){
     summary.sources.homey_report=homeyR.homeys.length;
     for(const h of homeyR.homeys){

--- a/.github/scripts/fetch-gmail-diagnostics.js
+++ b/.github/scripts/fetch-gmail-diagnostics.js
@@ -387,13 +387,60 @@ async function researchAndImplement(allNewFPs,idx){
   return{researched,added,details};
 }
 
+function runSummary(fetchOptions,extra={}){
+  return{mode:fetchOptions.allHistory?'all-history':'recent',since:fetchOptions.since||'rolling-30-days',
+    until:fetchOptions.until||'now',chunkDays:fetchOptions.chunkDays,maxTotalResults:fetchOptions.maxTotalResults,
+    maxResults:fetchOptions.maxResults,reprocess:fetchOptions.reprocess,stateLimit:fetchOptions.stateLimit,
+    ...extra};
+}
+
+function writeAccessFailureReport(fetchOptions,code,message,extra={}){
+  const now=new Date().toISOString();
+  const report=privacy.redactObject({timestamp:now,count:0,
+    run:runSummary(fetchOptions,extra),
+    access:{gmail:{ok:false,mode:'imap',code,message:privacy.redact(message)}},
+    byType:{},newFingerprints:[],
+    history:{diagnosticsAnalyzed:0,score:0,status:'blocked',categories:[],recommendedChecks:[],topErrors:[],latestEvents:[],missingGuardrails:[]},
+    deepResearch:{researched:0,added:0,details:[],autoImplement:fetchOptions.autoImplement},
+    diagnostics:[],
+    errors:[{source:'gmail',code,message:privacy.redact(message)}]});
+  fs.mkdirSync(SD,{recursive:true});
+  privacy.assertNoLeaks(report,RF);
+  fs.writeFileSync(RF,JSON.stringify(report,null,2));
+  const HF=path.join(SD,'gmail-token-health.json');
+  let consecutiveFails=1,lastOk=null,previousChecks=[];
+  try{
+    const existing=JSON.parse(fs.readFileSync(HF,'utf8'));
+    if(existing){
+      consecutiveFails=(Number(existing.consecutiveFails)||0)+1;
+      lastOk=existing.lastOk||null;
+      previousChecks=Array.isArray(existing.checks)?existing.checks.slice(-19):[];
+    }
+  }catch{}
+  const check={time:now,ok:false,mode:'imap',code,message:privacy.redact(message)};
+  const health=privacy.redactObject({mode:'imap',lastOk,lastFail:now,consecutiveFails,
+    errorCode:code,checks:[...previousChecks,check]});
+  privacy.assertNoLeaks(health,HF);
+  fs.writeFileSync(HF,JSON.stringify(health,null,2));
+}
+
 async function main(){
   const fetchOptions=parseFetchOptions(process.argv.slice(2));
   // v5.12.6: IMAP-only — no OAuth, no token expiry, permanent
   const e=process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL;
   const p=process.env.GMAIL_APP_PASSWORD||process.env.HOMEY_PASSWORD;
-  if(!e||!p){console.error('IMAP credentials missing. Set GMAIL_EMAIL + GMAIL_APP_PASSWORD (see SECRETS.md)');process.exit(1)}
-  if(!imap){console.error('gmail-imap-reader not available. npm install imapflow');process.exit(1)}
+  if(!e||!p){
+    const msg='IMAP credentials missing. Refresh the Gmail app credential, then rerun Gmail diagnostics.';
+    console.error('IMAP credentials missing. Set GMAIL_EMAIL + GMAIL_APP_PASSWORD (see SECRETS.md)');
+    writeAccessFailureReport(fetchOptions,'missing_imap_credentials',msg);
+    process.exit(1);
+  }
+  if(!imap){
+    const msg='gmail-imap-reader is unavailable. Install the IMAP dependencies before rerunning Gmail diagnostics.';
+    console.error('gmail-imap-reader not available. npm install imapflow');
+    writeAccessFailureReport(fetchOptions,'imap_reader_unavailable',msg);
+    process.exit(1);
+  }
   console.log('IMAP-only mode — connecting as',safeAlias('account',e));
   console.log('Diagnostics fetch options:',JSON.stringify({mode:fetchOptions.allHistory?'all-history':'recent',
     since:fetchOptions.since||'rolling-30-days',until:fetchOptions.until||'now',
@@ -431,7 +478,9 @@ async function main(){
     }
   }
   if(imapConnectionFailed&&!emails.length){
+    const msg='IMAP connection failed before diagnostics could be fetched. Refresh the Gmail app credential, then rerun Gmail Diagnostics.';
     console.error('::error::IMAP connection failed before diagnostics could be fetched. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD secrets, then rerun Gmail Diagnostics.');
+    writeAccessFailureReport(fetchOptions,'imap_connection_failed',msg,{windows:windows.length,fetched:0});
     process.exit(1);
   }
   if(imapConnectionFailed){
@@ -533,10 +582,7 @@ async function main(){
   const bt={};for(const r of res)bt[r.type]=(bt[r.type]||0)+1;
   const history=analyzeHistory(res);
   const report=privacy.redactObject({timestamp:st.lastCheck,count:res.length,
-    run:{mode:fetchOptions.allHistory?'all-history':'recent',since:fetchOptions.since||'rolling-30-days',
-      until:fetchOptions.until||'now',chunkDays:fetchOptions.chunkDays,maxTotalResults:fetchOptions.maxTotalResults,
-      maxResults:fetchOptions.maxResults,reprocess:fetchOptions.reprocess,stateLimit:fetchOptions.stateLimit,
-      fetched:emails.length,skippedAlreadyProcessed},
+    run:runSummary(fetchOptions,{fetched:emails.length,skippedAlreadyProcessed}),
     byType:bt,newFingerprints:newFPs,history,deepResearch:impl,diagnostics:res});
   privacy.assertNoLeaks(report,RF);
   fs.writeFileSync(RF,JSON.stringify(report,null,2));

--- a/.github/scripts/homey-device-diagnostics.js
+++ b/.github/scripts/homey-device-diagnostics.js
@@ -10,7 +10,6 @@ const STATE=path.join(__dirname,'..','state');
 const REPORT=path.join(STATE,'homey-device-report.json');
 const DDIR=path.join(__dirname,'..','..','drivers');
 const APP='com.dlnraja.tuya.zigbee';
-if(!TOKENS.length){console.log('HOMEY_PAT_API/HOMEY_PAT not set - skip');process.exit(1);}
 function log(t){console.log(t);if(SUM)fs.appendFileSync(SUM,t+'\n');}
 async function api(url){
   const r=await fetchWithRetry(url,{headers:{'Authorization':'Bearer '+PAT}},{retries:3,label:'homeyAPI'});
@@ -30,22 +29,61 @@ function getLocalFPs(){
   }catch{}
   return fps;
 }
+function baseReport(){
+  return{date:new Date().toISOString(),appId:APP,status:'incomplete',
+    auth:{tokensProvided:TOKENS.length,authenticated:false,canListHomeys:false},
+    homeys:[],localFPs:getLocalFPs().size,warnings:[],errors:[]};
+}
+function addIssue(report,level,code,message){
+  const target=level==='error'?report.errors:report.warnings;
+  target.push({source:'homey_device_diagnostics',code,message:privacy.redact(message)});
+}
+function saveReport(report){
+  fs.mkdirSync(STATE,{recursive:true});
+  const safe=privacy.redactObject(report);privacy.assertNoLeaks(safe,REPORT);
+  fs.writeFileSync(REPORT,JSON.stringify(safe,null,2)+'\n');
+}
+if(!TOKENS.length){
+  const report=baseReport();
+  addIssue(report,'error','missing_homey_credential','Homey runtime diagnostics could not run because no credential is configured.');
+  saveReport(report);
+  console.log('HOMEY_PAT_API/HOMEY_PAT not set - skip');
+  process.exit(1);
+}
 async function main(){
   log('## Homey Device Diagnostics');
+  const report=baseReport();
   let me=null;
   for(const t of TOKENS){
     PAT=t;
-    try{me=await api('https://api.athom.com/user/me');log('Auth OK (token ****)');break;}catch(e){log('Token **** failed: '+privacy.redact(e.message));}
+    try{me=await api('https://api.athom.com/user/me');report.auth.authenticated=true;log('Auth OK (token ****)');break;}catch(e){
+      addIssue(report,'warning','homey_auth_attempt_failed','A Homey credential failed authentication: '+privacy.redact(e.message));
+      log('Token **** failed: '+privacy.redact(e.message));
+    }
   }
-  if(!me){log('::error::All tokens failed for api.athom.com');process.exit(0);}
+  if(!me){
+    addIssue(report,'error','homey_auth_failed','All configured Homey credentials failed authentication.');
+    saveReport(report);
+    log('::error::All tokens failed for api.athom.com');
+    process.exit(1);
+  }
   log('User: '+privacy.alias('homey-user',(me.id||me.email||me.firstname||'unknown')));
   let homeys=[];
-  try{homeys=await api('https://api.athom.com/user/me/homey');}catch(e){log('::warning::Cannot list Homeys: '+privacy.redact(e.message)+' (PAT scope may be limited)');}
-  if(!homeys||!homeys.length){log('No Homeys found (try a full-scope OAuth token)');return;}
+  try{homeys=await api('https://api.athom.com/user/me/homey');report.auth.canListHomeys=true;}catch(e){
+    addIssue(report,'warning','homey_list_failed','Cannot list Homeys through the current Homey credential: '+privacy.redact(e.message));
+    log('::warning::Cannot list Homeys: '+privacy.redact(e.message)+' (PAT scope may be limited)');
+  }
+  if(!homeys||!homeys.length){
+    addIssue(report,'warning','homey_runtime_unavailable','No Homeys were accessible, so live runtime crash/device diagnostics were not collected.');
+    saveReport(report);
+    log('No Homeys found (try a full-scope OAuth token)');
+    return;
+  }
   log('Found '+homeys.length+' Homey(s)');
   const localFPs=getLocalFPs();
+  report.localFPs=localFPs.size;
+  report.status='complete';
   log('Local fingerprints: '+localFPs.size);
-  const report={date:new Date().toISOString(),homeys:[],localFPs:localFPs.size};
   for(const h of homeys){
     log('\n### Homey: '+homeyAlias(h.id||h.name));
     const base='https://'+h.id+'.connect.athom.com/api';
@@ -81,9 +119,7 @@ async function main(){
     if(zigbee?.nodes)hReport.zigbeeRouters=(Object.values(zigbee.nodes).filter(n=>n.type==='router')).length;
     report.homeys.push(hReport);
   }
-  fs.mkdirSync(STATE,{recursive:true});
-  const safe=privacy.redactObject(report);privacy.assertNoLeaks(safe,REPORT);
-  fs.writeFileSync(REPORT,JSON.stringify(safe,null,2)+'\n');
+  saveReport(report);
   log('\nReport saved to '+path.relative(process.cwd(),REPORT));
 }
 main().catch(e=>{console.error('Fatal:',privacy.redact(e.message));process.exit(1);});

--- a/scripts/ci/diagnostic-history-gate.js
+++ b/scripts/ci/diagnostic-history-gate.js
@@ -108,6 +108,9 @@ function npmScripts() {
 }
 
 function normalizeError(value) {
+  if (value && typeof value === 'object') {
+    value = value.err || value.error || value.message || value.code || JSON.stringify(value);
+  }
   return privacy.redact(String(value || '').replace(/\s+/g, ' ').trim()).substring(0, 180);
 }
 
@@ -117,11 +120,27 @@ function textFor(entry) {
     entry.subj,
     entry.subject,
     entry.error,
+    entry.err,
     entry.message,
+    entry.code,
     entry.crashInfo && entry.crashInfo.crashApp,
     Array.isArray(entry.errs) ? entry.errs.join(' ') : '',
     entry.crashInfo && Array.isArray(entry.crashInfo.stackTraces) ? entry.crashInfo.stackTraces.join(' ') : '',
   ].filter(Boolean).join(' ');
+}
+
+function aggregateErrorEntry(error) {
+  if (error && typeof error === 'object') {
+    const message = error.err || error.error || error.message || error.code || JSON.stringify(error);
+    return {
+      type: 'aggregate_error',
+      error: message,
+      code: error.code || null,
+      level: error.level || null,
+      source: error.source || 'aggregate',
+    };
+  }
+  return { type: 'aggregate_error', error, source: 'aggregate' };
 }
 
 function entriesFromSources(sources) {
@@ -134,7 +153,7 @@ function entriesFromSources(sources) {
     entries.push(...aggregate.reports.map(e => ({ ...e, source: 'aggregate' })));
   }
   if (aggregate && Array.isArray(aggregate.errors)) {
-    entries.push(...aggregate.errors.map(e => ({ type: 'aggregate_error', error: e, source: 'aggregate' })));
+    entries.push(...aggregate.errors.map(aggregateErrorEntry));
   }
   return entries;
 }


### PR DESCRIPTION
## What changed
- Write sanitized Gmail diagnostic reports even when IMAP credentials are missing or authentication fails before any crash email is fetched.
- Write sanitized Homey runtime reports even when credentials are missing, authentication fails, or Homeys cannot be listed because the credential scope is limited.
- Surface Gmail/Homey access failures in `diagnostics/summary.json` so deep diagnostics no longer report `0 errors` when crash sources were not reachable.
- Teach `diagnostic-history-gate` to render structured aggregate errors as useful messages instead of `[object Object]`.

## Why
The latest crash investigation was blocked by Gmail IMAP auth failure and limited Homey runtime API access. The workflow logs showed the blocker, but the aggregated artifacts still looked empty/healthy, which made crash triage misleading.

## Validation
- `node --check` on the four touched scripts
- simulated missing Gmail/Homey credentials: aggregator now reports 2 source-access errors
- `npm run check:diag-history`
- `npm run security:diagnostics`
- `npm run check:timer-context`
- `npm run check:button-flows`
- `node scripts/ci/bug-hunter.js --json` (0 critical)
- `npm test` (80 passing)
- pre-commit gate passed
- pre-push gate passed