### PR TITLE
Fix multi-gang button flow routing

### DIFF
--- a/.github/workflows/fetch-diags.yml
+++ b/.github/workflows/fetch-diags.yml
@@ -60,6 +60,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit || npm install
 
       - name: Fetch Diagnostics from Gmail
+        id: gmail_fetch
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
@@ -73,14 +74,24 @@ jobs:
           GMAIL_DIAG_REPROCESS: ${{ github.event.inputs.reprocess || 'false' }}
           GMAIL_DIAG_AI_MAX: "0"
           DRY_RUN: "true"
-        run: node .github/scripts/fetch-gmail-diagnostics.js
+        run: |
+          set +e
+          node .github/scripts/fetch-gmail-diagnostics.js
+          code=$?
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+          if [ "$code" -ne 0 ]; then
+            echo "::warning::Gmail diagnostics fetch failed with exit code $code; privacy gates and sanitized state commit will still run."
+          fi
+          exit 0
 
       - name: Privacy and diagnostic gates
+        if: always()
         run: |
           node .github/scripts/privacy-redactor.js .github/state/diagnostics-state.json .github/state/diagnostics-report.json .github/state/gmail-token-health.json .github/state/diagnostics-crossref.yml diagnostics
           npm run check:diag-history
 
       - name: Commit and Push changes
+        if: always()
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
@@ -92,3 +103,9 @@ jobs:
           else
             echo "No sanitized diagnostic state changes to push"
           fi
+
+      - name: Assert Gmail diagnostics access
+        if: always() && steps.gmail_fetch.outputs.exit_code != '0'
+        run: |
+          echo "::error::Gmail diagnostics could not authenticate via IMAP. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD secrets, then rerun Fetch Homey Diagnostics."
+          exit 1

