### PR TITLE
[codex] Guard stable DP inference and Gmail health

### DIFF
--- a/.github/scripts/gmail-token-keepalive.js
+++ b/.github/scripts/gmail-token-keepalive.js
@@ -27,7 +27,8 @@ async function main(){
     health.consecutiveFails=(health.consecutiveFails||0)+1;health.lastFail=now;
     health=privacy.redactObject(health);privacy.assertNoLeaks(health,HF);
     fs.writeFileSync(HF,JSON.stringify(health,null,2));
-    process.exit(0);
+    process.exitCode = 1;
+    return;
   }
 
   if(!imap){
@@ -36,7 +37,8 @@ async function main(){
     health.consecutiveFails=(health.consecutiveFails||0)+1;health.lastFail=now;
     health=privacy.redactObject(health);privacy.assertNoLeaks(health,HF);
     fs.writeFileSync(HF,JSON.stringify(health,null,2));
-    process.exit(1);
+    process.exitCode = 1;
+    return;
   }
 
   console.log('IMAP health check — connecting as',privacy.alias('account',e));
@@ -76,4 +78,12 @@ async function main(){
   fs.writeFileSync(HF,JSON.stringify(health,null,2));
   console.log('Health saved. Mode: imap | Consecutive fails:',health.consecutiveFails);
 }
-main().catch(e=>{console.error(e.message);process.exit(1)});
+main()
+  .then(() => {
+    if (process.exitCode) setImmediate(() => process.exit(process.exitCode));
+  })
+  .catch(e => {
+    console.error(e.message);
+    process.exitCode = 1;
+    setImmediate(() => process.exit(process.exitCode));
+  });

--- a/.github/workflows/gmail-token-keepalive.yml
+++ b/.github/workflows/gmail-token-keepalive.yml
@@ -1,0 +1,72 @@
+name: Gmail IMAP Health Check
+# <!-- badges:start -->
+# [![Gmail IMAP Health Check](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml/badge.svg)](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml)
+# <!-- badges:end -->
+
+
+# v5.12.7: IMAP-only daily health check
+on:
+  schedule:
+    - cron: '0 8 * * *'  # Daily 08:00 UTC
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: write
+  issues: write
+
+concurrency:
+  group: gmail-keepalive
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: "22"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  imap-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v5
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+      - run: npm ci --prefer-offline --no-audit || npm install
+      - name: IMAP health check
+        env:
+          GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
+          GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+        run: node .github/scripts/gmail-token-keepalive.js
+      - name: Commit health state
+        if: always()
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          node .github/scripts/privacy-redactor.js .github/state/gmail-token-health.json .github/state/_imap_alert.txt
+          git add .github/state/gmail-token-health.json 2>/dev/null || true
+          if ! git diff --staged --quiet; then
+            git commit -m "IMAP health $(date -u +%Y-%m-%d) [skip ci]"
+            git push origin HEAD:${GITHUB_REF_NAME:-master}
+          else
+            echo "No IMAP health changes to push"
+          fi
+      - name: Alert if IMAP failing
+        continue-on-error: true
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -f ".github/state/_imap_alert.txt" ]; then
+            node .github/scripts/privacy-redactor.js .github/state/_imap_alert.txt
+            gh issue create -R dlnraja/com.tuya.zigbee --title "[Alert] IMAP connection failing" \
+              --body "$(cat .github/state/_imap_alert.txt)" \
+              --label "automation" 2>/dev/null || true
+            rm -f .github/state/_imap_alert.txt
+          fi

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -185,6 +185,7 @@ jobs:
             echo "::endgroup::"
           }
 
