### PR TITLE
[codex] Support scaled permissive sensor values

### DIFF
--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3248,14 +3248,22 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
       return { capability: 'measure_battery', value: this.batteryEnumMap[numeric] ?? asPercent(), source: 'battery_enum' };
     }
 
-    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId)
-      && numeric >= -40 && numeric <= 80 && canUse('measure_temperature')) {
-      return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+    if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
+      if (numeric >= -40 && numeric <= 80) {
+        return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
+      }
+      if (numeric >= -400 && numeric <= 800) {
+        return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
+      }
     }
 
-    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId)
-      && numeric >= 0 && numeric <= 100 && canUse('measure_humidity')) {
-      return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+    if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
+      if (numeric >= 0 && numeric <= 100) {
+        return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
+      }
+      if (numeric >= 0 && numeric <= 1000) {
+        return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
+      }
     }
 
     if (finite && [101, 102, 103, 104, 105, 106, 107].includes(dpId)


### PR DESCRIPTION
## Summary
- Port the Gemini-requested permissive DP inference improvement from stable v5 back to `master`.
- Accept Tuya temperature and humidity reports scaled by 10, e.g. `255` -> `25.5°C` and `450` -> `45.0%`, while keeping existing unscaled fallback behavior.

## Sources crossed
- Gemini Code Assist review on #481 flagged scaled Tuya temperature/humidity reports as high-priority.
- Gmail crash investigation for v9.0.177 identified permissive DP fallback as the crash path, so the scaled support needs to stay aligned between both apps/branches.

## Validation
- `node --check lib/devices/UnifiedSensorBase.js`
- `npm run precommit`
- `git commit` pre-commit hook: all 9 checks passed
- `git push` pre-push gate: mandatory, Athom requirements, payload size and security checks passed