### PR TITLE
[codex] Keep learned DP scaling consistent

### DIFF
--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3249,7 +3249,11 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     }
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
-      if (numeric >= -40 && numeric <= 80) {
+      const learned = this._learnedDPMappings?.[dpId];
+      if (learned?.source === 'temperature_range_scaled') {
+        return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
+      }
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3258,7 +3262,11 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
     }
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
-      if (numeric >= 0 && numeric <= 100) {
+      const learned = this._learnedDPMappings?.[dpId];
+      if (learned?.source === 'humidity_range_scaled') {
+        return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
+      }
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {


### PR DESCRIPTION
## Summary
- Follow up on Gemini's post-merge review for #482.
- Keep permissive Tuya DP temperature/humidity scaling stable once a DP has been learned as scaled.
- Allow dynamic upgrade from unscaled to scaled when a later value leaves the unscaled range.

## Why
Without checking `_learnedDPMappings`, a scaled DP such as `50` could be interpreted as `50°C` after the same DP previously reported `255` as `25.5°C`. This keeps raw DP fallback values coherent over time for unknown or partially mapped devices.

## Validation
- `node --check lib/devices/UnifiedSensorBase.js`
- `npm run precommit`
- `git commit` pre-commit hook: all 9 checks passed
- `git push` pre-push gate: mandatory, Athom requirements and payload checks passed