+          run_diag 60 node .github/scripts/gmail-token-keepalive.js
           run_diag 180 node .github/scripts/fetch-gmail-diagnostics.js
           run_diag 60 npm run check:fingerprint-catalog
           run_diag 60 npm run check:homey-guidelines

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3261,7 +3261,11 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     }
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
-      if (numeric >= -40 && numeric <= 80) {
+      const learned = this._learnedDPMappings?.[dpId];
+      if (learned?.source === 'temperature_range_scaled') {
+        return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
+      }
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3270,7 +3274,11 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     }
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
-      if (numeric >= 0 && numeric <= 100) {
+      const learned = this._learnedDPMappings?.[dpId];
+      if (learned?.source === 'humidity_range_scaled') {
+        return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
+      }
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3260,14 +3260,22 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       return { capability: 'measure_battery', value: this.batteryEnumMap?.[numeric] ?? asPercent(), source: 'battery_enum' };
     }
 
-    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId)
-      && numeric >= -40 && numeric <= 80 && canUse('measure_temperature')) {
-      return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
+      if (numeric >= -40 && numeric <= 80) {
+        return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+      }
+      if (numeric >= -400 && numeric <= 800) {
+        return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
+      }
     }
 
-    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId)
-      && numeric >= 0 && numeric <= 100 && canUse('measure_humidity')) {
-      return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
+      if (numeric >= 0 && numeric <= 100) {
+        return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+      }
+      if (numeric >= 0 && numeric <= 1000) {
+        return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
+      }
     }
 
     if (finite && [101, 102, 103, 104, 105, 106, 107].includes(dpId)

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3226,6 +3226,78 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     return raw;
   }
 
