### PR TITLE
[codex] Scope learned DP scaling by capability

### DIFF
--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3250,10 +3250,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.source === 'temperature_range_scaled') {
+      if (learned?.capability === 'measure_temperature' && learned.source === 'temperature_range_scaled') {
         return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
       }
-      if (numeric >= -40 && numeric <= 80 && (!learned || learned.source === 'temperature_range')) {
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned.capability !== 'measure_temperature' || learned.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3263,10 +3263,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.source === 'humidity_range_scaled') {
+      if (learned?.capability === 'measure_humidity' && learned.source === 'humidity_range_scaled') {
         return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
       }
-      if (numeric >= 0 && numeric <= 100 && (!learned || learned.source === 'humidity_range')) {
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned.capability !== 'measure_humidity' || learned.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {


### PR DESCRIPTION
## Summary
- Follow up on Gemini's #483 review.
- Scope learned temperature/humidity scaling decisions to the matching capability.
- Prevent a DP learned as another capability, such as `alarm_motion`, from forcing later temperature or humidity values into scaled interpretation.

## Why
The permissive DP fallback handles multi-purpose Tuya datapoints. A learned mapping should only influence scaling when the learned capability is the same target sensor capability.

## Validation
- `node --check lib/devices/UnifiedSensorBase.js`
- `npm run precommit`
- `git commit` pre-commit hook: all 9 checks passed
- `git push` pre-push gate: mandatory, Athom requirements and payload checks passed on v9.0.179