### PR TITLE
[codex] Improve Athom processing failure diagnostics

### DIFF
--- a/.github/scripts/athom-build-error-diag.js
+++ b/.github/scripts/athom-build-error-diag.js
@@ -42,6 +42,43 @@ function log(m) {
   if (SUM) try { fs.appendFileSync(SUM, m+'\n'); } catch { /* ponytail: best-effort summary */ }
 }
 const sleep = ms => new Promise(r => setTimeout(r, ms));
+const FAILED_BUILD_STATES = new Set(['processing_failed', 'error', 'revoked']);
+
+function normalizeVersion(version) {
+  return String(version || '').replace(/^v/i, '');
+}
+
+function buildIdNumber(build) {
+  const id = build?.id || build?.buildId || build?._id || 0;
+  const n = Number(id);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function buildTimestamp(build) {
+  return Date.parse(build?.stateChangedAt || build?.state_changed_at || build?.createdAt || build?.created_at || '') || 0;
+}
+
+function isFailedBuild(build) {
+  return FAILED_BUILD_STATES.has(String(build?.state || '').toLowerCase());
+}
+
+function chooseFailedBuild(builds) {
+  const currentVersion = normalizeVersion(APP_VER);
+  return [...builds].filter(isFailedBuild).sort((a, b) => {
+    const aCurrent = normalizeVersion(a.version) === currentVersion ? 1 : 0;
+    const bCurrent = normalizeVersion(b.version) === currentVersion ? 1 : 0;
+    if (aCurrent !== bCurrent) return bCurrent - aCurrent;
+    const at = buildTimestamp(a);
+    const bt = buildTimestamp(b);
+    if (at !== bt) return bt - at;
+    return buildIdNumber(b) - buildIdNumber(a);
+  })[0] || null;
+}
+
+function buildLabel(build) {
+  if (!build) return 'unknown build';
+  return `#${build.id || build.buildId || build._id || '?'} (state=${build.state || '?'}, v${build.version || '?'})`;
+}
 
 async function snap(page, name) {
   const dir = path.join(__dirname,'..','..','screenshots');
@@ -244,11 +281,11 @@ async function main() {
       const api = new AthomAppsAPI({ token });
       const builds = await api.getBuilds({ $token: token, appId: APP_ID, query: { limit: 50 } });
       const list = Array.isArray(builds) ? builds : (builds.data || builds || []);
-      const failed = list.find(b => b.state === 'processing_failed' || b.state === 'error' || b.state === 'revoked');
+      const failed = chooseFailedBuild(list);
       if (failed) {
-        targetBuild = String(failed.id || failed.buildId);
+        targetBuild = String(failed.id || failed.buildId || failed._id);
         targetBuildInfo = failed;
-        log(`[STEP 0] Auto-detected latest failed build: #${targetBuild} (state=${failed.state}, v${failed.version})`);
+        log('[STEP 0] Auto-detected latest failed build: ' + buildLabel(failed));
       } else {
         log('[STEP 0] No failed build found in last 50 — nothing to diagnose.');
         return;

--- a/.github/scripts/verify-test-version.js
+++ b/.github/scripts/verify-test-version.js
@@ -207,6 +207,16 @@ function readDashboardReport(expectedVersion) {
     return true;
   }
 
+  const latestFailed = report.latestFailedBuild || null;
+  const failedCurrent = [expectedBuild, latest, latestFailed]
+    .filter(Boolean)
+    .find(build => normalizeVersion(build.version) === normalizeVersion(expectedVersion)
+      && build.state && build.state !== 'test');
+  if (failedCurrent) {
+    const detail = failedCurrent.failureDetail || failedCurrent.stateMeta || 'no failure detail returned by Athom API';
+    log(`Dashboard monitor reports v${expectedVersion} ${failedCurrent.state} build #${failedCurrent.id || '?'} (${detail})`);
+  }
+
   const latestText = latest
     ? `latest v${latest.version || '?'} ${latest.state || 'unknown'} #${latest.id || '?'}`
     : 'latest unavailable';


### PR DESCRIPTION
## Summary
- Prefer current-version/latest failed Athom build in build-error diagnostics instead of whichever failed build the API returns first
- Surface dashboard processing_failed/stateMeta details during test-version verification

## Context
Auto-publish for v9.0.175 created build #2547, but Athom marked it processing_failed with stateMeta=socket hang up. The previous diagnostic auto-selected stale build #32, so this patch makes the next failure actionable and keeps verification logs explicit.

## Verification
- node --check .github/scripts/athom-build-error-diag.js
- node --check .github/scripts/verify-test-version.js
- npm run precommit