### PR TITLE
[codex] Harden learned DP source guards

### DIFF
--- a/lib/devices/UnifiedSensorBase.js
+++ b/lib/devices/UnifiedSensorBase.js
@@ -3250,10 +3250,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [1, 5, 101, 102, 103, 104, 105].includes(dpId) && canUse('measure_temperature')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.capability === 'measure_temperature' && learned.source === 'temperature_range_scaled') {
+      if (learned?.capability === 'measure_temperature' && learned?.source === 'temperature_range_scaled') {
         return { capability: 'measure_temperature', value: Math.round(numeric) / 10, source: 'temperature_range_scaled' };
       }
-      if (numeric >= -40 && numeric <= 80 && (!learned || learned.capability !== 'measure_temperature' || learned.source === 'temperature_range')) {
+      if (numeric >= -40 && numeric <= 80 && (!learned || learned?.capability !== 'measure_temperature' || learned?.source === 'temperature_range')) {
         return { capability: 'measure_temperature', value: Math.round(numeric * 10) / 10, source: 'temperature_range' };
       }
       if (numeric >= -400 && numeric <= 800) {
@@ -3263,10 +3263,10 @@ class UnifiedSensorBase extends TuyaZigbeeDevice {
 
     if (finite && [2, 3, 102, 103, 104, 105].includes(dpId) && canUse('measure_humidity')) {
       const learned = this._learnedDPMappings?.[dpId];
-      if (learned?.capability === 'measure_humidity' && learned.source === 'humidity_range_scaled') {
+      if (learned?.capability === 'measure_humidity' && learned?.source === 'humidity_range_scaled') {
         return { capability: 'measure_humidity', value: Math.round(numeric) / 10, source: 'humidity_range_scaled' };
       }
-      if (numeric >= 0 && numeric <= 100 && (!learned || learned.capability !== 'measure_humidity' || learned.source === 'humidity_range')) {
+      if (numeric >= 0 && numeric <= 100 && (!learned || learned?.capability !== 'measure_humidity' || learned?.source === 'humidity_range')) {
         return { capability: 'measure_humidity', value: Math.round(numeric * 10) / 10, source: 'humidity_range' };
       }
       if (numeric >= 0 && numeric <= 1000) {


### PR DESCRIPTION
## Summary
- Apply Gemini Code Assist's optional-chaining follow-up from PR #484.
- Use `learned?.source` consistently for learned temperature/humidity DP source checks.
- Keep the learned DP scaling behavior unchanged while making future condition edits safer.

## Sources crossed
- Gmail notification for Gemini Code Assist review on PR #484.
- PR #484 review comments on `lib/devices/UnifiedSensorBase.js`.
- Same fix ported into stable PR #481 so both app lines stay aligned.

## Validation
- `node --check lib/devices/UnifiedSensorBase.js`
- `npm run precommit`
- `git commit` pre-commit hook passed
- `git push` pre-push gate passed