### PR TITLE
Add Gmail OAuth diagnostics fallback

### DIFF
--- a/.github/scripts/fetch-gmail-diagnostics.js
+++ b/.github/scripts/fetch-gmail-diagnostics.js
@@ -458,7 +458,7 @@ async function main(){
   const modesUsed=new Set();
   for(const win of windows){
     if(emails.length>=fetchOptions.maxTotalResults)break;
-    console.log('IMAP window:',JSON.stringify(win));
+    console.log('Gmail window:',JSON.stringify(win));
     let batch;
     let mode=null;
     if(hasImapCredentials&&imap){
@@ -474,8 +474,6 @@ async function main(){
         imapConnectionFailed=true;
         if(batch!==null)console.error('IMAP returned an invalid response; trying OAuth fallback if available');
       }
-    }else{
-      imapConnectionFailed=true;
     }
     if(!Array.isArray(batch)&&hasOAuthCredentials&&oauth){
       console.log('OAuth fallback window:',JSON.stringify(win));
@@ -491,7 +489,6 @@ async function main(){
       }
     }
     if(!Array.isArray(batch)){
-      if(!hasOAuthCredentials)oauthConnectionFailed=true;
       continue;
     }
     modesUsed.add(mode||'unknown');
@@ -502,7 +499,7 @@ async function main(){
       if(emails.length>=fetchOptions.maxTotalResults)break;
     }
   }
-  if(imapConnectionFailed&&!emails.length){
+  if((imapConnectionFailed||oauthConnectionFailed)&&!emails.length){
     const code=hasOAuthCredentials?'gmail_auth_failed':'imap_connection_failed';
     const msg=hasOAuthCredentials
       ? 'IMAP and OAuth Gmail access both failed before diagnostics could be fetched. Refresh Gmail IMAP app password and OAuth refresh token secrets, then rerun Gmail Diagnostics.'

--- a/.github/scripts/fetch-gmail-diagnostics.js
+++ b/.github/scripts/fetch-gmail-diagnostics.js
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 'use strict';
-// v5.12.6: IMAP-only mode — OAuth removed entirely
+// v5.13.2: IMAP primary with OAuth fallback when Gmail app-password auth breaks
 const fs=require('fs'),path=require('path');
 const{fetchWithRetry}=require('./retry-helper');
 const privacy=require('./privacy-redactor');
 let eng=null;try{eng=require('./fp-research-engine')}catch{}
 let imap=null;try{imap=require('./gmail-imap-reader')}catch(err){console.error('gmail-imap-reader load error:',err.message)}
+let oauth=null;try{oauth=require('./gmail-oauth-reader')}catch(err){console.error('gmail-oauth-reader load error:',err.message)}
 const{extractFP:_vFP,extractFPWithBrands:_vFPB,extractPID:_vPID,isValidTuyaFP}=require('./fp-validator');
 let KB=null;try{KB=require('./bug-knowledge-base')}catch{}
 const SD=path.join(__dirname,'..','state');
@@ -396,9 +397,10 @@ function runSummary(fetchOptions,extra={}){
 
 function writeAccessFailureReport(fetchOptions,code,message,extra={}){
   const now=new Date().toISOString();
+  const mode=extra.mode||'imap';
   const report=privacy.redactObject({timestamp:now,count:0,
     run:runSummary(fetchOptions,extra),
-    access:{gmail:{ok:false,mode:'imap',code,message:privacy.redact(message)}},
+    access:{gmail:{ok:false,mode,code,message:privacy.redact(message)}},
     byType:{},newFingerprints:[],
     history:{diagnosticsAnalyzed:0,score:0,status:'blocked',categories:[],recommendedChecks:[],topErrors:[],latestEvents:[],missingGuardrails:[]},
     deepResearch:{researched:0,added:0,details:[],autoImplement:fetchOptions.autoImplement},
@@ -417,8 +419,8 @@ function writeAccessFailureReport(fetchOptions,code,message,extra={}){
       previousChecks=Array.isArray(existing.checks)?existing.checks.slice(-19):[];
     }
   }catch{}
-  const check={time:now,ok:false,mode:'imap',code,message:privacy.redact(message)};
-  const health=privacy.redactObject({mode:'imap',lastOk,lastFail:now,consecutiveFails,
+  const check={time:now,ok:false,mode,code,message:privacy.redact(message)};
+  const health=privacy.redactObject({mode,lastOk,lastFail:now,consecutiveFails,
     errorCode:code,checks:[...previousChecks,check]});
   privacy.assertNoLeaks(health,HF);
   fs.writeFileSync(HF,JSON.stringify(health,null,2));
@@ -426,22 +428,25 @@ function writeAccessFailureReport(fetchOptions,code,message,extra={}){
 
 async function main(){
   const fetchOptions=parseFetchOptions(process.argv.slice(2));
-  // v5.12.6: IMAP-only — no OAuth, no token expiry, permanent
   const e=process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL;
   const p=process.env.GMAIL_APP_PASSWORD||process.env.HOMEY_PASSWORD;
-  if(!e||!p){
-    const msg='IMAP credentials missing. Refresh the Gmail app credential, then rerun Gmail diagnostics.';
-    console.error('IMAP credentials missing. Set GMAIL_EMAIL + GMAIL_APP_PASSWORD (see SECRETS.md)');
-    writeAccessFailureReport(fetchOptions,'missing_imap_credentials',msg);
+  const hasImapCredentials=Boolean(e&&p);
+  const hasOAuthCredentials=Boolean(oauth&&oauth.hasOAuthCredentials&&oauth.hasOAuthCredentials());
+  if(!hasImapCredentials&&!hasOAuthCredentials){
+    const msg='Gmail credentials missing. Set GMAIL_EMAIL/GMAIL_APP_PASSWORD or Gmail OAuth secrets, then rerun Gmail diagnostics.';
+    console.error('Gmail credentials missing. Set IMAP credentials or GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET + GMAIL_REFRESH_TOKEN.');
+    writeAccessFailureReport(fetchOptions,'missing_gmail_credentials',msg,{mode:'imap+oauth'});
     process.exit(1);
   }
-  if(!imap){
+  if(hasImapCredentials&&!imap&&!hasOAuthCredentials){
     const msg='gmail-imap-reader is unavailable. Install the IMAP dependencies before rerunning Gmail diagnostics.';
     console.error('gmail-imap-reader not available. npm install imapflow');
     writeAccessFailureReport(fetchOptions,'imap_reader_unavailable',msg);
     process.exit(1);
   }
-  console.log('IMAP-only mode — connecting as',safeAlias('account',e));
+  console.log('Gmail diagnostics mode — IMAP primary, OAuth fallback:',hasOAuthCredentials?'available':'unavailable');
+  if(hasImapCredentials)console.log('IMAP primary — connecting as',safeAlias('account',e));
+  else console.log('IMAP primary unavailable — missing GMAIL_EMAIL/GMAIL_APP_PASSWORD');
   console.log('Diagnostics fetch options:',JSON.stringify({mode:fetchOptions.allHistory?'all-history':'recent',
     since:fetchOptions.since||'rolling-30-days',until:fetchOptions.until||'now',
     maxResults:fetchOptions.maxResults,maxTotalResults:fetchOptions.maxTotalResults,
@@ -449,27 +454,47 @@ async function main(){
     reprocess:fetchOptions.reprocess,autoImplement:fetchOptions.autoImplement}));
   const windows=buildFetchWindows(fetchOptions);
   const emails=[],seenEmailIds=new Set();
-  let imapConnectionFailed=false;
+  let imapConnectionFailed=false,oauthConnectionFailed=false;
+  const modesUsed=new Set();
   for(const win of windows){
     if(emails.length>=fetchOptions.maxTotalResults)break;
     console.log('IMAP window:',JSON.stringify(win));
     let batch;
-    try{
-      batch=await imap.readViaIMAP({afterDate:win.since,untilDate:win.until,
-        maxResults:fetchOptions.maxResults,allHistory:fetchOptions.allHistory});
-    }catch(err){
-      console.error('IMAP read error:',privacy.redact(err.message));
-      batch=null;
-    }
-    if(batch===null){
+    let mode=null;
+    if(hasImapCredentials&&imap){
+      try{
+        batch=await imap.readViaIMAP({afterDate:win.since,untilDate:win.until,
+          maxResults:fetchOptions.maxResults,allHistory:fetchOptions.allHistory});
+      }catch(err){
+        console.error('IMAP read error:',privacy.redact(err.message));
+        batch=null;
+      }
+      if(Array.isArray(batch))mode='imap';
+      else{
+        imapConnectionFailed=true;
+        if(batch!==null)console.error('IMAP returned an invalid response; trying OAuth fallback if available');
+      }
+    }else{
       imapConnectionFailed=true;
-      continue;
+    }
+    if(!Array.isArray(batch)&&hasOAuthCredentials&&oauth){
+      console.log('OAuth fallback window:',JSON.stringify(win));
+      try{
+        batch=await oauth.readViaOAuth({afterDate:win.since,untilDate:win.until,
+          maxResults:fetchOptions.maxResults,allHistory:fetchOptions.allHistory});
+        if(Array.isArray(batch))mode='oauth';
+        else oauthConnectionFailed=true;
+      }catch(err){
+        oauthConnectionFailed=true;
+        batch=null;
+        console.error('OAuth read error:',privacy.redact(err.message));
+      }
     }
     if(!Array.isArray(batch)){
-      imapConnectionFailed=true;
-      console.error('IMAP returned an invalid response; refusing to treat this as an empty mailbox');
+      if(!hasOAuthCredentials)oauthConnectionFailed=true;
       continue;
     }
+    modesUsed.add(mode||'unknown');
     for(const em of batch){
       if(seenEmailIds.has(em.id))continue;
       seenEmailIds.add(em.id);
@@ -478,22 +503,29 @@ async function main(){
     }
   }
   if(imapConnectionFailed&&!emails.length){
-    const msg='IMAP connection failed before diagnostics could be fetched. Refresh the Gmail app credential, then rerun Gmail Diagnostics.';
-    console.error('::error::IMAP connection failed before diagnostics could be fetched. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD secrets, then rerun Gmail Diagnostics.');
-    writeAccessFailureReport(fetchOptions,'imap_connection_failed',msg,{windows:windows.length,fetched:0});
+    const code=hasOAuthCredentials?'gmail_auth_failed':'imap_connection_failed';
+    const msg=hasOAuthCredentials
+      ? 'IMAP and OAuth Gmail access both failed before diagnostics could be fetched. Refresh Gmail IMAP app password and OAuth refresh token secrets, then rerun Gmail Diagnostics.'
+      : 'IMAP connection failed before diagnostics could be fetched. Refresh the Gmail app credential, then rerun Gmail Diagnostics.';
+    console.error('::error::Gmail diagnostics could not authenticate. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and, if using OAuth fallback, GMAIL_REFRESH_TOKEN secrets.');
+    writeAccessFailureReport(fetchOptions,code,msg,{windows:windows.length,fetched:0,mode:hasOAuthCredentials?'imap+oauth':'imap'});
     process.exit(1);
   }
   if(imapConnectionFailed){
-    console.log('::warning::At least one IMAP window failed, but diagnostics were fetched from another window.');
+    console.log('::warning::At least one IMAP window failed, but diagnostics were fetched via',Array.from(modesUsed).join('+')||'fallback');
   }
-  if(!emails||!emails.length){console.log('No emails retrieved via IMAP');process.exit(0)}
-  console.log('IMAP OK:',emails.length,'emails across',windows.length,'window(s)');
+  if(oauthConnectionFailed&&hasOAuthCredentials&&!modesUsed.has('oauth')){
+    console.log('::warning::OAuth fallback did not fetch diagnostics.');
+  }
+  if(!emails||!emails.length){console.log('No emails retrieved via Gmail diagnostics');process.exit(0)}
+  const successMode=Array.from(modesUsed).join('+')||'unknown';
+  console.log('Gmail diagnostics OK:',emails.length,'emails across',windows.length,'window(s), mode:',successMode);
 
-  // Track IMAP health (replaces old OAuth health tracking)
+  // Track Gmail diagnostics health.
   const HF=path.join(SD,'gmail-token-health.json');
   try{
-    const h={mode:'imap',lastOk:new Date().toISOString(),consecutiveFails:0,emailsFetched:emails.length,
-      checks:[{time:new Date().toISOString(),ok:true,mode:'imap',windows:windows.length}]};
+    const h={mode:successMode,lastOk:new Date().toISOString(),consecutiveFails:0,emailsFetched:emails.length,
+      checks:[{time:new Date().toISOString(),ok:true,mode:successMode,windows:windows.length}]};
     const safeHealth=privacy.redactObject(h);privacy.assertNoLeaks(safeHealth,HF);
     fs.mkdirSync(SD,{recursive:true});fs.writeFileSync(HF,JSON.stringify(safeHealth,null,2));
   }catch{}
@@ -582,7 +614,7 @@ async function main(){
   const bt={};for(const r of res)bt[r.type]=(bt[r.type]||0)+1;
   const history=analyzeHistory(res);
   const report=privacy.redactObject({timestamp:st.lastCheck,count:res.length,
-    run:runSummary(fetchOptions,{fetched:emails.length,skippedAlreadyProcessed}),
+    run:runSummary(fetchOptions,{fetched:emails.length,skippedAlreadyProcessed,authMode:successMode}),
     byType:bt,newFingerprints:newFPs,history,deepResearch:impl,diagnostics:res});
   privacy.assertNoLeaks(report,RF);
   fs.writeFileSync(RF,JSON.stringify(report,null,2));
@@ -600,6 +632,7 @@ async function main(){
     yml+='  since: '+(fetchOptions.since||'rolling-30-days')+'\n';
     yml+='  until: '+(fetchOptions.until||'now')+'\n';
     yml+='  max_results: '+fetchOptions.maxResults+'\n';
+    yml+='  auth_mode: '+successMode+'\n';
     yml+='  max_total_results: '+fetchOptions.maxTotalResults+'\n';
     yml+='  chunk_days: '+fetchOptions.chunkDays+'\n';
     yml+='  reprocess: '+fetchOptions.reprocess+'\n';
@@ -742,7 +775,7 @@ async function main(){
   }catch(ye){console.log('YAML output error:',ye.message)}
 
 if(process.env.GITHUB_STEP_SUMMARY){
-    let sm='## Gmail Diagnostics (IMAP)\n| Metric | Count |\n|---|---|\n';
+    let sm='## Gmail Diagnostics ('+successMode+')\n| Metric | Count |\n|---|---|\n';
     sm+='| Emails | '+res.length+' |\n| New FPs | '+newFPs.length+' |\n';
     sm+='| Skipped already processed | '+skippedAlreadyProcessed+' |\n';
     sm+='| Researched | '+impl.researched+' |\n| Auto-added | '+impl.added+' |\n';

--- a/.github/scripts/gmail-oauth-reader.js
+++ b/.github/scripts/gmail-oauth-reader.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+'use strict';
+
+const privacy = require('./privacy-redactor');
+const {
+  parseMIME,
+  htmlToText,
+  extractPseudo,
+  extractCrashData,
+  decodeRFC2047
+} = require('./gmail-imap-reader');
+
+const TOKEN_URL = 'https://oauth2.googleapis.com/token';
+const GMAIL_API = 'https://gmail.googleapis.com/gmail/v1/users/me/messages';
+
+function boolValue(value) {
+  return /^(1|true|yes|on)$/i.test(String(value || '').trim());
+}
+
+function boundedInt(value, fallback, min, max) {
+  const n = Number.parseInt(String(value || ''), 10);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+function toYmdSlash(date) {
+  return date.toISOString().slice(0, 10).replace(/-/g, '/');
+}
+
+function resolveSinceDate(opts) {
+  const allHistory = opts.allHistory || boolValue(process.env.GMAIL_DIAG_ALL_HISTORY);
+  const raw = opts.afterDate || opts.since || process.env.GMAIL_DIAG_SINCE || (allHistory ? '2019-01-01' : null);
+  if (raw instanceof Date && Number.isFinite(raw.getTime())) return raw;
+  if (raw) {
+    const parsed = new Date(String(raw));
+    if (Number.isFinite(parsed.getTime())) return parsed;
+    console.log('[Gmail OAuth] Invalid since date, falling back to recent window:', privacy.redact(String(raw)));
+  }
+  return new Date(Date.now() - 30 * 864e5);
+}
+
+function resolveUntilDate(opts) {
+  const raw = opts.untilDate || opts.beforeDate || opts.until || opts.before || process.env.GMAIL_DIAG_UNTIL || null;
+  if (!raw) return null;
+  if (raw instanceof Date && Number.isFinite(raw.getTime())) return raw;
+  const parsed = new Date(String(raw));
+  if (Number.isFinite(parsed.getTime())) return parsed;
+  console.log('[Gmail OAuth] Invalid until date, ignoring:', privacy.redact(String(raw)));
+  return null;
+}
+
+function resolveMaxResults(opts) {
+  const allHistory = opts.allHistory || boolValue(process.env.GMAIL_DIAG_ALL_HISTORY);
+  const fallback = allHistory ? 1000 : 100;
+  return boundedInt(opts.maxResults || opts.max || process.env.GMAIL_DIAG_MAX_RESULTS, fallback, 1, 20000);
+}
+
+function hasOAuthCredentials() {
+  return Boolean(process.env.GMAIL_CLIENT_ID && process.env.GMAIL_CLIENT_SECRET && process.env.GMAIL_REFRESH_TOKEN);
+}
+
+function accountAlias(value) {
+  return privacy.alias('account', value || 'oauth-user');
+}
+
+function safeSender(addr) {
+  const from = String(addr || '').toLowerCase();
+  if (from.includes('notifications@github.com')) return 'notifications@github.com';
+  if (from.includes('community.homey.app')) return 'noreply@community.homey.app';
+  if (from.includes('athom.com')) return 'noreply@athom.com';
+  if (from.includes('homey.app')) return 'noreply@homey.app';
+  return privacy.alias('sender', from || 'unknown');
+}
+
+function parseFromHeader(value) {
+  const raw = decodeRFC2047(String(value || ''));
+  const match = raw.match(/^"?([^"<]*)"?\s*<([^>]+)>/);
+  if (match) return { name: match[1].trim(), address: match[2].trim() };
+  if (raw.includes('@')) return { name: '', address: raw.trim() };
+  return { name: raw.trim(), address: '' };
+}
+
+function base64UrlDecode(value) {
+  return Buffer.from(String(value || '').replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString('utf8');
+}
+
+function buildDateQuery(opts) {
+  const sinceDate = resolveSinceDate(opts);
+  const untilDate = resolveUntilDate(opts);
+  const parts = [`after:${toYmdSlash(sinceDate)}`];
+  if (untilDate) parts.push(`before:${toYmdSlash(untilDate)}`);
+  return parts.join(' ');
+}
+
+function buildQueries(opts) {
+  const date = buildDateQuery(opts);
+  return [
+    `${date} (homey OR tuya OR zigbee OR diagnostic OR diagnostics OR crash OR "error log" OR "processing failed" OR AggregateError OR "Missing Capability Listener" OR battery OR button OR "flow card")`,
+    `${date} (_TZE OR _TZE200 OR _TZE204 OR _TZE284 OR _TZ3000 OR TS0601 OR TS0014 OR TS0041 OR TS0042 OR TS0043 OR TS0044 OR TS011F OR TS0201 OR TS0203)`,
+    `${date} (from:noreply@community.homey.app OR from:noreply@athom.com OR from:noreply@homey.app OR from:support@athom.com OR from:support@homey.app OR from:notifications@github.com)`
+  ];
+}
+
+async function refreshAccessToken() {
+  const clientId = process.env.GMAIL_CLIENT_ID;
+  const clientSecret = process.env.GMAIL_CLIENT_SECRET;
+  const refreshToken = process.env.GMAIL_REFRESH_TOKEN;
+  if (!clientId || !clientSecret || !refreshToken) return null;
+
+  const params = new URLSearchParams({
+    client_id: clientId,
+    client_secret: clientSecret,
+    refresh_token: refreshToken,
+    grant_type: 'refresh_token'
+  });
+
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params.toString()
+  });
+
+  if (!res.ok) {
+    const errText = privacy.redact(await res.text());
+    throw new Error(`OAuth token refresh failed: ${res.status} ${errText}`);
+  }
+  const data = await res.json();
+  return data.access_token;
+}
+
+async function gmailGet(accessToken, url) {
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  if (!res.ok) {
+    const errText = privacy.redact(await res.text());
+    throw new Error(`Gmail API request failed: ${res.status} ${errText}`);
+  }
+  return res.json();
+}
+
+async function searchMessages(accessToken, query, remaining) {
+  const out = [];
+  let pageToken = null;
+  do {
+    const url = new URL(GMAIL_API);
+    url.searchParams.set('q', query);
+    url.searchParams.set('maxResults', String(Math.min(500, remaining - out.length)));
+    if (pageToken) url.searchParams.set('pageToken', pageToken);
+    const data = await gmailGet(accessToken, url.toString());
+    out.push(...(data.messages || []));
+    pageToken = data.nextPageToken || null;
+  } while (pageToken && out.length < remaining);
+  return out.slice(0, remaining);
+}
+
+async function getRawMessage(accessToken, id) {
+  const url = `${GMAIL_API}/${encodeURIComponent(id)}?format=raw`;
+  return gmailGet(accessToken, url);
+}
+
+function toEmailRecord(message) {
+  const raw = base64UrlDecode(message.raw || '');
+  const mime = parseMIME(raw);
+  const headers = mime.headers || {};
+  const subject = decodeRFC2047(headers.subject || message.snippet || '');
+  const fromParsed = parseFromHeader(headers.from || '');
+  const date = headers.date ? new Date(headers.date).toISOString() : '';
+  let body = subject;
+  let contentType = 'unknown';
+  if (mime.textPlain && mime.textPlain.trim().length > 10) {
+    body = mime.textPlain;
+    contentType = 'text/plain';
+  } else if (mime.textHtml) {
+    body = htmlToText(mime.textHtml);
+    contentType = 'text/html->text';
+  } else if (message.snippet) {
+    body = message.snippet;
+    contentType = 'snippet';
+  }
+  body = privacy.redact(String(body || '').slice(0, 256000));
+
+  let crashData = extractCrashData(body);
+  if (crashData) {
+    if (crashData.crashApp) crashData.crashApp = privacy.redact(crashData.crashApp);
+    if (crashData.stackTraces) crashData.stackTraces = crashData.stackTraces.map(privacy.redact);
+  }
+
+  const pseudo = extractPseudo(`${fromParsed.name || ''} <${fromParsed.address || ''}>`, null, body);
+  return {
+    id: 'oauth_' + privacy.digest(String(message.id || ''), 12),
+    subj: privacy.redact(subject),
+    from: safeSender(fromParsed.address),
+    fromName: privacy.redact(fromParsed.name),
+    date,
+    body,
+    bodyLength: body.length,
+    contentType,
+    pseudo: privacy.redactObject(pseudo),
+    crashData,
+    mimeInfo: { parts: mime.parts || [], headerKeys: Object.keys(headers) },
+    labels: message.labelIds || []
+  };
+}
+
+async function readViaOAuth(opts = {}) {
+  if (!hasOAuthCredentials()) {
+    console.log('[Gmail OAuth] Missing OAuth credentials');
+    return null;
+  }
+  const account = process.env.GMAIL_EMAIL || process.env.HOMEY_EMAIL || 'gmail-oauth';
+  const maxResults = resolveMaxResults(opts);
+  console.log('[Gmail OAuth] Trying', accountAlias(account), 'max', maxResults);
+  const accessToken = await refreshAccessToken();
+  if (!accessToken) return null;
+
+  const seen = new Set();
+  const ids = [];
+  for (const query of buildQueries(opts)) {
+    if (ids.length >= maxResults) break;
+    console.log('[Gmail OAuth] Search query:', privacy.redact(query));
+    const batch = await searchMessages(accessToken, query, maxResults - ids.length);
+    for (const msg of batch) {
+      if (!msg.id || seen.has(msg.id)) continue;
+      seen.add(msg.id);
+      ids.push(msg.id);
+      if (ids.length >= maxResults) break;
+    }
+  }
+
+  const out = [];
+  for (const id of ids) {
+    try {
+      out.push(toEmailRecord(await getRawMessage(accessToken, id)));
+    } catch (err) {
+      console.log('[Gmail OAuth] skip:', privacy.redact(err.message));
+    }
+  }
+  console.log('[Gmail OAuth] OK:', out.length);
+  return out;
+}
+
+module.exports = { hasOAuthCredentials, readViaOAuth };

--- a/.github/scripts/gmail-oauth-reader.js
+++ b/.github/scripts/gmail-oauth-reader.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const privacy = require('./privacy-redactor');
+const { fetchWithRetry } = require('./retry-helper');
 const {
   parseMIME,
   htmlToText,
@@ -114,22 +115,25 @@ async function refreshAccessToken() {
     grant_type: 'refresh_token'
   });
 
-  const res = await fetch(TOKEN_URL, {
+  const res = await fetchWithRetry(TOKEN_URL, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
     body: params.toString()
-  });
+  }, { retries: 2, label: 'oauthTokenRefresh' });
 
   if (!res.ok) {
     const errText = privacy.redact(await res.text());
     throw new Error(`OAuth token refresh failed: ${res.status} ${errText}`);
   }
   const data = await res.json();
+  if (!data || !data.access_token) {
+    throw new Error('OAuth token refresh response did not contain an access_token');
+  }
   return data.access_token;
 }
 
 async function gmailGet(accessToken, url) {
-  const res = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const res = await fetchWithRetry(url, { headers: { Authorization: `Bearer ${accessToken}` } }, { retries: 2, label: 'gmailApi' });
   if (!res.ok) {
     const errText = privacy.redact(await res.text());
     throw new Error(`Gmail API request failed: ${res.status} ${errText}`);
@@ -146,8 +150,10 @@ async function searchMessages(accessToken, query, remaining) {
     url.searchParams.set('maxResults', String(Math.min(500, remaining - out.length)));
     if (pageToken) url.searchParams.set('pageToken', pageToken);
     const data = await gmailGet(accessToken, url.toString());
-    out.push(...(data.messages || []));
-    pageToken = data.nextPageToken || null;
+    const messages = (data && data.messages) || [];
+    if (messages.length === 0) break;
+    out.push(...messages);
+    pageToken = (data && data.nextPageToken) || null;
   } while (pageToken && out.length < remaining);
   return out.slice(0, remaining);
 }
@@ -159,11 +165,15 @@ async function getRawMessage(accessToken, id) {
 
 function toEmailRecord(message) {
   const raw = base64UrlDecode(message.raw || '');
-  const mime = parseMIME(raw);
+  const mime = parseMIME(raw) || {};
   const headers = mime.headers || {};
   const subject = decodeRFC2047(headers.subject || message.snippet || '');
   const fromParsed = parseFromHeader(headers.from || '');
-  const date = headers.date ? new Date(headers.date).toISOString() : '';
+  let date = '';
+  if (headers.date) {
+    const parsedDate = new Date(headers.date);
+    if (Number.isFinite(parsedDate.getTime())) date = parsedDate.toISOString();
+  }
   let body = subject;
   let contentType = 'unknown';
   if (mime.textPlain && mime.textPlain.trim().length > 10) {

--- a/.github/workflows/fetch-diags.yml
+++ b/.github/workflows/fetch-diags.yml
@@ -64,6 +64,9 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GMAIL_DIAG_ALL_HISTORY: ${{ github.event.inputs.all_history || 'false' }}
           GMAIL_DIAG_SINCE: ${{ github.event.inputs.since || '' }}
           GMAIL_DIAG_UNTIL: ${{ github.event.inputs.until || '' }}
@@ -107,5 +110,5 @@ jobs:
       - name: Assert Gmail diagnostics access
         if: always() && steps.gmail_fetch.outputs.exit_code != '0'
         run: |
-          echo "::error::Gmail diagnostics could not authenticate via IMAP. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD secrets, then rerun Fetch Homey Diagnostics."
+          echo "::error::Gmail diagnostics could not authenticate via IMAP or OAuth fallback. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and GMAIL_REFRESH_TOKEN secrets, then rerun Fetch Homey Diagnostics."
           exit 1

--- a/.github/workflows/gmail-diagnostics.yml
+++ b/.github/workflows/gmail-diagnostics.yml
@@ -76,6 +76,9 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           NVIDIA_API_KEY: ${{ secrets.NVIDIA_API_KEY }}
           MISTRAL_API_KEY: ${{ secrets.MISTRAL_API_KEY || '' }}


### PR DESCRIPTION
## Summary
- add a Gmail API OAuth fallback reader for diagnostics when IMAP app-password auth fails
- wire OAuth secrets into the Gmail diagnostic workflows while keeping IMAP as the primary path
- keep diagnostic output anonymized/redacted and report the actual auth mode used in health/state summaries

## Evidence
- master fetch-diags run 28641394785 used GitHub secrets but failed IMAP auth
- branch fetch-diags run 28641743495 used IMAP first, then OAuth fallback, and failed with OAuth invalid_grant, proving the workflow wiring is active but the stored Gmail refresh token is stale/revoked

## Validation
- node --check .github/scripts/gmail-oauth-reader.js
- node --check .github/scripts/fetch-gmail-diagnostics.js
- OAuth reader mock API test
- npm run check:yaml
- npm run security-scan
- npm run check:diag-history
- npm run precommit