### PR TITLE
[codex] Fix diagnostics timer and Tuya DP control failures

### DIFF
--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -497,6 +497,7 @@ jobs:
             echo "::endgroup::"
           }
 
+          run_diag 60 node .github/scripts/gmail-token-keepalive.js
           run_diag 180 node .github/scripts/fetch-gmail-diagnostics.js
           run_diag 90 node scripts/automation/dashboard-monitor.js --latest
           run_diag 120 node .github/scripts/homey-device-diagnostics.js

--- a/.github/workflows/gmail-diagnostics.yml
+++ b/.github/workflows/gmail-diagnostics.yml
@@ -71,7 +71,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci --prefer-offline --no-audit || npm install
-      # v5.12.6: IMAP-only — OAuth removed
+      - name: IMAP health preflight
+        continue-on-error: true
+        env:
+          GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
+          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+        run: node .github/scripts/gmail-token-keepalive.js
+      # v5.12.7: IMAP-only diagnostics with health preflight
       - name: Fetch diagnostics via IMAP
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}

--- a/.github/workflows/gmail-token-keepalive.yml
+++ b/.github/workflows/gmail-token-keepalive.yml
@@ -4,10 +4,10 @@ name: Gmail IMAP Health Check
 # <!-- badges:end -->
 
 
-# v5.12.6: IMAP-only — OAuth keepalive replaced by IMAP health check
+# v5.12.7: IMAP-only daily health check
 on:
   schedule:
-    - cron: '0 8 * * 1'  # Weekly Monday 08:00 UTC
+    - cron: '0 8 * * *'  # Daily 08:00 UTC
   workflow_dispatch:
   workflow_call:
 

--- a/data/fingerprints.json
+++ b/data/fingerprints.json
@@ -554,5 +554,46 @@
       }
     },
     "notes": "Normalized TZE28C1000000 prefix sibling for Homey forum 26439 #5484 Zemismart boiler switch."
+  },
+  "_TZE204_myd45weu": {
+    "driverId": "soilsensor_2",
+    "type": "soil_sensor",
+    "powerSource": "battery",
+    "modelIds": [
+      "TS0601"
+    ],
+    "capabilities": [
+      "measure_humidity",
+      "measure_temperature",
+      "measure_humidity.soil",
+      "measure_battery"
+    ],
+    "dps": {
+      "3": {
+        "name": "soil_moisture",
+        "converter": "raw",
+        "capability": "measure_humidity.soil"
+      },
+      "5": {
+        "name": "temperature",
+        "converter": "divideBy10",
+        "capability": "measure_temperature"
+      },
+      "14": {
+        "name": "battery_state",
+        "converter": "enum",
+        "values": [
+          "low",
+          "medium",
+          "high"
+        ]
+      },
+      "15": {
+        "name": "battery",
+        "converter": "raw",
+        "capability": "measure_battery"
+      }
+    },
+    "notes": "TZE204 soil temperature/moisture variant; aligned with myd45weu soil profile and Johan #1416 diagnostic context."
   }
 }

--- a/drivers/air_purifier/driver.compose.json
+++ b/drivers/air_purifier/driver.compose.json
@@ -89,7 +89,6 @@
       "_TZE200_c2fmom5z",
       "_TZE200_ga1maeof",
       "_TZE200_9cqcpkgb",
-      "_TZE204_myd45weu",
       "_TZE284_aao3yzhs",
       "_TZE284_sgabhwa6",
       "_TZE200_2se8efxh",

--- a/drivers/boiler_switch_energy/driver.js
+++ b/drivers/boiler_switch_energy/driver.js
@@ -16,7 +16,7 @@ class BoilerSwitchEnergyDriver extends ZigBeeDriver {
       try {
         this.homey.flow.getDeviceTriggerCard(id);
       } catch (e) {
-        this.error(`Trigger ${id} registration error: ${e.message}`);
+        this.log(`[FLOW] Optional trigger ${id} not declared, skipping`);
       }
     }
 

--- a/drivers/soilsensor_2/driver.compose.json
+++ b/drivers/soilsensor_2/driver.compose.json
@@ -32,7 +32,8 @@
   "zigbee": {
     "manufacturerName": [
       "_TZE284_myd45weu",
-      "_TZE200_myd45weu"
+      "_TZE200_myd45weu",
+      "_TZE204_myd45weu"
     ],
     "productId": [
       "TS0601"

--- a/drivers/valve_dual_irrigation/device.js
+++ b/drivers/valve_dual_irrigation/device.js
@@ -31,8 +31,9 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
       await this.safeSetCapabilityValue(capability, value).catch(() => {});
       return;
     }
-    if (typeof this.setCapabilityValue === 'function') {
-      await this.setCapabilityValue(capability, value).catch(() => {});
+    const setCapabilityValue = this['setCapabilityValue'];
+    if (typeof setCapabilityValue === 'function') {
+      await setCapabilityValue.call(this, capability, value).catch(() => {});
     }
   }
 

--- a/drivers/valve_dual_irrigation/device.js
+++ b/drivers/valve_dual_irrigation/device.js
@@ -26,16 +26,6 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
     const normalized = String(type || 'value').toLowerCase();
     return ({ raw: 0, bool: 1, boolean: 1, value: 2, string: 3, enum: 4, bitmap: 5 })[normalized] ?? 2;
   }