+  /**
+   * Conservative fallback for permissive DP mode.
+   * Keeps unknown DP traffic from crashing while only inferring common sensor values.
+   */
+  _inferCapabilityFromValue(dp, value) {
+    const dpId = Number(dp);
+    if (!Number.isFinite(dpId) || value === null || value === undefined) {return null;}
+
+    const numeric = typeof value === 'number' ? value : Number(value);
+    const finite = Number.isFinite(numeric);
+    const has = (capability) => typeof this.hasCapability === 'function' && this.hasCapability(capability);
+    const canUse = (capability) => has(capability) || this._isPermissiveCapabilityAllowed(capability);
+    const asPercent = () => Math.max(0, Math.min(100, Math.round(numeric)));
+
+    if ((value === true || value === false || numeric === 0 || numeric === 1)
+      && [1, 2, 3, 101, 102, 103, 104, 105].includes(dpId)) {
+      const boolValue = value === true || numeric === 1;
+      if (canUse('alarm_human')) {
+        return { capability: 'alarm_human', value: boolValue, source: 'binary_presence' };
+      }
+      if (canUse('alarm_motion')) {
+        return { capability: 'alarm_motion', value: boolValue, source: 'binary_motion' };
+      }
+    }
+
+    if (!this.mainsPowered && finite && [4, 15, 59, 101, 102, 103, 105].includes(dpId)
+      && numeric >= 0 && numeric <= 100 && canUse('measure_battery')) {
+      return { capability: 'measure_battery', value: asPercent(), source: 'battery_percent' };
+    }
+
+    if (!this.mainsPowered && dpId === 14 && Number.isInteger(numeric) && numeric >= 0 && numeric <= 2 && canUse('measure_battery')) {
+      return { capability: 'measure_battery', value: this.batteryEnumMap?.[numeric] ?? asPercent(), source: 'battery_enum' };
+    }
+
+    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId)
+      && numeric >= -40 && numeric <= 80 && canUse('measure_temperature')) {
+      return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+    }
+
+    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId)
+      && numeric >= 0 && numeric <= 100 && canUse('measure_humidity')) {
+      return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+    }
+
+    if (finite && [101, 102, 103, 104, 105, 106, 107].includes(dpId)
+      && numeric >= 0 && numeric <= 100000 && canUse('measure_luminance')) {
+      return { capability: 'measure_luminance', value: Math.round(numeric), source: 'luminance_range' };
+    }
+
+    return null;
+  }
+
+  _isPermissiveCapabilityAllowed(capability) {
+    if (!capability) {return false;}
+    const allowed = new Set(Array.isArray(this.sensorCapabilities) ? this.sensorCapabilities : []);
+    return allowed.has(capability);
+  }
+
+  async _addCapabilityPermissive(capability) {
+    if (!this._isPermissiveCapabilityAllowed(capability)) {return false;}
+    if (typeof this.hasCapability === 'function' && this.hasCapability(capability)) {return true;}
+    if (typeof this.addCapability !== 'function') {return false;}
+
+    try {
+      await this.addCapability(capability);
+      this.log(`[DP-PERMISSIVE] Added capability ${capability}`);
+      return true;
+    } catch (err) {
+      this.log(`[DP-PERMISSIVE] Could not add ${capability}: ${err.message}`);
+      return false;
+    }
+  }
   // ═══════════════════════════════════════════════════════════════════════════
   // v5.3.96: TIME SYNC ON DEVICE WAKE
   // ═══════════════════════════════════════════════════════════════════════════

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3262,10 +3262,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.source === 'temperature_range_scaled') {
+      if (learned?.capability === 'measure_temperature' && learned.source === 'temperature_range_scaled') {
         return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
       }
-      if (numeric >= -40 && numeric <= 80 && (!learned || learned.source === 'temperature_range')) {
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned.capability !== 'measure_temperature' || learned.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3275,10 +3275,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.source === 'humidity_range_scaled') {
+      if (learned?.capability === 'measure_humidity' && learned.source === 'humidity_range_scaled') {
         return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
       }
-      if (numeric >= 0 && numeric <= 100 && (!learned || learned.source === 'humidity_range')) {
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned.capability !== 'measure_humidity' || learned.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {

--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3262,10 +3262,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.capability === 'measure_temperature' && learned.source === 'temperature_range_scaled') {
+      if (learned?.capability === 'measure_temperature' && learned?.source === 'temperature_range_scaled') {
         return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
       }
-      if (numeric >= -40 && numeric <= 80 && (!learned || learned.capability !== 'measure_temperature' || learned.source === 'temperature_range')) {
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned?.capability !== 'measure_temperature' || learned?.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3275,10 +3275,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.capability === 'measure_humidity' && learned.source === 'humidity_range_scaled') {
+      if (learned?.capability === 'measure_humidity' && learned?.source === 'humidity_range_scaled') {
         return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
       }
-      if (numeric >= 0 && numeric <= 100 && (!learned || learned.capability !== 'measure_humidity' || learned.source === 'humidity_range')) {
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned?.capability !== 'measure_humidity' || learned?.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {


### PR DESCRIPTION
## Summary
- Add the missing permissive DP inference helpers to stable v5 `UnifiedSensorBase` so unknown Tuya DP traffic cannot crash on `_inferCapabilityFromValue`.
- Make the stable Gmail IMAP health script fail fast on missing credentials or missing IMAP support instead of reporting success.
- Add a daily Gmail IMAP health workflow and run the same health preflight in the stable publish diagnostics sweep.
- Support scaled Tuya temperature/humidity values, keep learned DP scaling consistent, scope learned scaling by capability, and use optional chaining consistently on learned DP source checks.

## Sources crossed
- Gmail crash thread for `com.dlnraja.tuya.zigbee` through v9.0.177 showed repeated `TypeError: this._inferCapabilityFromValue is not a function` in `UnifiedSensorBase`.
- Stable v5 had the same permissive-mode call site without the helper definition, so the same guard is ported conservatively.
- Gemini Code Assist flagged scaled Tuya sensor values, learned-value oscillation, multi-purpose DP capability scoping, and optional-chaining consistency.

## Validation
- `node --check lib/devices/UnifiedSensorBase.js`
- `node --check .github/scripts/gmail-token-keepalive.js`
- `node .github/scripts/_validate-workflows.js`
- `npm run precommit`
- `git commit` pre-commit hooks passed for the stable follow-up commits