### PR TITLE
[codex] Make WiFi pairing ad-hoc local-first

### DIFF
--- a/docs/WIFI_LOCAL_FIRST_ARCHITECTURE.md
+++ b/docs/WIFI_LOCAL_FIRST_ARCHITECTURE.md
@@ -424,16 +424,17 @@
   │    ├─ Token with TTL (auto-refresh)                             │
   │    └─ 15s HTTP timeout ← v9.0.40                               │
   │                                                                 │
-  │  Layer 4: Key Recovery (self-healing)                           │
-  │    ├─ Max 3 attempts, 1h cooldown ← v9.0.40                    │
-  │    ├─ Uses cloud API credentials from app settings              │
-  │    └─ Updates local_key without re-pairing                      │
+  │  Layer 4: Key Recovery (explicit repair / opt-in fallback)      │
+  │    ├─ Disabled by default for local-first devices               │
+  │    ├─ Repair can refresh the local_key when user requests it    │
+  │    └─ Automatic cloud recovery requires explicit policy opt-in  │
   │                                                                 │
   │  Layer 5: Runtime Isolation                                     │
   │    ├─ 100% local on Homey Pro                                   │
   │    ├─ Zero cloud calls during normal operation                  │
   │    ├─ No secrets in app bundle                                  │
-  │    └─ Cloud only for pairing + key recovery                     │
+  │    ├─ Cloud only for optional pairing/key repair                │
+  │    └─ No automatic cloud fallback by default                    │
   │                                                                 │
   └─────────────────────────────────────────────────────────────────┘
 ```
@@ -492,7 +493,8 @@
   │  ├─ ✅ HTTP timeout (15s) prevents cloud API hang              │
   │  ├─ ✅ Token expire calculation fixed (seconds→ms)             │
   │  ├─ ✅ sendCommand now refreshes token before send             │
-  │  ├─ ✅ Key recovery rate-limited (3 attempts, 1h cooldown)     │
+  │  ├─ ✅ Key recovery rate-limited and opt-in for runtime        │
+  │  ├─ ✅ LAN discovery timers no longer require Homey context    │
   │  ├─ ✅ MQTT reconnect with exponential backoff                  │
   │  ├─ ✅ Mixin order standardized (14 files)                     │
   │  └─ ✅ Missing imports added (2 files)                         │

--- a/drivers/wifi_air_purifier/pair/configure.html
+++ b/drivers/wifi_air_purifier/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_air_quality/pair/configure.html
+++ b/drivers/wifi_air_quality/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_camera/pair/configure.html
+++ b/drivers/wifi_camera/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_cover/pair/configure.html
+++ b/drivers/wifi_cover/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_dehumidifier/pair/configure.html
+++ b/drivers/wifi_dehumidifier/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_dimmer/pair/configure.html
+++ b/drivers/wifi_dimmer/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_door_lock/pair/configure.html
+++ b/drivers/wifi_door_lock/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_doorbell/pair/configure.html
+++ b/drivers/wifi_doorbell/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_ewelink_bulb/pair/configure.html
+++ b/drivers/wifi_ewelink_bulb/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_dimmer/pair/configure.html
+++ b/drivers/wifi_ewelink_dimmer/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_fan/pair/configure.html
+++ b/drivers/wifi_ewelink_fan/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_led/pair/configure.html
+++ b/drivers/wifi_ewelink_led/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_plug/pair/configure.html
+++ b/drivers/wifi_ewelink_plug/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_pow/pair/configure.html
+++ b/drivers/wifi_ewelink_pow/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_switch/pair/configure.html
+++ b/drivers/wifi_ewelink_switch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_switch_2ch/pair/configure.html
+++ b/drivers/wifi_ewelink_switch_2ch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_switch_4ch/pair/configure.html
+++ b/drivers/wifi_ewelink_switch_4ch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_ewelink_th/pair/configure.html
+++ b/drivers/wifi_ewelink_th/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_fan/pair/configure.html
+++ b/drivers/wifi_fan/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_garage_door/pair/configure.html
+++ b/drivers/wifi_garage_door/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_generic/pair/configure.html
+++ b/drivers/wifi_generic/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_heater/pair/configure.html
+++ b/drivers/wifi_heater/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_humidifier/pair/configure.html
+++ b/drivers/wifi_humidifier/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_ir_remote/pair/configure.html
+++ b/drivers/wifi_ir_remote/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_led_strip/pair/configure.html
+++ b/drivers/wifi_led_strip/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_light/pair/configure.html
+++ b/drivers/wifi_light/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_pet_feeder/pair/configure.html
+++ b/drivers/wifi_pet_feeder/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_plug/pair/configure.html
+++ b/drivers/wifi_plug/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_power_strip/pair/configure.html
+++ b/drivers/wifi_power_strip/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_robot_vacuum/pair/configure.html
+++ b/drivers/wifi_robot_vacuum/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_sensor/pair/configure.html
+++ b/drivers/wifi_sensor/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_siren/pair/configure.html
+++ b/drivers/wifi_siren/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_sonoff_basicr4/pair/configure.html
+++ b/drivers/wifi_sonoff_basicr4/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_dualr3/pair/configure.html
+++ b/drivers/wifi_sonoff_dualr3/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_micro/pair/configure.html
+++ b/drivers/wifi_sonoff_micro/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_minir3/pair/configure.html
+++ b/drivers/wifi_sonoff_minir3/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_minir4/pair/configure.html
+++ b/drivers/wifi_sonoff_minir4/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_pow_elite/pair/configure.html
+++ b/drivers/wifi_sonoff_pow_elite/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_smate2/pair/configure.html
+++ b/drivers/wifi_sonoff_smate2/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_thr316d/pair/configure.html
+++ b/drivers/wifi_sonoff_thr316d/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_tx_1ch/pair/configure.html
+++ b/drivers/wifi_sonoff_tx_1ch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_tx_2ch/pair/configure.html
+++ b/drivers/wifi_sonoff_tx_2ch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_sonoff_tx_3ch/pair/configure.html
+++ b/drivers/wifi_sonoff_tx_3ch/pair/configure.html
@@ -2,209 +2,53 @@
 <html><head><style>
 *{box-sizing:border-box}body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;padding:14px;color:#333;margin:0;font-size:13px}
 h2{margin:0 0 2px;font-size:17px}.sub{color:#666;font-size:11px;margin:0 0 10px}
-.tabs{display:flex;border-bottom:2px solid #eee;margin-bottom:12px}
-.tab{padding:7px 12px;cursor:pointer;font-size:12px;font-weight:600;color:#888;border-bottom:2px solid transparent;margin-bottom:-2px;white-space:nowrap}
-.tab.active{color:#00a870;border-bottom-color:#00a870}
-.pnl{display:none}.pnl.active{display:block}
 .fg{margin-bottom:10px}label{display:block;font-weight:600;margin-bottom:2px;font-size:12px}
 .hint{font-size:10px;color:#888;margin-top:1px}
 input,select{width:100%;padding:7px;border:1px solid #ccc;border-radius:5px;font-size:12px}
 input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px rgba(0,230,160,.15)}
 .row{display:flex;gap:8px}.row>*{flex:1}
 .btn{display:block;width:100%;padding:9px;border:none;border-radius:5px;font-size:13px;font-weight:600;cursor:pointer;margin-top:6px}
-.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}.btn-p:disabled{background:#aaa}
+.btn-p{background:#00a870;color:#fff}.btn-p:hover{background:#009060}
 .err{color:#e74c3c;font-size:11px;display:none;margin-top:5px;padding:5px;background:#fef2f2;border-radius:4px}
-.ok{color:#00a870;font-size:11px;display:none;margin-top:5px;padding:5px;background:#f0faf5;border-radius:4px}
 .box{background:#f0faf5;border:1px solid #c3f0d8;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
 .box b{color:#00a870}.box ol{margin:3px 0 0;padding-left:16px}
-.box2{background:#fff8e6;border:1px solid #ffe0a0;border-radius:5px;padding:8px;margin-bottom:10px;font-size:11px;line-height:1.5}
-.sp{display:inline-block;width:13px;height:13px;border:2px solid #fff;border-top-color:transparent;border-radius:50%;animation:spin .7s linear infinite;vertical-align:middle;margin-right:5px}
-@keyframes spin{to{transform:rotate(360deg)}}
-details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
-<h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
-<div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
-<div class="tab" data-t="sl">Smart Life Login</div>
-<div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
-</div>
-
-<!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<h2>eWeLink / SONOFF WiFi Setup</h2>
+<p class="sub">100% local LAN control - no cloud needed after setup</p>
 <div class="box">
-<b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
-Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
-<details><summary>First time? Save credentials in App Settings</summary>
+<b>How to get Device ID and API Key:</b>
 <ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-<li>Go to this app's <b>Settings page</b> and save them there</li>
+<li>Open eWeLink app > Device > Settings > Device Info > <b>Device ID</b></li>
+<li>For API Key: use <b>eWeLink Web</b> or a tool like <b>SonoffLAN</b></li>
+<li>For DIY mode devices: API Key is not needed (leave empty)</li>
+<li>IP: find in your router's DHCP table or use mDNS scan</li>
 </ol>
-After this one-time setup, you only need email + password to pair devices.
-</details>
 </div>
-<div class="fg"><label>Smart Life Email</label><input type="email" id="ez_email" placeholder="your@email.com"/></div>
-<div class="fg"><label>Password</label><input type="password" id="ez_pw" placeholder="Smart Life / Tuya Smart password"/></div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="ez_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE, 31=NL</div></div>
-<div class="fg"><label>App</label><select id="ez_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-ez" onclick="doEasy()">Log in & scan devices</button>
-<div class="err" id="ez-err"></div><div class="ok" id="ez-ok"></div>
-</div>
-
-<!-- TAB 1: Smart Life Login -->
-<div id="p-sl" class="pnl">
-<div class="box">
-<b>Full login</b> - Enter IoT credentials + Smart Life email/password.
-<details><summary>How to get Access ID/Secret (free, 5 min)</summary>
-<ol>
-<li>Go to <b>iot.tuya.com</b> and create a free account</li>
-<li>Cloud > Create Cloud Project > select <b>Smart Home</b></li>
-<li>Subscribe to <b>IoT Core</b> + <b>Authorization</b> APIs</li>
-<li>Devices > <b>Link App Account</b> > scan QR with Smart Life app</li>
-<li>Copy <b>Access ID</b> + <b>Access Secret</b> from Overview tab</li>
-</ol>
-Credentials saved locally. Cloud only used once for key retrieval.
-</details>
-</div>
-<div class="row">
-<div class="fg"><label>Access ID</label><input type="text" id="sl_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="sl_as" placeholder="from iot.tuya.com"/></div>
-</div>
-<div class="row">
-<div class="fg"><label>No account needed (Leave empty to use 1-Click Phone link)</label></div>
-</div>
-<div class="row">
-<div class="fg"><label>Country Code</label><input type="text" id="sl_cc" value="33" placeholder="33"/><div class="hint">33=FR, 1=US, 44=UK, 49=DE</div></div>
-<div class="fg"><label>Region</label><select id="sl_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<div class="fg"><label>App</label><select id="sl_schema"><option value="smartlife">Smart Life</option><option value="tuyaSmart">Tuya Smart</option></select></div>
-</div>
-<button class="btn btn-p" id="btn-sl" onclick="doSmartLife()">Log in & scan devices</button>
-<div class="err" id="sl-err"></div><div class="ok" id="sl-ok"></div>
-</div>
-
-<!-- TAB 2: IoT Platform -->
-<div id="p-iot" class="pnl">
-<div class="box">
-<b>IoT Platform direct</b> - Uses your Tuya IoT project credentials to fetch all linked devices + local keys automatically.
-Same setup as above but without email/password (uses linked account).
-</div>
-<div class="fg"><label>Access ID</label><input type="text" id="iot_aid" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Access Secret</label><input type="password" id="iot_as" placeholder="from iot.tuya.com"/></div>
-<div class="fg"><label>Region</label><select id="iot_reg"><option value="eu">Europe</option><option value="us">Americas</option><option value="cn">China</option><option value="in">India</option></select></div>
-<button class="btn btn-p" id="btn-iot" onclick="doIoT()">Scan devices</button>
-<div class="err" id="iot-err"></div><div class="ok" id="iot-ok"></div>
-</div>
-
-<!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
-<div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
-Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
-</div>
-<div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>
-<div class="fg"><label>Local Key *</label><input type="text" id="m_lk" placeholder="16-char AES key"/></div>
-<div class="fg"><label>IP Address</label><input type="text" id="m_ip" placeholder="auto-discovered if empty"/></div>
-<div class="fg"><label>Device Name</label><input type="text" id="m_name" placeholder="e.g. Radiateur Salon"/></div>
-<div class="fg"><label>Protocol</label><select id="m_pv"><option value="3.1">3.1</option><option value="3.3" selected>3.3</option><option value="3.4">3.4</option><option value="3.5">3.5</option></select></div>
-<div class="err" id="man-err"></div>
-</div>
-
+<div class="fg"><label>Device ID *</label><input type="text" id="did" placeholder="e.g. 1000ab1234"/></div>
+<div class="fg"><label>API Key</label><input type="text" id="akey" placeholder="Leave empty for DIY mode devices"/><div class="hint">Required for encrypted LAN mode, not needed for DIY mode</div></div>
+<div class="fg"><label>IP Address *</label><input type="text" id="ip" placeholder="e.g. 192.168.1.100"/></div>
+<div class="fg"><label>Device Name</label><input type="text" id="dname" placeholder="e.g. SONOFF BASIC R4"/></div>
+<div class="fg"><label>Encryption</label><select id="enc"><option value="true">Encrypted (default)</option><option value="false">DIY Mode (no encryption)</option></select></div>
+<div class="err" id="err"></div>
 <script>
 var H,done=false;
-document.querySelectorAll('.tab').forEach(function(t){t.addEventListener('click',function(){document.querySelectorAll('.tab').forEach(function(x){x.classList.remove('active')});document.querySelectorAll('.pnl').forEach(function(p){p.classList.remove('active')});t.classList.add('active');document.getElementById('p-'+t.dataset.t).classList.add('active')})});
-function hide(id){document.getElementById(id).style.display='none'}
-function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block'}
-function spin(id){var b=document.getElementById(id);b.disabled=true;b.dataset.orig=b.innerHTML;b.innerHTML='<span class="sp"></span>Scanning...'}
-function unspin(id){var b=document.getElementById(id);b.disabled=false;b.innerHTML=b.dataset.orig||'Scan'}
-
-function doEasy(){
-  var em=document.getElementById('ez_email').value.trim(),pw=document.getElementById('ez_pw').value.trim();
-  var cc=document.getElementById('ez_cc').value.trim(),schema=document.getElementById('ez_schema').value;
-  hide('ez-err');hide('ez-ok');
-  if(!em||!pw){show('ez-err','Email and password required');return}
-  spin('btn-ez');
-  H.emit('login',{mode:'simple',email:em,password:pw,countryCode:cc,schema:schema},function(err,r){
-    unspin('btn-ez');
-    if(err){show('ez-err',err.message||String(err));return}
-    done=true;show('ez-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
-function doSmartLife(){
-  var aid=document.getElementById('sl_aid').value.trim(),as=document.getElementById('sl_as').value.trim();
-  var reg=document.getElementById('sl_reg').value,schema=document.getElementById('sl_schema').value;
-  hide('sl-err');hide('sl-ok');
-  spin('btn-sl');
-  
-  if (aid && as) {
-      // Direct IoT login
-      H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        done=true;show('sl-ok',r.count+' devices found! Click Next to select.');
-      });
-  } else {
-      // SmartLife QR + DeepLink approach (no accessId/secret)
-      H.emit('login',{mode:'smartlife_qr',region:reg,schema:schema},function(err,r){
-        unspin('btn-sl');
-        if(err){show('sl-err',err.message||String(err));return}
-        var qrUrl = schema + '://qrLogin?token=' + r.qrCode;
-        var msg = '<b>Scan this or click the link!</b><br>';
-        if (r.localQrImage) {
-          msg += '<img src="'+r.localQrImage+'" style="margin:10px auto;display:block;" /><br>';
-        }
-        msg += '<a href="'+qrUrl+'" target="_blank" style="display:inline-block;padding:10px;background:#00a870;color:white;text-decoration:none;border-radius:5px;margin:5px 0;">Click to Open App (Phone only)</a>';
-        msg += '<br><i>(Wait here after authorizing)</i>';
-        show('sl-ok',msg);
-        
-        // Start polling!
-        H.emit('poll_qr',{}, function(err2,r2) {
-           if(err2){show('sl-err',err2.message||String(err2));return}
-           done=true; show('sl-ok',r2.count+' devices found! Click Next.');
-        });
-      });
-  }
-}
-
-function doIoT(){
-  var aid=document.getElementById('iot_aid').value.trim(),as=document.getElementById('iot_as').value.trim();
-  var reg=document.getElementById('iot_reg').value;
-  hide('iot-err');hide('iot-ok');
-  if(!aid||!as){show('iot-err','Access ID and Secret required');return}
-  spin('btn-iot');
-  H.emit('login',{mode:'cloud',accessId:aid,accessSecret:as,region:reg},function(err,r){
-    unspin('btn-iot');
-    if(err){show('iot-err',err.message||String(err));return}
-    done=true;show('iot-ok',r.count+' devices found! Click Next to select.');
-  });
-}
-
+function show(id,msg){var e=document.getElementById(id);e.textContent=msg;e.style.display='block';}
+function hide(id){document.getElementById(id).style.display='none';}
 function onHomeyReady(Homey){
-  H=Homey;
-  Homey.ready();
-  Homey.emit('getSavedCredentials',{},function(err,r){
-    if(!err&&r&&r.hasSaved){
-      document.getElementById('sl_aid').value=r.accessId||'';
-      document.getElementById('iot_aid').value=r.accessId||'';
-      if(r.region){document.getElementById('sl_reg').value=r.region;document.getElementById('iot_reg').value=r.region}
-    }
-  });
+  H=Homey;Homey.ready();
   Homey.on('nextView',function(){
     if(done)return;
-    var tab=document.querySelector('.tab.active');
-    if(!tab||tab.dataset.t!=='man')return;
-    var did=document.getElementById('m_did').value.trim(),lk=document.getElementById('m_lk').value.trim();
-    hide('man-err');
-    if(!did||!lk){show('man-err','Device ID and Local Key required');return}
-    if(lk.length<16){show('man-err','Local Key must be at least 16 characters');return}
-    H.emit('configure',{device_id:did,local_key:lk,ip:document.getElementById('m_ip').value.trim(),name:document.getElementById('m_name').value.trim(),protocol_version:document.getElementById('m_pv').value},function(err){if(err){show('man-err',err.message||String(err))}else{done=true}});
+    var did=document.getElementById('did').value.trim();
+    var ip=document.getElementById('ip').value.trim();
+    var akey=document.getElementById('akey').value.trim();
+    var name=document.getElementById('dname').value.trim();
+    var enc=document.getElementById('enc').value==='true';
+    hide('err');
+    if(!did){show('err','Device ID is required');return;}
+    if(!ip){show('err','IP address is required');return;}
+    H.emit('configure',{device_id:did,api_key:akey,ip:ip,name:name,encrypt:enc},function(e){
+      if(e){show('err',e.message||String(e));}else{done=true;}
+    });
   });
 }
 </script>

--- a/drivers/wifi_switch/pair/configure.html
+++ b/drivers/wifi_switch/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_switch_2gang/pair/configure.html
+++ b/drivers/wifi_switch_2gang/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_switch_3gang/pair/configure.html
+++ b/drivers/wifi_switch_3gang/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_switch_4gang/pair/configure.html
+++ b/drivers/wifi_switch_4gang/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_thermostat/pair/configure.html
+++ b/drivers/wifi_thermostat/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_water_tank_monitor/pair/configure.html
+++ b/drivers/wifi_water_tank_monitor/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/drivers/wifi_water_valve/pair/configure.html
+++ b/drivers/wifi_water_valve/pair/configure.html
@@ -23,16 +23,16 @@ input:focus,select:focus{border-color:#00E6A0;outline:none;box-shadow:0 0 0 2px 
 details{margin-bottom:8px;font-size:11px}details summary{cursor:pointer;font-weight:600;color:#00a870}
 </style></head><body>
 <h2>Tuya WiFi Setup</h2>
-<p class="sub">100% local control after initial key retrieval</p>
+<p class="sub">Local-first LAN control. Cloud only if you choose key retrieval.</p>
 <div class="tabs">
-<div class="tab active" data-t="ez">Easy Login</div>
+<div class="tab" data-t="ez">Easy Login</div>
 <div class="tab" data-t="sl">Smart Life Login</div>
 <div class="tab" data-t="iot">IoT Platform</div>
-<div class="tab" data-t="man">Manual</div>
+<div class="tab active" data-t="man">Local / Ad hoc</div>
 </div>
 
 <!-- TAB 0: Easy Login (email+password only, uses saved creds) -->
-<div id="p-ez" class="pnl active">
+<div id="p-ez" class="pnl">
 <div class="box">
 <b>Easiest method</b> - Just enter your Smart Life / Tuya Smart email and password.<br>
 Requires IoT credentials saved in <b>App Settings</b> (one-time setup).
@@ -103,9 +103,9 @@ Same setup as above but without email/password (uses linked account).
 </div>
 
 <!-- TAB 3: Manual -->
-<div id="p-man" class="pnl">
+<div id="p-man" class="pnl active">
 <div class="box2">
-<b>Manual entry</b> - Enter Device ID and Local Key directly.
+<b>Local / ad hoc</b> - Enter Device ID and Local Key directly. Homey connects on LAN first.
 Get these from <b>tinytuya wizard</b>, browser extension, or iot.tuya.com API Explorer.
 </div>
 <div class="fg"><label>Device ID *</label><input type="text" id="m_did" placeholder="e.g. bf1234abcdef567890"/></div>

--- a/lib/ewelink-local/EweLinkLocalDriver.js
+++ b/lib/ewelink-local/EweLinkLocalDriver.js
@@ -1,5 +1,6 @@
 'use strict';
 const Homey=require('homey');
+const { createWiFiConnectionStore } = require('../wifi/WiFiConnectionPolicy');
 
 class EweLinkLocalDriver extends Homey.Driver{
   async onInit(){this.log('[EWE-DRV] Init');}
@@ -23,6 +24,7 @@ class EweLinkLocalDriver extends Homey.Driver{
         devices.push({
           name:pairData.name||`eWeLink ${pairData.device_id.substring(0,8)}`,
           data:{id:pairData.device_id},
+          store:createWiFiConnectionStore({pairingMode:'ad_hoc',transport:'lan_mdns',localDiscovery:true}),
           settings:{device_id:pairData.device_id,api_key:pairData.api_key||'',ip:pairData.ip||'',encrypt:pairData.encrypt!==false}
         });
       }
@@ -35,6 +37,7 @@ class EweLinkLocalDriver extends Homey.Driver{
           devices.push({
             name:txt.type||`eWeLink ${id.substring(0,8)}`,
             data:{id},
+            store:createWiFiConnectionStore({pairingMode:'ad_hoc',transport:'lan_mdns',localDiscovery:true}),
             settings:{device_id:id,api_key:'',ip:dr.address||'',encrypt:true}
           });
         }

--- a/lib/tuya-local/README.md
+++ b/lib/tuya-local/README.md
@@ -53,9 +53,9 @@ Manual entry ──────────────────────�
 | File | Purpose |
 |------|---------|
 | `TuyaSmartLifeAuth.js` | Authentication: QR scan + IoT Platform + token management |
-| `TuyaDeviceDiscovery.js` | UDP LAN discovery on ports 6666/6667 |
+| `TuyaDeviceDiscovery.js` | UDP LAN discovery on ports 6666/6667/6668 |
 | `TuyaLocalDevice.js` | Base device class: tuyapi wrapper with reconnect + heartbeat |
-| `TuyaLocalDriver.js` | Pairing driver: 3 methods + cloud device list + LAN discovery |
+| `TuyaLocalDriver.js` | Local-first pairing driver: ad-hoc manual + optional cloud key lookup + LAN discovery |
 | `TuyaZigbeeBridge.js` | Zigbee gateway bridge: sub-device control via gateway TCP |
 | `TuyaCloudAPI.js` | Legacy Tuya Open API client (IoT Platform method) |
 | `TuyaCloudMQTT.js` | Real-time cloud MQTT updates (optional, AES-ECB/GCM) |
@@ -146,9 +146,9 @@ Manual entry > device_id + local_key + IP
 | File | Purpose |
 |------|---------|
 | `TuyaSmartLifeAuth.js` | Authentication: QR scan + IoT Platform + token management |
-| `TuyaDeviceDiscovery.js` | UDP LAN discovery on ports 6666/6667 |
+| `TuyaDeviceDiscovery.js` | UDP LAN discovery on ports 6666/6667/6668 |
 | `TuyaLocalDevice.js` | Base device class: tuyapi wrapper with reconnect + heartbeat |
-| `TuyaLocalDriver.js` | Pairing driver: 3 methods + cloud device list + LAN discovery |
+| `TuyaLocalDriver.js` | Local-first pairing driver: ad-hoc manual + optional cloud key lookup + LAN discovery |
 | `TuyaZigbeeBridge.js` | Zigbee gateway bridge: sub-device control via gateway TCP |
 | `TuyaCloudAPI.js` | Legacy Tuya Open API client (IoT Platform method) |
 | `TuyaCloudMQTT.js` | Real-time cloud MQTT updates (optional, AES-ECB/GCM) |

--- a/lib/tuya-local/TuyaDeviceDiscovery.js
+++ b/lib/tuya-local/TuyaDeviceDiscovery.js
@@ -26,6 +26,8 @@ class TuyaDeviceDiscovery extends EventEmitter {
     this._devices = new Map();
     this._sockets = [];
     this._running = false;
+    this._scanTimer = null;
+    this._scanResolve = null;
   }
 
   // Start discovery scan, returns promise with all found devices
@@ -35,20 +37,38 @@ class TuyaDeviceDiscovery extends EventEmitter {
     this._running = true;
     this._startListening();
     return new Promise((resolve) => {
-      this.homey.setTimeout(() => {
-        if (this._destroyed) return;
-        this.stop();
-        resolve(Array.from(this._devices.values()));
+      this._scanResolve = resolve;
+      this._scanTimer = globalThis.setTimeout(() => {
+        this._finishScan();
       }, timeout);
+      this._scanTimer.unref?.();
     });
+  }
+
+  _finishScan() {
+    const resolve = this._scanResolve;
+    this._scanResolve = null;
+    this.stop();
+    if (resolve) {
+      resolve(Array.from(this._devices.values()));
+    }
   }
 
   stop() {
     this._running = false;
+    if (this._scanTimer) {
+      clearTimeout(this._scanTimer);
+      this._scanTimer = null;
+    }
     for (const sock of this._sockets) {
       try { sock.close(); } catch (e) { /* ignore */ }
     }
     this._sockets = [];
+    if (this._scanResolve) {
+      const resolve = this._scanResolve;
+      this._scanResolve = null;
+      resolve(Array.from(this._devices.values()));
+    }
   }
 
   _startListening() {

--- a/lib/tuya-local/TuyaLocalDevice.js
+++ b/lib/tuya-local/TuyaLocalDevice.js
@@ -8,6 +8,7 @@ const CapabilityMapCache = require('../utils/CapabilityMapCache');
 const { getDeviceCache, removeDeviceCache } = require('../managers/DPCache');
 // v9.0.40: SmartDivisorManager for WiFi devices with smartDivisor: true
 const { smartParse } = require('../managers/SmartDivisorManager');
+const { allowsCloudFallback, normalizeWiFiConnectionPolicy } = require('../wifi/WiFiConnectionPolicy');
 
 class TuyaLocalDevice extends Homey.Device {
   /** Override: capability-to-DP mappings [{capability, dp, toDevice, fromDevice}] */
@@ -105,6 +106,15 @@ class TuyaLocalDevice extends Homey.Device {
     return true;
   }
 
+  getWiFiConnectionPolicy() {
+    const stored = this.getStoreValue?.('wifi_connection_policy') || this.getStoreValue?.('wifiConnectionPolicy') || {};
+    return normalizeWiFiConnectionPolicy(stored);
+  }
+
+  _allowsCloudKeyRecovery() {
+    return allowsCloudFallback(this.getWiFiConnectionPolicy());
+  }
+
   async onInit() {
     this.log('TuyaLocalDevice init:', this.getName());
     this._destroyed = false; // v9.0.40: Lifecycle guard
@@ -162,8 +172,12 @@ class TuyaLocalDevice extends Homey.Device {
       this._client.on('error', (err) => this._onError(err));
       this._client.on('dp-update', (dps) => this._onData({ dps }));
       this._client.on('auth-error', (err) => {
-        this.setWarning('Authentication failed: Local key might have changed. Attempting auto-recovery...');
-        this._attemptLocalKeyRecovery();
+        if (this._allowsCloudKeyRecovery()) {
+          this.setWarning('Authentication failed: Local key might have changed. Attempting opted-in cloud recovery...');
+          this._attemptLocalKeyRecovery();
+          return;
+        }
+        this.setWarning('Authentication failed: Local key might have changed. Local-first mode keeps cloud fallback disabled; update the key from Repair.');
       });
 
       // v9.0.40: Connection state tracking for offline mode
@@ -353,6 +367,10 @@ class TuyaLocalDevice extends Homey.Device {
   }
 
   async _attemptLocalKeyRecovery() {
+    if (!this._allowsCloudKeyRecovery()) {
+      this.log('[TUYA-TCP] Cloud key recovery skipped by local-first policy.');
+      return;
+    }
     if (this._isRecoveringKey) return;
     // v9.0.40: Max 3 retry attempts, then cool down for 1 hour
     if (!this._keyRecoveryAttempts) this._keyRecoveryAttempts = 0;

--- a/lib/tuya-local/TuyaLocalDriver.js
+++ b/lib/tuya-local/TuyaLocalDriver.js
@@ -10,6 +10,7 @@ const TuyaDeviceDiscovery = require('./TuyaDeviceDiscovery');
 const TuyaZigbeeBridge = require('./TuyaZigbeeBridge');
 const QRCode = require('qrcode');
 const TuyaCloudAPI = require('./TuyaCloudAPI');
+const { createWiFiConnectionStore } = require('../wifi/WiFiConnectionPolicy');
 
 class TuyaLocalDriver extends Homey.Driver {
   
@@ -51,6 +52,43 @@ class TuyaLocalDriver extends Homey.Driver {
     }
   }
 
+  _toLocalFirstPairDevice(device, pairingMode = 'ad_hoc') {
+    const id = device.id || device.device_id;
+    const localKey = device.local_key || device.localKey || device.key;
+    const ip = device.ip || device.ip_address || device.device_ip || '';
+    const version = device.version || device.protocol_version || '3.3';
+    const name = device.name || (id ? `Tuya ${String(id).slice(-6)}` : 'Tuya WiFi Device');
+
+    let badge = '';
+    if (device.brand && device.deviceType) {
+      badge = `[${device.brand} - ${device.deviceType}] `;
+    } else if (device.brand) {
+      badge = `[${device.brand}] `;
+    } else if (device.deviceType) {
+      badge = `[${device.deviceType}] `;
+    }
+
+    return {
+      name: badge + name,
+      data: { id },
+      store: createWiFiConnectionStore({
+        pairingMode,
+        transport: 'lan_tcp',
+        localDiscovery: true,
+        cloudFallback: false,
+        cloudMirroring: false,
+      }),
+      settings: {
+        device_id: id,
+        local_key: localKey,
+        ip_address: ip,
+        protocol_version: version,
+        zb_model_id: device.product_id || '',
+        zb_manufacturer_name: device.product_name || device.name || '',
+      },
+    };
+  }
+
   async onPair(session) {
     let pairMethod = 'manual';
     let discoveredDevices = [];
@@ -90,6 +128,7 @@ class TuyaLocalDriver extends Homey.Driver {
     });
 
     session.setHandler('smartlife_get_devices', async () => {
+      pairMethod = 'cloud_key_lookup';
       if (!this._auth) {return { success: false, error: 'Not authenticated' };}
       // Get cloud devices with local keys
       const cloudResult = await this._auth.getDevicesWithLocalKeys();
@@ -110,6 +149,7 @@ class TuyaLocalDriver extends Homey.Driver {
 
     // ─── Method 2: IoT Platform API ───
     session.setHandler('iot_login', async (data) => {
+      pairMethod = 'cloud_key_lookup';
       const { accessId, accessSecret, region } = data;
       this._auth = new TuyaSmartLifeAuth({ region, log: this });
       const loginRes = await this._auth.loginWithApiKey(accessId, accessSecret);
@@ -131,21 +171,21 @@ class TuyaLocalDriver extends Homey.Driver {
     session.setHandler('manual_add', async (data) => {
       const { device_id, local_key, ip_address, name, protocol_version } = data;
       if (!device_id || !local_key) {throw new Error('Device ID and Local Key required');}
-      return [{
+      pairMethod = 'ad_hoc';
+      return [this._toLocalFirstPairDevice({
+        id: device_id,
+        local_key,
+        ip: ip_address || '',
         name: name || 'Tuya WiFi Device',
-        data: { id: device_id },
-        settings: {
-          device_id, local_key,
-          ip_address: ip_address || '',
-          protocol_version: protocol_version || '3.3',
-        },
-      }];
+        version: protocol_version || '3.3',
+      }, 'ad_hoc')];
     });
 
     // ─── Unified UI Login Handler (from configure.html) ───
     session.setHandler('login', async (data) => {
       try {
         if (data.mode === 'simple') {
+          pairMethod = 'cloud_key_lookup';
           // Easy Login flow using email + password + saved global credentials
           const accessId = this.homey.settings.get('tuya_cloud_access_id');
           const accessSecret = this.homey.settings.get('tuya_cloud_access_secret');
@@ -200,6 +240,7 @@ class TuyaLocalDriver extends Homey.Driver {
 
           return { count: discoveredDevices.length, devices: discoveredDevices };
         } else if (data.mode === 'cloud' || data.mode === 'smartlife') {
+          pairMethod = 'cloud_key_lookup';
           this._auth = new TuyaSmartLifeAuth({ region: data.region, log: this });
           const loginRes = await this._auth.loginWithApiKey(data.accessId, data.accessSecret);
           if (!loginRes.success) {throw new Error(loginRes.error || 'API Login failed');}
@@ -218,6 +259,7 @@ class TuyaLocalDriver extends Homey.Driver {
           
           return { count: discoveredDevices.length, devices: discoveredDevices };
         } else if (data.mode === 'smartlife_qr') {
+          pairMethod = 'cloud_key_lookup';
           this._auth = new TuyaSmartLifeAuth({ region: data.region, log: this });
           const schema = data.schema || 'smartlife';
           const qrRes = await this._auth.getQRCode(null, schema);
@@ -235,6 +277,7 @@ class TuyaLocalDriver extends Homey.Driver {
 
     // ─── Poll QR ───
     session.setHandler('poll_qr', async (data) => {
+      pairMethod = 'cloud_key_lookup';
       if (!this._auth) {return { success: false, error: 'No auth session' };}
       const pollRes = await this._auth.pollQRLogin(120000);
       if (!pollRes.success) {throw new Error(pollRes.error);}
@@ -252,12 +295,14 @@ class TuyaLocalDriver extends Homey.Driver {
     });
 
     session.setHandler('configure', async (data) => {
+      pairMethod = 'ad_hoc';
       discoveredDevices = [{
         id: data.device_id,
         name: data.name || 'Tuya WiFi Device',
         local_key: data.local_key,
         ip: data.ip,
-        version: data.protocol_version || '3.3'
+        version: data.protocol_version || '3.3',
+        pairingMode: 'ad_hoc',
       }];
       return true;
     });
@@ -267,28 +312,7 @@ class TuyaLocalDriver extends Homey.Driver {
       if (!discoveredDevices.length) {return [];}
       return discoveredDevices
         .filter(d => d.local_key)
-        .map(d => {
-          let badge = '';
-          if (d.brand && d.deviceType) {
-            badge = `[${d.brand} - ${d.deviceType}] `;
-          } else if (d.brand) {
-            badge = `[${d.brand}] `;
-          } else if (d.deviceType) {
-            badge = `[${d.deviceType}] `;
-          }
-          return {
-            name: badge + (d.name || `Tuya ${  d.id.slice(-6)}`),
-            data: { id: d.id },
-            settings: {
-              device_id: d.id,
-              local_key: d.local_key,
-              ip_address: d.ip || '',
-              protocol_version: d.version || '3.3',
-              zb_model_id: d.product_id || '',
-              zb_manufacturer_name: d.product_name || d.name || '',
-            },
-          };
-        });
+        .map(d => this._toLocalFirstPairDevice(d, d.pairingMode || pairMethod || 'ad_hoc'));
     });
 
 

--- a/lib/tuya-local/TuyaUDPDiscovery.js
+++ b/lib/tuya-local/TuyaUDPDiscovery.js
@@ -20,6 +20,7 @@ class TuyaUDPDiscovery extends EventEmitter {
     this._cleanupInterval = null;
     this._log = opts.log || (() => {});
     this._deviceTTL = opts.deviceTTL || 120000;
+    this._destroyed = false;
   }
 
   get devices() {
@@ -36,6 +37,7 @@ class TuyaUDPDiscovery extends EventEmitter {
   async start() {
     if (this._running) {return;}
     this._running = true;
+    this._destroyed = false;
     this._log('[UDP-DISC] Starting Tuya UDP discovery on ports 6666/6667/6668...');
     try {
       await this._bindSocket(6666, false, false);
@@ -45,17 +47,26 @@ class TuyaUDPDiscovery extends EventEmitter {
       this._log('[UDP-DISC] Bind error (non-fatal):', err.message);
     }
     // v9.0.40: Use native setInterval (no homey dependency required)
-    this._cleanupInterval = this.homey.setInterval(() => { if (this._destroyed) return; this._cleanup(); }, 60000);
+    this._cleanupInterval = globalThis.setInterval(() => { if (this._destroyed) return; this._cleanup(); }, 60000);
+    this._cleanupInterval.unref?.();
     this._log('[UDP-DISC] Discovery active');
   }
 
   _bindSocket(port, encrypted, gcm) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve) => {
+      let timer = null;
+      let settled = false;
+      const done = () => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve();
+      };
       const sock = dgram.createSocket({ type: 'udp4', reuseAddr: true });
       sock.on('error', (err) => {
         this._log(`[UDP-DISC] Socket error port ${  port  }:`, err.message);
         try { sock.close(); } catch (e) { /* socket cleanup on error */ }
-        resolve();
+        done();
       });
       sock.on('message', (msg, rinfo) => {
         try { this._handleMessage(msg, rinfo, encrypted, gcm); }
@@ -66,9 +77,10 @@ class TuyaUDPDiscovery extends EventEmitter {
         this._sockets.push(sock);
         const label = gcm ? ' (GCM/3.5)' : encrypted ? ' (ECB)' : ' (plaintext)';
         this._log(`[UDP-DISC] Listening on port ${  port  }${label}`);
-        resolve();
+        done();
       });
-      this.homey.setTimeout(() => { if (this._destroyed) return; resolve(); }, 3000);
+      timer = globalThis.setTimeout(done, 3000);
+      timer.unref?.();
     });
   }
 
@@ -141,6 +153,7 @@ class TuyaUDPDiscovery extends EventEmitter {
 
   async stop() {
     this._running = false;
+    this._destroyed = true;
     if (this._cleanupInterval) { clearInterval(this._cleanupInterval); this._cleanupInterval = null; }
     for (const sock of this._sockets) {
       try { sock.close(); } catch (e) { /* cleanup - safe to ignore */ }

--- a/lib/wifi/WiFiConnectionPolicy.js
+++ b/lib/wifi/WiFiConnectionPolicy.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const DEFAULT_WIFI_CONNECTION_POLICY = Object.freeze({
+  schemaVersion: 1,
+  strategy: 'local_first',
+  pairingMode: 'ad_hoc',
+  transport: 'lan',
+  localDiscovery: true,
+  cloudFallback: false,
+  cloudMirroring: false,
+});
+
+function asBoolean(value, fallback) {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function normalizeWiFiConnectionPolicy(policy = {}) {
+  const source = policy && typeof policy === 'object' ? policy : {};
+
+  return {
+    schemaVersion: Number.isInteger(source.schemaVersion) ? source.schemaVersion : DEFAULT_WIFI_CONNECTION_POLICY.schemaVersion,
+    strategy: source.strategy || DEFAULT_WIFI_CONNECTION_POLICY.strategy,
+    pairingMode: source.pairingMode || DEFAULT_WIFI_CONNECTION_POLICY.pairingMode,
+    transport: source.transport || DEFAULT_WIFI_CONNECTION_POLICY.transport,
+    localDiscovery: asBoolean(source.localDiscovery, DEFAULT_WIFI_CONNECTION_POLICY.localDiscovery),
+    cloudFallback: asBoolean(source.cloudFallback, DEFAULT_WIFI_CONNECTION_POLICY.cloudFallback),
+    cloudMirroring: asBoolean(source.cloudMirroring, DEFAULT_WIFI_CONNECTION_POLICY.cloudMirroring),
+  };
+}
+
+function createWiFiConnectionPolicy(overrides = {}) {
+  return normalizeWiFiConnectionPolicy({
+    ...DEFAULT_WIFI_CONNECTION_POLICY,
+    ...overrides,
+  });
+}
+
+function createWiFiConnectionStore(overrides = {}) {
+  return {
+    wifi_connection_policy: createWiFiConnectionPolicy(overrides),
+  };
+}
+
+function allowsCloudFallback(policy) {
+  return normalizeWiFiConnectionPolicy(policy).cloudFallback === true;
+}
+
+module.exports = {
+  DEFAULT_WIFI_CONNECTION_POLICY,
+  normalizeWiFiConnectionPolicy,
+  createWiFiConnectionPolicy,
+  createWiFiConnectionStore,
+  allowsCloudFallback,
+};

--- a/scripts/validation/check-wifi-lifecycle.js
+++ b/scripts/validation/check-wifi-lifecycle.js
@@ -12,6 +12,7 @@ const fs = require('fs');
 const path = require('path');
 
 const DRIVERS_DIR = path.join(__dirname, '..', '..', 'drivers');
+const ROOT_DIR = path.join(__dirname, '..', '..');
 const WIFI_PREFIX = 'wifi_';
 
 let errors = 0;
@@ -96,12 +97,60 @@ function scanDrivers() {
     checkFile(driverPath, driver);
   }
 
+  checkSharedWiFiLocalFirstLayer();
+
   console.log(`\n📊 Results: ${errors} errors, ${warnings} warnings`);
   if (errors > 0) {
     console.log('❌ FAILED - Fix errors before committing');
     process.exit(1);
   } else {
     console.log('✅ PASSED');
+  }
+}
+
+function checkSharedWiFiLocalFirstLayer() {
+  const required = [
+    {
+      file: path.join(ROOT_DIR, 'lib', 'tuya-local', 'TuyaLocalDriver.js'),
+      tokens: ['createWiFiConnectionStore', 'pairingMode', 'cloudFallback: false'],
+      message: 'Tuya pairing must stamp devices with local-first/ad-hoc policy and cloud fallback disabled',
+    },
+    {
+      file: path.join(ROOT_DIR, 'lib', 'tuya-local', 'TuyaLocalDevice.js'),
+      tokens: ['_allowsCloudKeyRecovery', 'Cloud key recovery skipped by local-first policy'],
+      message: 'Tuya runtime must keep cloud key recovery opt-in',
+    },
+    {
+      file: path.join(ROOT_DIR, 'lib', 'ewelink-local', 'EweLinkLocalDriver.js'),
+      tokens: ['createWiFiConnectionStore', "pairingMode:'ad_hoc'"],
+      message: 'eWeLink pairing must stamp devices with local-first/ad-hoc policy',
+    },
+  ];
+
+  for (const item of required) {
+    const relPath = path.relative(process.cwd(), item.file);
+    if (!fs.existsSync(item.file)) {
+      log('ERROR', relPath, item.message);
+      continue;
+    }
+    const content = fs.readFileSync(item.file, 'utf8');
+    for (const token of item.tokens) {
+      if (!content.includes(token)) {
+        log('ERROR', relPath, `${item.message} (missing ${token})`);
+      }
+    }
+  }
+
+  for (const rel of [
+    path.join('lib', 'tuya-local', 'TuyaDeviceDiscovery.js'),
+    path.join('lib', 'tuya-local', 'TuyaUDPDiscovery.js'),
+  ]) {
+    const file = path.join(ROOT_DIR, rel);
+    if (!fs.existsSync(file)) continue;
+    const content = fs.readFileSync(file, 'utf8');
+    if (/this\.homey\.(setTimeout|setInterval)/.test(content)) {
+      log('ERROR', path.relative(process.cwd(), file), 'LAN discovery helper uses Homey timers without a Homey context');
+    }
   }
 }
 

--- a/test/critical/smartlife-wifi-regressions.test.js
+++ b/test/critical/smartlife-wifi-regressions.test.js
@@ -19,6 +19,9 @@ Module._load = function loadWithHomeyMock(request, parent, isMain) {
 const { parseDPValue, stringifyDPValue } = require('../../lib/tuya-local/DPValueParser');
 const TuyaLocalClient = require('../../lib/tuya-local/TuyaLocalClient');
 const TuyaLocalDevice = require('../../lib/tuya-local/TuyaLocalDevice');
+const TuyaLocalDriver = require('../../lib/tuya-local/TuyaLocalDriver');
+const TuyaDeviceDiscovery = require('../../lib/tuya-local/TuyaDeviceDiscovery');
+const TuyaUDPDiscovery = require('../../lib/tuya-local/TuyaUDPDiscovery');
 const TuyaCloudAPI = require('../../lib/tuya-local/TuyaCloudAPI');
 const TuyaSmartLifeAuth = require('../../lib/tuya-local/TuyaSmartLifeAuth');
 const { ERROR_CATEGORY, classifyError } = require('../../lib/utils/ErrorClassifier');
@@ -82,6 +85,65 @@ describe('SmartLife/Tuya WiFi regressions', () => {
     await client.destroy();
 
     assert(refreshes >= 1);
+  });
+
+  it('keeps LAN discovery scans independent from Homey timer APIs', async () => {
+    const discovery = new TuyaDeviceDiscovery({ log: { log: () => {}, error: () => {} }, timeout: 1 });
+    discovery._startListening = () => {};
+
+    const devices = await discovery.scan(1);
+
+    assert.deepStrictEqual(devices, []);
+  });
+
+  it('settles LAN discovery scans when stopped before timeout', async () => {
+    const discovery = new TuyaDeviceDiscovery({ log: { log: () => {}, error: () => {} }, timeout: 1000 });
+    discovery._startListening = () => {};
+
+    const pending = discovery.scan(1000);
+    discovery.stop();
+    const devices = await pending;
+
+    assert.deepStrictEqual(devices, []);
+  });
+
+  it('keeps global UDP discovery cleanup independent from Homey timer APIs', async () => {
+    const discovery = new TuyaUDPDiscovery({ log: () => {} });
+    let boundPorts = 0;
+    discovery._bindSocket = async () => { boundPorts++; };
+
+    await discovery.start();
+    await discovery.stop();
+
+    assert.strictEqual(boundPorts, 3);
+  });
+
+  it('stamps manually paired Tuya WiFi devices as local-first ad-hoc without cloud fallback', () => {
+    const driver = Object.create(TuyaLocalDriver.prototype);
+    const descriptor = driver._toLocalFirstPairDevice({
+      id: 'bf1234567890abcdef',
+      local_key: '0123456789abcdef',
+      ip: '192.168.1.50',
+      version: '3.5',
+      name: 'Desk Plug',
+    }, 'ad_hoc');
+
+    assert.strictEqual(descriptor.store.wifi_connection_policy.strategy, 'local_first');
+    assert.strictEqual(descriptor.store.wifi_connection_policy.pairingMode, 'ad_hoc');
+    assert.strictEqual(descriptor.store.wifi_connection_policy.cloudFallback, false);
+    assert.strictEqual(descriptor.store.wifi_connection_policy.localDiscovery, true);
+    assert.strictEqual(descriptor.settings.ip_address, '192.168.1.50');
+    assert.strictEqual(descriptor.settings.protocol_version, '3.5');
+  });
+
+  it('keeps Tuya WiFi cloud key recovery opt-in for local-first devices', () => {
+    const device = Object.create(TuyaLocalDevice.prototype);
+
+    device.getStoreValue = () => undefined;
+    assert.strictEqual(TuyaLocalDevice.prototype._allowsCloudKeyRecovery.call(device), false);
+
+    device.getStoreValue = key => key === 'wifi_connection_policy' ? { cloudFallback: true } : undefined;
+    assert.strictEqual(TuyaLocalDevice.prototype._allowsCloudKeyRecovery.call(device), true);
   });
 
   it('settles command timeouts even after the local client is destroyed', async () => {


### PR DESCRIPTION
## Summary

- Make Tuya WiFi pairing stamp added devices with an explicit `local_first` / `ad_hoc` policy and keep runtime cloud key recovery opt-in instead of automatic.
- Fix Tuya LAN discovery helpers so scans and UDP cleanup use native timers rather than a missing Homey context.
- Put Tuya WiFi pairing screens on the Local / Ad hoc tab by default and replace SONOFF/eWeLink pairing screens with the eWeLink local setup UI.
- Add WiFi lifecycle/test guards so local-first policy and LAN discovery timer behavior cannot regress quietly.

## Root Cause

The WiFi runtime was mostly local already, but pairing did not persist an explicit local-first policy, automatic key recovery could still call cloud on auth errors, and LAN discovery helpers used `this.homey` timers even though those helper classes are not Homey objects. Several SONOFF/eWeLink drivers also had Tuya pairing HTML copied into local eWeLink drivers, which made ad-hoc setup confusing or wrong.

## Validation

- `npx mocha test/critical/smartlife-wifi-regressions.test.js --timeout 5000` -> 14 passing
- `npm test` -> 85 passing
- `npm run check:wifi` -> 0 errors, existing warnings only
- `npm run check:timer-context` -> passed
- `npm run check:button-flows` -> no errors/warnings
- `npm run check:flows` -> no duplicates
- `npm run security-scan` -> clean
- `npm run check:all` -> passed with existing warnings
- `npm run validate:debug` -> validated successfully with existing titleFormatted warnings
- `npm run build` -> built successfully
- `npm run prepare-publish` -> publish payload gate passed
- pre-commit hook -> passed
- pre-push gate -> passed