### PR TITLE
[codex] Resolve fingerprint collisions after driver maintenance merge

### DIFF
--- a/drivers/fingerbot/driver.compose.json
+++ b/drivers/fingerbot/driver.compose.json
@@ -33,8 +33,7 @@
   "zigbee": {
     "manufacturerName": [
       "_TZ3210_pwj6vuj9",
-      "_TZ3210_d3m9v8p6",
-      "_TZ3210_dse8ogfy"
+      "_TZ3210_d3m9v8p6"
     ],
     "productId": [
       "TS0001",

--- a/drivers/handheld_remote_4_buttons/driver.compose.json
+++ b/drivers/handheld_remote_4_buttons/driver.compose.json
@@ -41,10 +41,7 @@
       "_tz3000_w8jwkczz",
       "_tz3000_xkh6oajz",
       "_tz3000_yesuiipb",
-      "_tz3000_zszzgweg",
-      "_TZ3000_vp6clf9d",
-      "_TZ3000_ufhtxr59",
-      "_TZ3000_wkai4ga5"
+      "_tz3000_zszzgweg"
     ],
     "productId": [
       "TS0044",

--- a/drivers/wall_curtain_switch/driver.compose.json
+++ b/drivers/wall_curtain_switch/driver.compose.json
@@ -33,16 +33,7 @@
   "zigbee": {
     "manufacturerName": [
       "HOBEIAN",
-      "hobeian",
-      "_TZ3000_dph3rpss",
-      "_TZ3000_8kzqqzu4",
-      "_TZ3000_ltiqubue",
-      "_TZ3000_dbpmpco1",
-      "_TZ3000_fvhunhxb",
-      "_TZ3000_ctbafvhm",
-      "_TZ3000_qqdbccb3",
-      "_TZ3000_wptayaqr",
-      "_TZ3000_qa8s8vca"
+      "hobeian"
     ],
     "productId": [
       "TS130F"

--- a/drivers/wall_remote_2_gang/driver.compose.json
+++ b/drivers/wall_remote_2_gang/driver.compose.json
@@ -33,9 +33,7 @@
     "manufacturerName": [
       "_tz3000_wd7pvcs3",
       "_tz3000_ab9pba9q",
-      "_tz3000_df6005om",
-      "_TYZB02_keyjhapk",
-      "_TZ3000_5e235jpa"
+      "_tz3000_df6005om"
     ],
     "productId": [
       "TS0042"

--- a/drivers/wall_remote_6_gang/driver.compose.json
+++ b/drivers/wall_remote_6_gang/driver.compose.json
@@ -80,8 +80,7 @@
     },
     "manufacturerName": [
       "_hybrid_wall_remote_6_gang_needs_device_assignment",
-      "_HYBRID_WALL_REMOTE_6_GANG_NEEDS_DEVICE_ASSIGNMENT",
-      "_TZ3000_iszegwpd"
+      "_HYBRID_WALL_REMOTE_6_GANG_NEEDS_DEVICE_ASSIGNMENT"
     ]
   },
   "settings": [


### PR DESCRIPTION
## Summary
- removes ambiguous fingerprints introduced by the driver-maintenance merge from the duplicate specialized drivers
- keeps the Gemini crash fixes from PR #471 intact
- restores the fingerprint collision gate to 0 current / 0 new collisions on master

## Root cause
PR #471 was auto-merged at b67e08a before the follow-up collision cleanup could land. That left master with newly introduced manufacturerName/productId collisions that fail the Validate and Universal Validation checks.

## Validation
- node .github/scripts/fp-collision-check.js --baseline .github/fingerprint-collision-baseline.json
- npm run check:button-flows
- npm run security-scan
- npm run precommit