### PR TITLE
Fix auto-publish metadata staging

### DIFF
--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -399,6 +399,9 @@ jobs:
             for path in app.json .homeycompose .homeychangelog.json CHANGELOG.md README.md docs .github/scripts/_stats.json package.json package-lock.json; do
               [ -e "$path" ] && git add "$path"
             done
+            for path in drivers/*/driver.compose.json; do
+              [ -e "$path" ] && git add "$path"
+            done
           }
           node scripts/maintenance/sanitize-manifest.cjs app.json .homeybuild/app.json || true
           node <<'NODE'


### PR DESCRIPTION
## Summary
- stage generated drivers/*/driver.compose.json files in the auto-publish bot metadata commit
- prevents the bot from failing before rebase when publish maintenance scripts update driver compose manifests

## Checks
- npm run check:yaml
- npm run security-scan
- npm run precommit