--- a/drivers/switch_2gang/driver.js
+++ b/drivers/switch_2gang/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseZigBeeDriver = require('../../lib/drivers/BaseZigBeeDriver');
+const { setGangOnOff, setAllGangsOnOff } = require('../../lib/drivers/FlowGangControl');
 
 /**
  * 2-Gang Switch Driver v8.1.0
@@ -52,7 +53,7 @@ class TuyaZigbeeDriver extends BaseZigBeeDriver {
     // ACTIONS
     gangs.forEach((gang, idx) => {
       try {
-        const cap = idx === 0 ? 'onoff' : `onoff.gang${idx + 1}`;
+        const gangNumber = idx + 1;
         ['turn_on', 'turn_off', 'toggle'].forEach(action => {
           try {
             const id = `${P}_${action}_${gang}`;
@@ -60,8 +61,8 @@ class TuyaZigbeeDriver extends BaseZigBeeDriver {
             if (card) {
               card.registerRunListener(async (args) => {
                 if (!args.device) {return false;}
-                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : !args.device.getCapabilityValue(cap);
-                await args.device['setCapabilityValue'](cap, val);
+                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : 'toggle';
+                await setGangOnOff(args.device, gangNumber, val);
                 return true;
               });
             }
@@ -77,12 +78,7 @@ class TuyaZigbeeDriver extends BaseZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            for (let i = 1; i <= 2; i++) {
-              const cap = i === 1 ? 'onoff' : `onoff.gang${i}`;
-              if (args.device.hasCapability(cap)) {
-                await args.device['setCapabilityValue'](cap, action === 'turn_on_all').catch(() => {});
-              }
-            }
+            await setAllGangsOnOff(args.device, 2, action === 'turn_on_all');
             return true;
           });
         }

--- a/drivers/switch_3gang/driver.js
+++ b/drivers/switch_3gang/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseZigBeeDriver = require('../../lib/drivers/BaseZigBeeDriver');
+const { setGangOnOff } = require('../../lib/drivers/FlowGangControl');
 
 class TuyaZigbeeDriver extends BaseZigBeeDriver {
 async onInit() {
@@ -43,8 +44,8 @@ async onInit() {
     // ACTIONS
     ['gang1', 'gang2', 'gang3'].forEach((gang, idx) => {
       try {
-        const cap = idx === 0 ? 'onoff' : `onoff.gang${idx + 1}`;
-        
+        const gangNumber = idx + 1;
+
         ['turn_on', 'turn_off', 'toggle'].forEach(action => {
           try {
             const id = `${P}_${action}_${gang}`;
@@ -52,8 +53,8 @@ async onInit() {
             if (card) {
               card.registerRunListener(async (args) => {
                 if (!args.device) {return false;}
-                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : !args.device.getCapabilityValue(cap);
-                await args.device['setCapabilityValue'](cap, val);
+                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : 'toggle';
+                await setGangOnOff(args.device, gangNumber, val);
                 return true;
               });
             }

--- a/drivers/switch_4gang/driver.js
+++ b/drivers/switch_4gang/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const BaseZigBeeDriver = require('../../lib/drivers/BaseZigBeeDriver');
+const { setGangOnOff, setAllGangsOnOff } = require('../../lib/drivers/FlowGangControl');
 
 class TuyaZigbeeDriver extends BaseZigBeeDriver {
 async onInit() {
@@ -44,7 +45,7 @@ async onInit() {
     // ACTIONS
     gangs.forEach((gang, idx) => {
       try {
-        const cap = idx === 0 ? 'onoff' : `onoff.gang${idx + 1}`;
+        const gangNumber = idx + 1;
         ['turn_on', 'turn_off', 'toggle'].forEach(action => {
           try {
             const id = `${P}_${action}_${gang}`;
@@ -52,8 +53,8 @@ async onInit() {
             if (card) {
               card.registerRunListener(async (args) => {
                 if (!args.device) {return false;}
-                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : !args.device.getCapabilityValue(cap);
-                await args.device['setCapabilityValue'](cap, val);
+                const val = action === 'turn_on' ? true : action === 'turn_off' ? false : 'toggle';
+                await setGangOnOff(args.device, gangNumber, val);
                 return true;
               });
             }
@@ -69,12 +70,7 @@ async onInit() {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            for (let i = 1; i <= 4; i++) {
-              const cap = i === 1 ? 'onoff' : `onoff.gang${i}`;
-              if (args.device.hasCapability(cap)) {
-                await args.device['setCapabilityValue'](cap, action === 'turn_on_all').catch(() => {});
-              }
-            }
+            await setAllGangsOnOff(args.device, 4, action === 'turn_on_all');
             return true;
           });
         }

--- a/drivers/wall_switch_2gang_1way/driver.js
+++ b/drivers/wall_switch_2gang_1way/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ZigBeeDriver } = require('homey-zigbeedriver');
+const { setGangOnOff, setAllGangsOnOff } = require('../../lib/drivers/FlowGangControl');
 
 /**
  * Wall Switch 2-Gang 1-Way Driver (BSEED Sub-Device)
@@ -64,9 +65,9 @@ class WallSwitch2Gang1WayDriver extends ZigBeeDriver {
 
     // ACTION: Virtual control
     const simpleActions = [
-      { id: `${P}_turn_on`, fn: async (d) => { await d['setCapabilityValue']('onoff', true); } },
-      { id: `${P}_turn_off`, fn: async (d) => { await d['setCapabilityValue']('onoff', false); } },
-      { id: `${P}_toggle`, fn: async (d) => { const v = d.getCapabilityValue('onoff'); await d['setCapabilityValue']('onoff', !v); } },
+      { id: `${P}_turn_on`, fn: async (d) => setGangOnOff(d, 1, true) },
+      { id: `${P}_turn_off`, fn: async (d) => setGangOnOff(d, 1, false) },
+      { id: `${P}_toggle`, fn: async (d) => setGangOnOff(d, 1, 'toggle') },
     ];
 
     for (const { id, fn } of simpleActions) {
@@ -100,13 +101,8 @@ class WallSwitch2Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
             try {
-              if (val === 'toggle') {
-                await args.device['setCapabilityValue'](cap, !args.device.getCapabilityValue(cap));
-              } else {
-                await args.device['setCapabilityValue'](cap, val);
-              }
+              await setGangOnOff(args.device, ep, val);
             } catch (e) {
               args.device.error('Flow Action Error:', e);
             }
@@ -130,11 +126,7 @@ class WallSwitch2Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const numGangs = 2; // Hardcoded for this driver
-            for (let ep = 1; ep <= numGangs; ep++) {
-              const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
-              await args.device['setCapabilityValue'](cap, val).catch(() => {});
-            }
+            await setAllGangsOnOff(args.device, 2, val);
             return true;
           });
         }

--- a/drivers/wall_switch_3gang_1way/driver.js
+++ b/drivers/wall_switch_3gang_1way/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ZigBeeDriver } = require('homey-zigbeedriver');
+const { setGangOnOff, setAllGangsOnOff } = require('../../lib/drivers/FlowGangControl');
 
 class WallSwitch3Gang1WayDriver extends ZigBeeDriver {
   async onInit() {
@@ -58,9 +59,9 @@ class WallSwitch3Gang1WayDriver extends ZigBeeDriver {
 
     // Virtual control
     const simpleActions = [
-      { id: `${P}_turn_on`, fn: async (d) => { await d['setCapabilityValue']('onoff', true); } },
-      { id: `${P}_turn_off`, fn: async (d) => { await d['setCapabilityValue']('onoff', false); } },
-      { id: `${P}_toggle`, fn: async (d) => { const v = d.getCapabilityValue('onoff'); await d['setCapabilityValue']('onoff', !v); } },
+      { id: `${P}_turn_on`, fn: async (d) => setGangOnOff(d, 1, true) },
+      { id: `${P}_turn_off`, fn: async (d) => setGangOnOff(d, 1, false) },
+      { id: `${P}_toggle`, fn: async (d) => setGangOnOff(d, 1, 'toggle') },
     ];
 
     for (const { id, fn } of simpleActions) {
@@ -97,13 +98,8 @@ class WallSwitch3Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
             try {
-              if (val === 'toggle') {
-                await args.device['setCapabilityValue'](cap, !args.device.getCapabilityValue(cap));
-              } else {
-                await args.device['setCapabilityValue'](cap, val);
-              }
+              await setGangOnOff(args.device, ep, val);
             } catch (e) {
               args.device.error('Flow Action Error:', e);
             }
@@ -127,11 +123,7 @@ class WallSwitch3Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const numGangs = 3;
-            for (let ep = 1; ep <= numGangs; ep++) {
-              const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
-              await args.device['setCapabilityValue'](cap, val).catch(() => {});
-            }
+            await setAllGangsOnOff(args.device, 3, val);
             return true;
           });
         }

--- a/drivers/wall_switch_4gang_1way/driver.js
+++ b/drivers/wall_switch_4gang_1way/driver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ZigBeeDriver } = require('homey-zigbeedriver');
+const { setGangOnOff, setAllGangsOnOff } = require('../../lib/drivers/FlowGangControl');
 
 class WallSwitch4Gang1WayDriver extends ZigBeeDriver {
   async onInit() {
@@ -59,9 +60,9 @@ class WallSwitch4Gang1WayDriver extends ZigBeeDriver {
 
     // Virtual control
     const simpleActions = [
-      { id: `${P}_turn_on`, fn: async (d) => { await d['setCapabilityValue']('onoff', true); } },
-      { id: `${P}_turn_off`, fn: async (d) => { await d['setCapabilityValue']('onoff', false); } },
-      { id: `${P}_toggle`, fn: async (d) => { const v = d.getCapabilityValue('onoff'); await d['setCapabilityValue']('onoff', !v); } },
+      { id: `${P}_turn_on`, fn: async (d) => setGangOnOff(d, 1, true) },
+      { id: `${P}_turn_off`, fn: async (d) => setGangOnOff(d, 1, false) },
+      { id: `${P}_toggle`, fn: async (d) => setGangOnOff(d, 1, 'toggle') },
     ];
 
     for (const { id, fn } of simpleActions) {
@@ -101,13 +102,8 @@ class WallSwitch4Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
             try {
-              if (val === 'toggle') {
-                await args.device['setCapabilityValue'](cap, !args.device.getCapabilityValue(cap));
-              } else {
-                await args.device['setCapabilityValue'](cap, val);
-              }
+              await setGangOnOff(args.device, ep, val);
             } catch (e) {
               args.device.error('Flow Action Error:', e);
             }
@@ -131,11 +127,7 @@ class WallSwitch4Gang1WayDriver extends ZigBeeDriver {
         if (card) {
           card.registerRunListener(async (args) => {
             if (!args.device) {return false;}
-            const numGangs = 4;
-            for (let ep = 1; ep <= numGangs; ep++) {
-              const cap = ep === 1 ? 'onoff' : `onoff.gang${  ep}`;
-              await args.device['setCapabilityValue'](cap, val).catch(() => {});
-            }
+            await setAllGangsOnOff(args.device, 4, val);
             return true;
           });
         }

--- a/lib/devices/UnifiedSwitchBase.js
+++ b/lib/devices/UnifiedSwitchBase.js
@@ -7,6 +7,7 @@ const DeviceTypeManager = require('./DeviceTypeManager');
 const ManufacturerVariationManager = require('../ManufacturerVariationManager');
 const { getModelId, getManufacturer } = require('../helpers/DeviceDataHelper');
 const { ensureManufacturerSettings } = require('../helpers/ManufacturerNameHelper');
+const { capabilityForGang } = require('../drivers/FlowGangControl');
 
 // v5.5.818: BSEED TS0726 FIX - Import OnOffBoundCluster for outputCluster command reception
 let OnOffBoundCluster = null;
@@ -186,6 +187,12 @@ class UnifiedSwitchBase extends TuyaZigbeeDevice {
       this._registerCapabilityListeners();
     } catch (e) {
       this.error(`[HYBRID-SWITCH] ❌ Capability listeners: ${e.message}`);
+    }
+
+    try {
+      this._registerButtonCapabilityListeners();
+    } catch (e) {
+      this.error(`[HYBRID-SWITCH] ❌ Button capability listeners: ${e.message}`);
     }
 
     // v5.5.812: Setup additional features (non-critical)
@@ -626,6 +633,36 @@ class UnifiedSwitchBase extends TuyaZigbeeDevice {
         await this.setSettings({ power_on_behavior: value }).catch(() => {});
         return true;
       });
+    }
+  }
+
+  _registerButtonCapabilityListeners() {
+    if (!this._buttonCapListenersRegistered) {this._buttonCapListenersRegistered = new Set();}
+
+    for (let gang = 1; gang <= this.gangCount; gang++) {
+      const capability = `button.${gang}`;
+      if (!this.hasCapability(capability) || this._buttonCapListenersRegistered.has(capability)) {
+        continue;
+      }
+
+      this.registerCapabilityListener(capability, async () => {
+        this.log(`[BUTTON-UI] ${capability} pressed; routing to gang ${gang}`);
+
+        if (typeof this._triggerPhysicalFlow === 'function') {
+          this._triggerPhysicalFlow(gang, 'single', { source: 'virtual', _internalTrigger: true });
+        }
+
+        const switchCapability = capabilityForGang(gang);
+        if (this.hasCapability(switchCapability)) {
+          const currentValue = this.getCapabilityValue(switchCapability);
+          await this._setGangOnOff(gang, !currentValue);
+        }
+
+        return true;
+      });
+
+      this._buttonCapListenersRegistered.add(capability);
+      this.log(`[HYBRID-SWITCH] ✅ Registered ${capability} listener`);
     }
   }
 

--- a/lib/drivers/FlowGangControl.js
+++ b/lib/drivers/FlowGangControl.js
@@ -1,0 +1,63 @@
+'use strict';
+
+function capabilityForGang(gang) {
+  return gang === 1 ? 'onoff' : `onoff.gang${gang}`;
+}
+
+function readCapability(device, capability) {
+  try {
+    return device.getCapabilityValue(capability);
+  } catch (_) {
+    return false;
+  }
+}
+
+async function syncCapability(device, capability, value) {
+  if (!device?.hasCapability?.(capability)) return;
+  if (typeof device.safeSetCapabilityValue === 'function') {
+    await device.safeSetCapabilityValue(capability, value).catch(() => {});
+    return;
+  }
+  await device.setCapabilityValue?.(capability, value).catch(() => {});
+}
+
+async function setGangOnOff(device, gang, value) {
+  if (!device) return false;
+  const capability = capabilityForGang(gang);
+  const nextValue = value === 'toggle'
+    ? !readCapability(device, capability)
+    : value === true;
+
+  if (typeof device._setGangOnOff === 'function') {
+    await device._setGangOnOff(gang, nextValue);
+    await syncCapability(device, capability, nextValue);
+    return true;
+  }
+
+  if (typeof device.triggerCapabilityListener === 'function') {
+    try {
+      await device.triggerCapabilityListener(capability, nextValue);
+      await syncCapability(device, capability, nextValue);
+      return true;
+    } catch (_) {
+      // Fall through to UI sync for legacy devices without a listener.
+    }
+  }
+
+  await syncCapability(device, capability, nextValue);
+  return true;
+}
+
+async function setAllGangsOnOff(device, gangCount, value) {
+  if (!device) return false;
+  for (let gang = 1; gang <= gangCount; gang++) {
+    await setGangOnOff(device, gang, value);
+  }
+  return true;
+}
+
+module.exports = {
+  capabilityForGang,
+  setGangOnOff,
+  setAllGangsOnOff,
+};

--- a/test/button-flow-runtime-routing.test.js
+++ b/test/button-flow-runtime-routing.test.js
@@ -118,4 +118,52 @@ describe('button flow runtime routing guards', function() {
     assert.match(source, /await this\.triggerButtonPress\(i, 'single', 1, \{ source: 'virtual' \}\)/);
     assert.match(source, /await this\._triggerPhysicalFlow\?\.\(i, 'single', \{ source: 'virtual', _internalTrigger: true \}\)/);
   });
+
+  it('routes mixed switch button UI and flow actions through real gang commands', async function() {
+    const switchBase = read('lib/devices/UnifiedSwitchBase.js');
+    const flowHelper = read('lib/drivers/FlowGangControl.js');
+    const drivers = [
+      'drivers/switch_2gang/driver.js',
+      'drivers/switch_3gang/driver.js',
+      'drivers/switch_4gang/driver.js',
+      'drivers/wall_switch_2gang_1way/driver.js',
+      'drivers/wall_switch_3gang_1way/driver.js',
+      'drivers/wall_switch_4gang_1way/driver.js',
+    ];
+
+    assert.match(switchBase, /_registerButtonCapabilityListeners\(\)/);
+    assert.match(switchBase, /this\.registerCapabilityListener\(capability, async \(\) =>/);
+    assert.match(switchBase, /this\._triggerPhysicalFlow\(gang, 'single', \{ source: 'virtual', _internalTrigger: true \}\)/);
+    assert.match(switchBase, /await this\._setGangOnOff\(gang, !currentValue\)/);
+    assert.match(flowHelper, /device\._setGangOnOff\(gang, nextValue\)/);
+
+    for (const driver of drivers) {
+      const source = read(driver);
+      assert.match(source, /FlowGangControl/);
+      assert.doesNotMatch(source, /\['setCapabilityValue'\]\(cap/);
+    }
+
+    const { setGangOnOff, setAllGangsOnOff } = require('../lib/drivers/FlowGangControl');
+    const commands = [];
+    const values = { onoff: false, 'onoff.gang2': true };
+    const fakeDevice = {
+      hasCapability: cap => Object.prototype.hasOwnProperty.call(values, cap),
+      getCapabilityValue: cap => values[cap],
+      _setGangOnOff: async (gang, value) => {
+        commands.push([gang, value]);
+      },
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+    };
+
+    await setGangOnOff(fakeDevice, 2, 'toggle');
+    assert.deepStrictEqual(commands, [[2, false]]);
+    assert.strictEqual(values['onoff.gang2'], false);
+
+    await setAllGangsOnOff(fakeDevice, 2, true);
+    assert.deepStrictEqual(commands.slice(-2), [[1, true], [2, true]]);
+    assert.strictEqual(values.onoff, true);
+    assert.strictEqual(values['onoff.gang2'], true);
+  });
 });


### PR DESCRIPTION
## Summary
- Fix mixed wall-switch/button devices that showed `Missing Capability Listener: Button N` by registering `button.N` virtual capability listeners in `UnifiedSwitchBase`.
- Route 2/3/4-gang switch and wall-switch flow actions through a shared `FlowGangControl` helper so flows send real gang commands instead of only updating UI capabilities.
- Harden the Gmail diagnostics workflow so failed IMAP auth still preserves sanitized health/report artifacts before failing with an explicit secret-refresh message.

## Sources crossed
- Homey forum test thread #2099: `_TZ3000_mrduubod` / `TS0014` Moes 4-gang switch reported as 4 buttons with `Missing Capability Listener: Button 1..4`.
- GitHub activity: open #428/#439 checked, recent Gemini/PR activity checked; no open Gemini-requested change remained after prior merged PRs.
- Gmail/Homey diagnostics: Gmail connector/IMAP currently blocked by invalid auth, so workflow now records the blocker and gives a clear remediation instead of losing the diagnostic state.

## Validation
- `npx mocha test/button-flow-runtime-routing.test.js test/critical/forum-routing-regressions.test.js --timeout 10000`
- `npm test`
- `npm run check:all`
- `npm run check:button-flows`
- `npm run check:flows`
- `npm run check:yaml`
- `npm run check:diag-history`
- `npm run security-scan`
- `npm run build`
- `npm run validate:publish`
- `npm run prepare-publish`
- `npm run precommit`
- Git pre-push gate passed