-  async _safeSetValveCapability(capability, value) {
-    if (typeof this.safeSetCapabilityValue === 'function') {
-      await this.safeSetCapabilityValue(capability, value).catch(() => {});
-      return;
-    }
-    const setCapabilityValue = this['setCapabilityValue'];
-    if (typeof setCapabilityValue === 'function') {
-      await setCapabilityValue.call(this, capability, value).catch(() => {});
-    }
-  }
 
   get dpMappings() {
     return {
@@ -88,8 +78,7 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
 
     if (manager) {
       if (typeof manager.sendDP === 'function') {
-        const sent = await manager.sendDP(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });
-        if (sent !== false) {return sent;}
+        return manager.sendDP(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });
       }
       if (typeof manager.sendDPWithConfirmation === 'function') {
         const result = await manager.sendDPWithConfirmation(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });

--- a/drivers/valve_dual_irrigation/device.js
+++ b/drivers/valve_dual_irrigation/device.js
@@ -13,17 +13,40 @@ const BaseUnifiedDevice = require('../../lib/devices/BaseUnifiedDevice');
  */
 class ValveDualIrrigationDevice extends BaseUnifiedDevice {
 
+  _isValveOn(value) {
+    if (typeof value === 'boolean') {return value;}
+    if (typeof value === 'number') {return value === 1;}
+    if (typeof value === 'string') {
+      return ['1', 'true', 'on', 'open', 'opened', 'running', 'watering'].includes(value.toLowerCase());
+    }
+    return false;
+  }
+
+  _toTuyaDPType(type) {
+    const normalized = String(type || 'value').toLowerCase();
+    return ({ raw: 0, bool: 1, boolean: 1, value: 2, string: 3, enum: 4, bitmap: 5 })[normalized] ?? 2;
+  }
+  async _safeSetValveCapability(capability, value) {
+    if (typeof this.safeSetCapabilityValue === 'function') {
+      await this.safeSetCapabilityValue(capability, value).catch(() => {});
+      return;
+    }
+    if (typeof this.setCapabilityValue === 'function') {
+      await this.setCapabilityValue(capability, value).catch(() => {});
+    }
+  }
+
   get dpMappings() {
     return {
       // Valve 1
-      1: { capability: 'onoff.valve_1', transform: (v) => v === 1 || v === true },
-      104: { capability: 'onoff.valve_1', transform: (v) => v === 1 || v === 0 }, // Status reporting
+      1: { capability: 'onoff.valve_1', transform: (v) => this._isValveOn(v) },
+      104: { capability: 'onoff.valve_1', transform: (v) => this._isValveOn(v) }, // Status reporting
       13: { capability: 'countdown_remaining' },
       25: { internal: 'duration_1' },
 
       // Valve 2
-      2: { capability: 'onoff.valve_2', transform: (v) => v === 1 || v === true },
-      105: { capability: 'onoff.valve_2', transform: (v) => v === 1 || v === 0 }, // Status reporting
+      2: { capability: 'onoff.valve_2', transform: (v) => this._isValveOn(v) },
+      105: { capability: 'onoff.valve_2', transform: (v) => this._isValveOn(v) }, // Status reporting
       14: { capability: 'countdown_remaining' },
       26: { internal: 'duration_2' },
 
@@ -46,23 +69,47 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
       this.log(`[VALVE-2] Setting Valve 1 = ${value}`);
       // Insoma valves often require explicit 1/0 as bool
       await this.sendDP(1, value ? true : false, 'bool');
+      await this.safeSetCapabilityValue?.('onoff.valve_1', Boolean(value)).catch(() => {});
       });
 
     this.registerCapabilityListener('onoff.valve_2', async (value) => {
       this.log(`[VALVE-2] Setting Valve 2 = ${value}`);
       await this.sendDP(2, value ? true : false, 'bool');
+      await this.safeSetCapabilityValue?.('onoff.valve_2', Boolean(value)).catch(() => {});
       });
 
     this.log('[VALVE-2]  Ready (Dual Engine v7.4.4)');
   }
 
-  // Override sendDP to ensure tuyaEF00Manager is used
+  // Override sendDP to keep dual-valve actions working across manager variants.
   async sendDP(dp, value, type = 'bool') {
-    if (this.tuyaEF00Manager) {
-      return this.tuyaEF00Manager.sendDP(dp, value, type);
+    const manager = this.tuyaEF00Manager || this._tuyaEF00Manager;
+
+    if (manager) {
+      if (typeof manager.sendDP === 'function') {
+        const sent = await manager.sendDP(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });
+        if (sent !== false) {return sent;}
+      }
+      if (typeof manager.sendDPWithConfirmation === 'function') {
+        const result = await manager.sendDPWithConfirmation(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });
+        if (result?.success) {return true;}
+      }
+      if (typeof manager._sendDPRaw === 'function') {
+        const sent = await manager._sendDPRaw(dp, value, type);
+        if (sent) {return true;}
+      }
+      if (typeof manager.sendTuyaDP === 'function') {
+        const sent = await manager.sendTuyaDP(dp, this._toTuyaDPType(type), value);
+        if (sent) {return true;}
+      }
     }
-    this.error('[VALVE-2]  Error: tuyaEF00Manager not initialized');
-    throw new Error('tuya_manager_not_found');
+
+    if (typeof this._sendTuyaDP === 'function') {
+      return this._sendTuyaDP(dp, value, type);
+    }
+
+    this.error('[VALVE-2] Error: no Tuya DP sender available');
+    throw new Error('tuya_dp_sender_not_found');
   }
 
   /**

--- a/drivers/valve_dual_irrigation/driver.compose.json
+++ b/drivers/valve_dual_irrigation/driver.compose.json
@@ -49,8 +49,7 @@
   "energy": {
     "batteries": [
       "AA"
-    ],
-    "mains": true
+    ]
   },
   "maintenanceActions": [
     {

--- a/lib/DeviceFingerprintDB.js
+++ b/lib/DeviceFingerprintDB.js
@@ -70,6 +70,7 @@ const FINGERPRINT_DB = {
   // SOIL SENSORS
   // ─────────────────────────────────────────────────────────────────────────
   '_TZE200_myd45weu|TS0601': { driver: 'soilsensor_2', protocol: 'tuya_dp', dpProfile: 'SOIL_STANDARD', dp: { 3: 'measure_humidity.soil', 5: 'measure_temperature/10', 15: 'measure_battery' }, notes: 'Soil temperature/moisture sensor, Zigbee2MQTT #27346' },
+  '_TZE204_myd45weu|TS0601': { driver: 'soilsensor_2', protocol: 'tuya_dp', dpProfile: 'SOIL_STANDARD', dp: { 3: 'measure_humidity.soil', 5: 'measure_temperature/10', 15: 'measure_battery' }, notes: 'Johan #1416 diagnostic context: TZE204 myd45weu soil variant; keep away from air_purifier fallback' },
   '_TZE284_myd45weu|TS0601': { driver: 'soilsensor_2', protocol: 'tuya_dp', dpProfile: 'SOIL_STANDARD', dp: { 3: 'measure_humidity.soil', 5: 'measure_temperature/10', 15: 'measure_battery' }, notes: 'Homey forum #2097, Zigbee2MQTT #27346' },
   '_TZE284_oitavov2|TS0601': { driver: 'soil_sensor', protocol: 'tuya_dp', dpProfile: 'SOIL_ALT', dp: { 3: 'measure_humidity.soil', 5: 'measure_temperature/10', 15: 'measure_battery', 109: 'measure_humidity' }, notes: 'GitHub #398 QT-07S soil tester; keep away from air_purifier_soil collision' },
   '_TZE284_aao3yzhs|TS0601': { driver: 'soil_sensor', protocol: 'tuya_dp', dpProfile: 'SOIL_STANDARD', dp: { 3: 'measure_humidity.soil', 5: 'measure_temperature/10', 15: 'measure_battery*2' }, notes: 'GitHub #1341' },

--- a/lib/battery/BatteryProfileDatabase.js
+++ b/lib/battery/BatteryProfileDatabase.js
@@ -95,6 +95,26 @@ const BATTERY_PROFILES = {
     voltageMax: 3.0,
     notes: 'Soil sensor _TZE200'
   },
+  '_TZE204_myd45weu': {
+    chemistry: BATTERY_CHEMISTRY.CR2450,
+    source: BATTERY_SOURCE.TUYA_DP,
+    dpId: 15,
+    dpIdState: 14,
+    algorithm: VOLTAGE_ALGO.DIRECT_PERCENT,
+    voltageMin: 2.5,
+    voltageMax: 3.0,
+    notes: 'Soil sensor _TZE204'
+  },
+  '_TZE284_myd45weu': {
+    chemistry: BATTERY_CHEMISTRY.CR2450,
+    source: BATTERY_SOURCE.TUYA_DP,
+    dpId: 15,
+    dpIdState: 14,
+    algorithm: VOLTAGE_ALGO.DIRECT_PERCENT,
+    voltageMin: 2.5,
+    voltageMax: 3.0,
+    notes: 'Soil sensor _TZE284'
+  },
 
   // ═══════════════════════════════════════════════════════════════════════════
   // CLIMATE SENSORS - Usually CR2032, Tuya DP with x2 multiplier

--- a/lib/battery/UnifiedBatteryHandler.js
+++ b/lib/battery/UnifiedBatteryHandler.js
@@ -296,6 +296,8 @@ class UnifiedBatteryHandler {
     '_TZE284_oitavov2':    { chemistry: 'CR2032', source: 'tuya_dp', dpId: 15, algorithm: 'direct', notes: 'QT-07S Soil sensor' },
     '_TZE284_aao3yzhs':   { chemistry: 'CR2032', source: 'tuya_dp', dpId: 15, algorithm: 'direct', notes: 'Soil variant' },
     '_TZE200_myd45weu':   { chemistry: 'CR2450', source: 'tuya_dp', dpId: 15, algorithm: 'direct', notes: 'Soil _TZE200' },
+    '_TZE204_myd45weu':   { chemistry: 'CR2450', source: 'tuya_dp', dpId: 15, algorithm: 'direct', notes: 'Soil _TZE204' },
+    '_TZE284_myd45weu':   { chemistry: 'CR2450', source: 'tuya_dp', dpId: 15, algorithm: 'direct', notes: 'Soil _TZE284' },
     '_TZE284_vvmbj46n':   { chemistry: 'CR2032', source: 'tuya_dp', dpId: 4, algorithm: 'multiply_2', notes: 'TH05Z LCD Climate' },
     '_TZE200_vvmbj46n':   { chemistry: 'CR2032', source: 'tuya_dp', dpId: 4, algorithm: 'multiply_2', notes: 'ONENUO TH05Z' },
     '_TZE200_bjawzodf':   { chemistry: 'CR2032', source: 'tuya_dp', dpId: 4, algorithm: 'multiply_2', notes: 'Climate standard' },

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3213,6 +3213,79 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     }
   }
 
+
+  /**
+   * v9.0.178: Conservative fallback for permissive DP mode.
+   * Keeps unknown DP traffic from crashing while only inferring common sensor values.
+   */
+  _inferCapabilityFromValue(dp, value) {
+    const dpId = Number(dp);
+    if (!Number.isFinite(dpId) || value === null || value === undefined) {return null;}
+
+    const numeric = typeof value === 'number' ? value : Number(value);
+    const finite = Number.isFinite(numeric);
+    const has = (capability) => typeof this.hasCapability === 'function' && this.hasCapability(capability);
+    const canUse = (capability) => has(capability) || this._isPermissiveCapabilityAllowed(capability);
+    const asPercent = () => Math.max(0, Math.min(100, Math.round(numeric)));
+
+    if ((value === true || value === false || numeric === 0 || numeric === 1)
+      && [1, 2, 3, 101, 102, 103, 104, 105].includes(dpId)) {
+      const boolValue = value === true || numeric === 1;
+      if (canUse('alarm_human')) {
+        return { capability: 'alarm_human', value: boolValue, source: 'binary_presence' };
+      }
+      if (canUse('alarm_motion')) {
+        return { capability: 'alarm_motion', value: boolValue, source: 'binary_motion' };
+      }
+    }
+
+    if (!this.mainsPowered && finite && [4, 15, 59, 101, 102, 103, 105].includes(dpId)
+      && numeric >= 0 && numeric <= 100 && canUse('measure_battery')) {
+      return { capability: 'measure_battery', value: asPercent(), source: 'battery_percent' };
+    }
+
+    if (!this.mainsPowered && dpId === 14 && Number.isInteger(numeric) && numeric >= 0 && numeric <= 2 && canUse('measure_battery')) {
+      return { capability: 'measure_battery', value: this.batteryEnumMap[numeric] ?? asPercent(), source: 'battery_enum' };
+    }
+
+    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId)
+      && numeric >= -40 && numeric <= 80 && canUse('measure_temperature')) {
+      return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+    }
+
+    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId)
+      && numeric >= 0 && numeric <= 100 && canUse('measure_humidity')) {
+      return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+    }
+
+    if (finite && [101, 102, 103, 104, 105, 106, 107].includes(dpId)
+      && numeric >= 0 && numeric <= 100000 && canUse('measure_luminance')) {
+      return { capability: 'measure_luminance', value: Math.round(numeric), source: 'luminance_range' };
+    }
+
+    return null;
+  }
+
+  _isPermissiveCapabilityAllowed(capability) {
+    if (!capability) {return false;}
+    const allowed = new Set(Array.isArray(this.sensorCapabilities) ? this.sensorCapabilities : []);
+    return allowed.has(capability);
+  }
+
+  async _addCapabilityPermissive(capability) {
+    if (!this._isPermissiveCapabilityAllowed(capability)) {return false;}
+    if (typeof this.hasCapability === 'function' && this.hasCapability(capability)) {return true;}
+    if (typeof this.addCapability !== 'function') {return false;}
+
+    try {
+      await this.addCapability(capability);
+      this.log(`[DP-PERMISSIVE] Added capability ${capability}`);
+      return true;
+    } catch (err) {
+      this.log(`[DP-PERMISSIVE] Could not add ${capability}: ${err.message}`);
+      return false;
+    }
+  }
   /**
    * v5.5.305: Enhanced value parser with better Buffer handling
    * Fixes DP12 NaN issue where Buffer {type:"Buffer",data:[0,0,13,70]} was parsed as 'F'

--- a/lib/managers/DynamicCapabilityManager.js
+++ b/lib/managers/DynamicCapabilityManager.js
@@ -115,14 +115,54 @@ class DynamicCapabilityManager {
 
   constructor(device) {
     this.device = device;
+    this.homey = device?.homey || null;
     this._added = new Set();
     this._timers = [];
     this._initialized = false;
     this._isFallback = false;
     this._scanCount = 0;
+    this._destroyed = false;
 
     // v9.1.0: Track unknown/unmapped DPs for debug export
     this._unknownDPs = new Map(); // dpId -> { firstSeen, lastSeen, count, lastValue, dpType }
+  }
+
+  _getHomey() {
+    return this.homey || this.device?.homey || null;
+  }
+
+  _setTimeout(fn, ms) {
+    const homey = this._getHomey();
+    const setTimeoutFn = homey && typeof homey.setTimeout === 'function'
+      ? homey.setTimeout.bind(homey)
+      : globalThis.setTimeout.bind(globalThis);
+    return setTimeoutFn(fn, ms);
+  }
+
+  _setInterval(fn, ms) {
+    const homey = this._getHomey();
+    const setIntervalFn = homey && typeof homey.setInterval === 'function'
+      ? homey.setInterval.bind(homey)
+      : globalThis.setInterval.bind(globalThis);
+    return setIntervalFn(fn, ms);
+  }
+
+  _clearTimer(timer) {
+    if (!timer?.ref) {return;}
+    const homey = this._getHomey();
+    try {
+      if (timer.type === 'interval') {
+        const clearIntervalFn = homey && typeof homey.clearInterval === 'function'
+          ? homey.clearInterval.bind(homey)
+          : globalThis.clearInterval.bind(globalThis);
+        clearIntervalFn(timer.ref);
+        return;
+      }
+      const clearTimeoutFn = homey && typeof homey.clearTimeout === 'function'
+        ? homey.clearTimeout.bind(homey)
+        : globalThis.clearTimeout.bind(globalThis);
+      clearTimeoutFn(timer.ref);
+    } catch (_) {}
   }
 
   /**
@@ -145,7 +185,7 @@ class DynamicCapabilityManager {
     // Schedule scans: 30s, 5min, then every 2h
     this._schedule(30000, () => this._scan('initial'));
     this._schedule(300000, () => this._scan('stabilized'));
-    const periodic = this.homey.setInterval(() => { if (this._destroyed) return; this._scan('periodic'); }, 7200000);
+    const periodic = this._setInterval(() => { if (this._destroyed) return; this._scan('periodic'); }, 7200000);
     this._timers.push({ type: 'interval', ref: periodic });
   }
 
@@ -426,7 +466,7 @@ class DynamicCapabilityManager {
    * Schedule a one-shot timer
    */
   _schedule(ms, fn) {
-    const t = this.homey.setTimeout(async () => {
+    const t = this._setTimeout(async () => {
       if (this._destroyed) return;
       try { await fn(); } catch (e) { /* ignore */ }
     }, ms);
@@ -446,9 +486,9 @@ class DynamicCapabilityManager {
    * Cleanup on device deletion
    */
   cleanup() {
+    this._destroyed = true;
     for (const t of this._timers) {
-      if (t.type === 'timeout') {clearTimeout(t.ref);}
-      if (t.type === 'interval') {clearInterval(t.ref);}
+      this._clearTimer(t);
     }
     this._timers = [];
     this._added.clear();

--- a/lib/tuya/EnrichedDPMappings.js
+++ b/lib/tuya/EnrichedDPMappings.js
@@ -603,6 +603,7 @@ const MANUFACTURER_DP_PROFILES = {
 
   // Soil sensors
   '_TZE284_myd45weu': { profile: SOIL_SENSOR_DPS.STANDARD, type: 'soil' },
+  '_TZE204_myd45weu': { profile: SOIL_SENSOR_DPS.STANDARD, type: 'soil' },
   '_TZE284_aao3yzhs': { profile: SOIL_SENSOR_DPS.STANDARD, type: 'soil' },
   '_TZE200_myd45weu': { profile: SOIL_SENSOR_DPS.STANDARD, type: 'soil' },
   // v5.8.31: QT-07S variants - temp ÷100 (centidegrees!) per ZHA quirk + INTERVIEW_RESEARCH

--- a/lib/tuya/TuyaDataQuery.js
+++ b/lib/tuya/TuyaDataQuery.js
@@ -34,6 +34,16 @@ const DEFAULT_ENDPOINT = 1;
 // After learning, use observed behavior to decide
 const LEARNING_PERIOD_MS = 5 * 60 * 1000; // 5 minutes
 
+function sleep(device, delayMs) {
+  return new Promise(resolve => {
+    const homey = device?.homey;
+    const setTimeoutFn = homey && typeof homey.setTimeout === 'function'
+      ? homey.setTimeout.bind(homey)
+      : globalThis.setTimeout.bind(globalThis);
+    setTimeoutFn(resolve, delayMs);
+  });
+}
+
 // ═══════════════════════════════════════════════════════════════════════════
 // STANDALONE FUNCTION
 // ═══════════════════════════════════════════════════════════════════════════
@@ -142,7 +152,7 @@ async function tuyaDataQuery(device, dpIds, options = {}) {
 
       // Delay between queries to avoid overwhelming the device
       if (delayBetweenQueries > 0 && dpIds.indexOf(dp) < dpIds.length - 1) {
-        await new Promise(resolve => this.homey.setTimeout(resolve, delayBetweenQueries));
+        await sleep(device, delayBetweenQueries);
       }
     } catch (err) {
       error(`${logPrefix} Failed to query DP${dp}:`, err.message);

--- a/lib/tuya/TuyaEF00Manager.js
+++ b/lib/tuya/TuyaEF00Manager.js
@@ -208,9 +208,7 @@ class TuyaEF00Manager extends EventEmitter {
     if (typeof this.sendDPWithConfirmation === 'function') {
       const result = await this.sendDPWithConfirmation(dpId, value, typeName, sendOptions);
       if (result?.success) {return true;}
-    }
-
-    if (typeof this._sendDPRaw === 'function') {
+    } else if (typeof this._sendDPRaw === 'function') {
       const rawSent = await this._sendDPRaw(dpId, value, typeName);
       if (rawSent) {return true;}
     }

--- a/lib/tuya/TuyaEF00Manager.js
+++ b/lib/tuya/TuyaEF00Manager.js
@@ -176,6 +176,52 @@ class TuyaEF00Manager extends EventEmitter {
     }
   }
 
+  _normalizeDPTypeName(dpType) {
+    if (typeof dpType === 'number') {
+      return ({ 0: 'raw', 1: 'bool', 2: 'value', 3: 'string', 4: 'enum', 5: 'bitmap' })[dpType] || 'value';
+    }
+    const type = String(dpType || 'value').toLowerCase();
+    if (type === 'boolean') {return 'bool';}
+    if (['raw', 'bool', 'value', 'string', 'enum', 'bitmap'].includes(type)) {return type;}
+    return 'value';
+  }
+
+  _normalizeDPTypeId(dpType) {
+    const type = this._normalizeDPTypeName(dpType);
+    return ({ raw: 0, bool: 1, value: 2, string: 3, enum: 4, bitmap: 5 })[type] ?? 2;
+  }
+
+  /**
+   * Public compatibility alias used by unified drivers.
+   * Signature: sendDP(dpId, value, dpType). Internally routes through the
+   * confirmation-capable raw sender and falls back to the parser-based sender.
+   */
+  async sendDP(dpId, value, dpType = 'value', options = {}) {
+    const typeName = this._normalizeDPTypeName(dpType);
+    const sendOptions = {
+      timeout: 2500,
+      retries: 0,
+      expectEcho: false,
+      ...options,
+    };
+
+    if (typeof this.sendDPWithConfirmation === 'function') {
+      const result = await this.sendDPWithConfirmation(dpId, value, typeName, sendOptions);
+      if (result?.success) {return true;}
+    }
+
+    if (typeof this._sendDPRaw === 'function') {
+      const rawSent = await this._sendDPRaw(dpId, value, typeName);
+      if (rawSent) {return true;}
+    }
+
+    if (typeof this.sendTuyaDP === 'function') {
+      return this.sendTuyaDP(dpId, this._normalizeDPTypeId(typeName), value);
+    }
+
+    return false;
+  }
+
   get safeApp() {
     try {
       if (!this.device || this.device._destroyed) return null;

--- a/lib/utils/data-collector.js
+++ b/lib/utils/data-collector.js
@@ -374,8 +374,11 @@ function startPeriodicPolling(device, zclNode, intervalMs = 300000) {
   // Initial poll
   pollData();
 
-  // Start interval
-  const interval = this.homey.setInterval(pollData, intervalMs);
+  const homey = device?.homey;
+  const setIntervalFn = homey && typeof homey.setInterval === 'function'
+    ? homey.setInterval.bind(homey)
+    : globalThis.setInterval.bind(globalThis);
+  const interval = setIntervalFn(pollData, intervalMs);
 
   return interval;
 }
@@ -385,10 +388,13 @@ function startPeriodicPolling(device, zclNode, intervalMs = 300000) {
  *
  * @param {Object} interval - Interval handle
  */
-function stopPeriodicPolling(interval) {
-  if (interval) {
-    clearInterval(interval);
-  }
+function stopPeriodicPolling(interval, device = null) {
+  if (!interval) {return;}
+  const homey = device?.homey;
+  const clearIntervalFn = homey && typeof homey.clearInterval === 'function'
+    ? homey.clearInterval.bind(homey)
+    : globalThis.clearInterval.bind(globalThis);
+  clearIntervalFn(interval);
 }
 
 /**

--- a/lib/zigbee/GreenPowerCluster.js
+++ b/lib/zigbee/GreenPowerCluster.js
@@ -20,22 +20,28 @@
 
 const { Cluster, ZCLDataTypes } = require('zigbee-clusters');
 
+const GP_DATA_TYPES = {
+  eui64: ZCLDataTypes.EUI64 || ZCLDataTypes.buffer,
+  longOctetStr: ZCLDataTypes.longOctetStr || ZCLDataTypes.buffer,
+  securityKey128: ZCLDataTypes.securityKey128 || ZCLDataTypes.buffer,
+};
+
 // Cluster ID
 const GREEN_POWER_CLUSTER_ID = 0x0021;
 
 // Attribute IDs
 const ATTRIBUTES = {
   gppMaxProxyTableEntries: { id: 0x0000, type: ZCLDataTypes.uint8 },
-  proxyTableEntries: { id: 0x0001, type: ZCLDataTypes.longOctetStr },
+  proxyTableEntries: { id: 0x0001, type: GP_DATA_TYPES.longOctetStr },
   gppNotificationRetryNumber: { id: 0x0002, type: ZCLDataTypes.uint8 },
   gppNotificationRetryTimer: { id: 0x0003, type: ZCLDataTypes.uint8 },
   gppMaxSearchCounter: { id: 0x0004, type: ZCLDataTypes.uint8 },
-  gppBlockedGPDID: { id: 0x0005, type: ZCLDataTypes.longOctetStr },
+  gppBlockedGPDID: { id: 0x0005, type: GP_DATA_TYPES.longOctetStr },
   gppFunctionality: { id: 0x0006, type: ZCLDataTypes.map24 },
   gppActiveFunctionality: { id: 0x0007, type: ZCLDataTypes.map24 },
   gpSharedSecurityKeyType: { id: 0x0020, type: ZCLDataTypes.map8 },
-  gpSharedSecurityKey: { id: 0x0021, type: ZCLDataTypes.securityKey128 },
-  gpLinkKey: { id: 0x0022, type: ZCLDataTypes.securityKey128 }
+  gpSharedSecurityKey: { id: 0x0021, type: GP_DATA_TYPES.securityKey128 },
+  gpLinkKey: { id: 0x0022, type: GP_DATA_TYPES.securityKey128 }
 };
 
 // Command IDs (Server → Client, i.e., GPD → GPS)
@@ -46,7 +52,7 @@ const COMMANDS = {
     args: {
       options: ZCLDataTypes.map16,
       gpdId: ZCLDataTypes.uint32,
-      gpdIeee: ZCLDataTypes.EUI64,
+      gpdIeee: GP_DATA_TYPES.eui64,
       endpoint: ZCLDataTypes.uint8,
       securityFrameCounter: ZCLDataTypes.uint32,
       commandId: ZCLDataTypes.uint8,
@@ -58,14 +64,14 @@ const COMMANDS = {
     args: {
       options: ZCLDataTypes.map24,
       gpdId: ZCLDataTypes.uint32,
-      gpdIeee: ZCLDataTypes.EUI64,
+      gpdIeee: GP_DATA_TYPES.eui64,
       endpoint: ZCLDataTypes.uint8,
-      sinkIeee: ZCLDataTypes.EUI64,
+      sinkIeee: GP_DATA_TYPES.eui64,
       sinkNwkAddress: ZCLDataTypes.uint16,
       sinkGroupId: ZCLDataTypes.uint16,
       deviceId: ZCLDataTypes.uint8,
       frameCounter: ZCLDataTypes.uint32,
-      key: ZCLDataTypes.securityKey128
+      key: GP_DATA_TYPES.securityKey128
     }
   },
   gpProxyCommissioningMode: {
@@ -83,7 +89,7 @@ const COMMANDS = {
       tempMaster: ZCLDataTypes.uint16,
       tempMasterTxChannel: ZCLDataTypes.uint8,
       gpdId: ZCLDataTypes.uint32,
-      gpdIeee: ZCLDataTypes.EUI64,
+      gpdIeee: GP_DATA_TYPES.eui64,
       endpoint: ZCLDataTypes.uint8,
       commandId: ZCLDataTypes.uint8,
       payload: ZCLDataTypes.buffer
@@ -94,7 +100,7 @@ const COMMANDS = {
     args: {
       options: ZCLDataTypes.map16,
       gpdId: ZCLDataTypes.uint32,
-      gpdIeee: ZCLDataTypes.EUI64,
+      gpdIeee: GP_DATA_TYPES.eui64,
       endpoint: ZCLDataTypes.uint8,
       translations: ZCLDataTypes.buffer
     }
@@ -111,7 +117,7 @@ const COMMANDS = {
       actions: ZCLDataTypes.map8,
       options: ZCLDataTypes.map16,
       gpdId: ZCLDataTypes.uint32,
-      gpdIeee: ZCLDataTypes.EUI64,
+      gpdIeee: GP_DATA_TYPES.eui64,
       endpoint: ZCLDataTypes.uint8,
       deviceId: ZCLDataTypes.uint8,
       groupList: ZCLDataTypes.buffer,
@@ -119,12 +125,12 @@ const COMMANDS = {
       forwardingRadius: ZCLDataTypes.uint8,
       securityOptions: ZCLDataTypes.uint8,
       frameCounter: ZCLDataTypes.uint32,
-      key: ZCLDataTypes.securityKey128,
+      key: GP_DATA_TYPES.securityKey128,
       numPairedEndpoints: ZCLDataTypes.uint8,
       pairedEndpoints: ZCLDataTypes.buffer,
       actions2: ZCLDataTypes.map8,
       sinkType: ZCLDataTypes.uint8,
-      sinkAddress: ZCLDataTypes.EUI64,
+      sinkAddress: GP_DATA_TYPES.eui64,
       sinkGroupId: ZCLDataTypes.uint16
     }
   }


### PR DESCRIPTION
## Summary
- Fix device-scoped timer usage in DataCollector, DynamicCapabilityManager, and TuyaDataQuery to stop diagnostics/runtime errors around undefined `homey` / `setTimeout`.
- Add a public `TuyaEF00Manager.sendDP` compatibility alias and harden dual irrigation valve DP control with non-duplicating fallback paths.
- Fix the Gmail crash root cause by adding conservative permissive-DP inference helpers to `UnifiedSensorBase` for presence/radar sensor traffic.
- Route `_TZE204_myd45weu` soil sensors away from air purifier fallback into `soilsensor_2`, including DP and battery profiles.
- Harden Gmail diagnostics automation: daily IMAP health check, diagnostics preflight, and post-publish health sweep.

## Sources crossed
- Gmail crash thread through 2026-07-04 02:41 UTC: `v9.0.177` / build `#2551` crashed with `TypeError: this._inferCapabilityFromValue is not a function` in `UnifiedSensorBase` → fixed here.
- Homey forum test thread #2098/#2100: Moes 4-button remote diagnostics `5f9e3d94-cb21-4a02-a85a-772b71e51bd1` and `3bb7a795-4f2a-4029-9e5a-565dd33e2312`.
- Homey forum #2101 + Johan #1416: soil sensor still unknown, diagnostic `af615373-f7a7-4b3c-9642-551ff8b555f1` → `_TZE204_myd45weu` now mapped to soil sensor.
- Homey forum #2102: valve actions visible but not working, diagnostic `ec0b4c11-9b13-4852-8a1d-b0fa9491e57d` → dual valve send path and state transforms hardened.
- Gemini PR #480 review: removed the unused valve helper, avoided redundant `manager.sendDP` fallback, and prevented duplicate `_sendDPRaw` transmissions after confirmation attempts.
- GitHub #428: confirmed known sensor routing fixed by user; regression path kept covered.

## Validation
- `npm run check:yaml`
- `npm run precommit`
- `node --check lib/utils/data-collector.js`
- `node --check lib/tuya/TuyaDataQuery.js`
- `node --check lib/managers/DynamicCapabilityManager.js`
- `node --check lib/tuya/TuyaEF00Manager.js`
- `node --check drivers/valve_dual_irrigation/device.js`
- `node --check lib/zigbee/GreenPowerCluster.js`
- `node --check drivers/boiler_switch_energy/driver.js`
- `node --check lib/devices/UnifiedSensorBase.js`
- GitHub Actions for head `9cb2a32d588709f97c57c03ca3744a2f4fb26de8`: Code Quality, Syntax/SDK3, Validate Homey App, Smart PR Auto-Merge, and Unified CI/CD all passed.