### PR TITLE
[codex] Harden crash diagnostics and boiler flows

### DIFF
--- a/.homeycompose/flow/conditions/boiler_switch_energy_power_above.json
+++ b/.homeycompose/flow/conditions/boiler_switch_energy_power_above.json
@@ -1,0 +1,30 @@
+{
+  "id": "boiler_switch_energy_power_above",
+  "title": {
+    "en": "Boiler power is above [[threshold]] W",
+    "fr": "La puissance chaudiere est au-dessus de [[threshold]] W"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "capabilities=measure_power"
+    },
+    {
+      "name": "threshold",
+      "type": "number",
+      "title": {
+        "en": "Threshold",
+        "fr": "Seuil"
+      },
+      "min": 0,
+      "max": 10000,
+      "step": 10,
+      "value": 1000
+    }
+  ],
+  "titleFormatted": {
+    "en": "Boiler power is above [[threshold]] W [[device]]",
+    "fr": "La puissance chaudiere est au-dessus de [[threshold]] W [[device]]"
+  }
+}

--- a/.homeycompose/flow/conditions/boiler_switch_energy_temperature_above.json
+++ b/.homeycompose/flow/conditions/boiler_switch_energy_temperature_above.json
@@ -1,0 +1,30 @@
+{
+  "id": "boiler_switch_energy_temperature_above",
+  "title": {
+    "en": "Boiler temperature is above [[threshold]] C",
+    "fr": "La temperature chaudiere est au-dessus de [[threshold]] C"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "capabilities=measure_temperature"
+    },
+    {
+      "name": "threshold",
+      "type": "number",
+      "title": {
+        "en": "Threshold",
+        "fr": "Seuil"
+      },
+      "min": -40,
+      "max": 150,
+      "step": 0.5,
+      "value": 50
+    }
+  ],
+  "titleFormatted": {
+    "en": "Boiler temperature is above [[threshold]] C [[device]]",
+    "fr": "La temperature chaudiere est au-dessus de [[threshold]] C [[device]]"
+  }
+}

--- a/.homeycompose/flow/triggers/boiler_switch_energy_turned_off.json
+++ b/.homeycompose/flow/triggers/boiler_switch_energy_turned_off.json
@@ -1,0 +1,36 @@
+{
+  "id": "boiler_switch_energy_turned_off",
+  "title": {
+    "en": "Boiler switch turned off",
+    "fr": "Interrupteur chaudiere eteint"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "capabilities=onoff,measure_power"
+    }
+  ],
+  "tokens": [
+    {
+      "name": "power",
+      "type": "number",
+      "title": {
+        "en": "Power",
+        "fr": "Puissance"
+      }
+    },
+    {
+      "name": "temperature",
+      "type": "number",
+      "title": {
+        "en": "Temperature",
+        "fr": "Temperature"
+      }
+    }
+  ],
+  "titleFormatted": {
+    "en": "Boiler switch turned off [[device]]",
+    "fr": "Interrupteur chaudiere eteint [[device]]"
+  }
+}

--- a/.homeycompose/flow/triggers/boiler_switch_energy_turned_on.json
+++ b/.homeycompose/flow/triggers/boiler_switch_energy_turned_on.json
@@ -1,0 +1,36 @@
+{
+  "id": "boiler_switch_energy_turned_on",
+  "title": {
+    "en": "Boiler switch turned on",
+    "fr": "Interrupteur chaudiere allume"
+  },
+  "args": [
+    {
+      "type": "device",
+      "name": "device",
+      "filter": "capabilities=onoff,measure_power"
+    }
+  ],
+  "tokens": [
+    {
+      "name": "power",
+      "type": "number",
+      "title": {
+        "en": "Power",
+        "fr": "Puissance"
+      }
+    },
+    {
+      "name": "temperature",
+      "type": "number",
+      "title": {
+        "en": "Temperature",
+        "fr": "Temperature"
+      }
+    }
+  ],
+  "titleFormatted": {
+    "en": "Boiler switch turned on [[device]]",
+    "fr": "Interrupteur chaudiere allume [[device]]"
+  }
+}

--- a/drivers/boiler_switch_energy/device.js
+++ b/drivers/boiler_switch_energy/device.js
@@ -29,12 +29,61 @@ class BoilerSwitchEnergyDevice extends PhysicalButtonMixin(VirtualButtonMixin(Un
     };
   }
 
+  _getBoilerTrigger(id) {
+    try {
+      return this.homey?.flow?.getDeviceTriggerCard(id) || null;
+    } catch (err) {
+      this.log(`[BoilerSwitchEnergy] Flow trigger ${id} unavailable: ${err.message}`);
+      return null;
+    }
+  }
+
+  _triggerBoilerOnOff(state) {
+    const nextState = Boolean(state);
+    if (this._lastBoilerOnOff === nextState) {return;}
+    this._lastBoilerOnOff = nextState;
+
+    const cardId = nextState
+      ? 'boiler_switch_energy_turned_on'
+      : 'boiler_switch_energy_turned_off';
+    const trigger = this._boilerTriggers?.[cardId] || this._getBoilerTrigger(cardId);
+    if (!trigger) {return;}
+
+    const tokens = {
+      power: Number(this.getCapabilityValue('measure_power') || 0),
+      temperature: Number(this.getCapabilityValue('measure_temperature') || 0),
+    };
+    trigger.trigger(this, tokens, {}).catch(err => {
+      this.log(`[BoilerSwitchEnergy] Flow trigger ${cardId} failed: ${err.message}`);
+    });
+  }
+
+  _parseBoilerOnOff(rawValue) {
+    if (Buffer.isBuffer(rawValue)) {
+      return rawValue.length > 0 && rawValue[0] === 1;
+    }
+    return rawValue === 1 || rawValue === true;
+  }
+
+  _handleDP(dpId, rawValue) {
+    const result = super._handleDP(dpId, rawValue);
+    if (Number(dpId) === 1) {
+      this._triggerBoilerOnOff(this._parseBoilerOnOff(rawValue));
+    }
+    return result;
+  }
+
   async onNodeInit({ zclNode }) {
     if (this._initialized || this._initializing) return;
     this._initializing = true;
 
     try {
       await super.onNodeInit({ zclNode });
+      this._boilerTriggers = {
+        boiler_switch_energy_turned_on: this._getBoilerTrigger('boiler_switch_energy_turned_on'),
+        boiler_switch_energy_turned_off: this._getBoilerTrigger('boiler_switch_energy_turned_off'),
+      };
+      this._lastBoilerOnOff = Boolean(this.getCapabilityValue('onoff'));
       await this.removeCapability('measure_battery').catch(() => {});
       await this.removeCapability('alarm_battery').catch(() => {});
       await this.initPhysicalButtonDetection?.(zclNode);

--- a/drivers/valve_dual_irrigation/device.js
+++ b/drivers/valve_dual_irrigation/device.js
@@ -58,18 +58,30 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
     // Register capability listeners for BOTH valves
     this.registerCapabilityListener('onoff.valve_1', async (value) => {
       this.log(`[VALVE-2] Setting Valve 1 = ${value}`);
-      // Insoma valves often require explicit 1/0 as bool
-      await this.sendDP(1, value ? true : false, 'bool');
-      await this.safeSetCapabilityValue?.('onoff.valve_1', Boolean(value)).catch(() => {});
+      await this._sendValveDP(1, 'onoff.valve_1', value);
       });
 
     this.registerCapabilityListener('onoff.valve_2', async (value) => {
       this.log(`[VALVE-2] Setting Valve 2 = ${value}`);
-      await this.sendDP(2, value ? true : false, 'bool');
-      await this.safeSetCapabilityValue?.('onoff.valve_2', Boolean(value)).catch(() => {});
+      await this._sendValveDP(2, 'onoff.valve_2', value);
       });
 
     this.log('[VALVE-2]  Ready (Dual Engine v7.4.4)');
+  }
+
+  async _sendValveDP(dp, capability, value) {
+    const sent = await this.sendDP(dp, Boolean(value), 'bool');
+    if (!this._isValveDPSendSuccess(sent)) {
+      throw new Error(`valve_dp_${dp}_not_sent`);
+    }
+    await this.safeSetCapabilityValue?.(capability, Boolean(value)).catch(() => {});
+    return true;
+  }
+
+  _isValveDPSendSuccess(result) {
+    if (result === true) {return true;}
+    if (!result || typeof result !== 'object') {return false;}
+    return result.success === true || result.status === 'success';
   }
 
   // Override sendDP to keep dual-valve actions working across manager variants.
@@ -83,8 +95,7 @@ class ValveDualIrrigationDevice extends BaseUnifiedDevice {
       if (typeof manager.sendDPWithConfirmation === 'function') {
         const result = await manager.sendDPWithConfirmation(dp, value, type, { retries: 1, timeout: 2500, expectEcho: false });
         if (result?.success) {return true;}
-      }
-      if (typeof manager._sendDPRaw === 'function') {
+      } else if (typeof manager._sendDPRaw === 'function') {
         const sent = await manager._sendDPRaw(dp, value, type);
         if (sent) {return true;}
       }

--- a/lib/tuya/TuyaEF00Manager.js
+++ b/lib/tuya/TuyaEF00Manager.js
@@ -176,6 +176,26 @@ class TuyaEF00Manager extends EventEmitter {
     }
   }
 
+  _getTimerHost() {
+    return this.device?.homey || this.homey || globalThis;
+  }
+
+  _setTimeout(fn, ms) {
+    const host = this._getTimerHost();
+    const setTimeoutFn = host && typeof host.setTimeout === 'function'
+      ? host.setTimeout.bind(host)
+      : globalThis.setTimeout.bind(globalThis);
+    return setTimeoutFn(fn, ms);
+  }
+
+  _clearTimeout(timer) {
+    const host = this._getTimerHost();
+    const clearTimeoutFn = host && typeof host.clearTimeout === 'function'
+      ? host.clearTimeout.bind(host)
+      : globalThis.clearTimeout.bind(globalThis);
+    return clearTimeoutFn(timer);
+  }
+
   _normalizeDPTypeName(dpType) {
     if (typeof dpType === 'number') {
       return ({ 0: 'raw', 1: 'bool', 2: 'value', 3: 'string', 4: 'enum', 5: 'bitmap' })[dpType] || 'value';
@@ -512,14 +532,14 @@ class TuyaEF00Manager extends EventEmitter {
       const cleanup = () => {
         if (!resolved) {
           resolved = true;
-          clearTimeout(timer);
+          this._clearTimeout(timer);
           if (handler) {
             this.removeListener('dpReport', handler);
           }
         }
       };
 
-      const timer = this.device.homey.setTimeout(() => {
+      const timer = this._setTimeout(() => {
         cleanup();
         resolve({ confirmed: false, waitTime: timeout });
       }, timeout);

--- a/lib/zigbee/GreenPowerCluster.js
+++ b/lib/zigbee/GreenPowerCluster.js
@@ -20,10 +20,25 @@
 
 const { Cluster, ZCLDataTypes } = require('zigbee-clusters');
 
+const typeOr = (primary, fallback) => ZCLDataTypes[primary] || ZCLDataTypes[fallback] || ZCLDataTypes.buffer;
+const GP_ZCL_TYPES = {
+  uint8: typeOr('uint8', 'uint8'),
+  uint16: typeOr('uint16', 'uint16'),
+  uint32: typeOr('uint32', 'uint32'),
+  data16: typeOr('data16', 'uint16'),
+  map8: typeOr('map8', 'uint8'),
+  map16: typeOr('map16', 'uint16'),
+  map24: typeOr('map24', 'uint32'),
+  buffer: typeOr('buffer', 'string'),
+  eui64: typeOr('EUI64', 'buffer'),
+  longOctetStr: typeOr('longOctetStr', 'buffer'),
+  securityKey128: typeOr('securityKey128', 'buffer'),
+};
+
 const GP_DATA_TYPES = {
-  eui64: ZCLDataTypes.EUI64 || ZCLDataTypes.buffer,
-  longOctetStr: ZCLDataTypes.longOctetStr || ZCLDataTypes.buffer,
-  securityKey128: ZCLDataTypes.securityKey128 || ZCLDataTypes.buffer,
+  eui64: GP_ZCL_TYPES.eui64,
+  longOctetStr: GP_ZCL_TYPES.longOctetStr,
+  securityKey128: GP_ZCL_TYPES.securityKey128,
 };
 
 // Cluster ID
@@ -31,15 +46,15 @@ const GREEN_POWER_CLUSTER_ID = 0x0021;
 
 // Attribute IDs
 const ATTRIBUTES = {
-  gppMaxProxyTableEntries: { id: 0x0000, type: ZCLDataTypes.uint8 },
+  gppMaxProxyTableEntries: { id: 0x0000, type: GP_ZCL_TYPES.uint8 },
   proxyTableEntries: { id: 0x0001, type: GP_DATA_TYPES.longOctetStr },
-  gppNotificationRetryNumber: { id: 0x0002, type: ZCLDataTypes.uint8 },
-  gppNotificationRetryTimer: { id: 0x0003, type: ZCLDataTypes.uint8 },
-  gppMaxSearchCounter: { id: 0x0004, type: ZCLDataTypes.uint8 },
+  gppNotificationRetryNumber: { id: 0x0002, type: GP_ZCL_TYPES.uint8 },
+  gppNotificationRetryTimer: { id: 0x0003, type: GP_ZCL_TYPES.uint8 },
+  gppMaxSearchCounter: { id: 0x0004, type: GP_ZCL_TYPES.uint8 },
   gppBlockedGPDID: { id: 0x0005, type: GP_DATA_TYPES.longOctetStr },
-  gppFunctionality: { id: 0x0006, type: ZCLDataTypes.map24 },
-  gppActiveFunctionality: { id: 0x0007, type: ZCLDataTypes.map24 },
-  gpSharedSecurityKeyType: { id: 0x0020, type: ZCLDataTypes.map8 },
+  gppFunctionality: { id: 0x0006, type: GP_ZCL_TYPES.map24 },
+  gppActiveFunctionality: { id: 0x0007, type: GP_ZCL_TYPES.map24 },
+  gpSharedSecurityKeyType: { id: 0x0020, type: GP_ZCL_TYPES.map8 },
   gpSharedSecurityKey: { id: 0x0021, type: GP_DATA_TYPES.securityKey128 },
   gpLinkKey: { id: 0x0022, type: GP_DATA_TYPES.securityKey128 }
 };
@@ -50,88 +65,88 @@ const COMMANDS = {
   gpNotification: {
     id: 0x00,
     args: {
-      options: ZCLDataTypes.map16,
-      gpdId: ZCLDataTypes.uint32,
+      options: GP_ZCL_TYPES.map16,
+      gpdId: GP_ZCL_TYPES.uint32,
       gpdIeee: GP_DATA_TYPES.eui64,
-      endpoint: ZCLDataTypes.uint8,
-      securityFrameCounter: ZCLDataTypes.uint32,
-      commandId: ZCLDataTypes.uint8,
-      payload: ZCLDataTypes.buffer
+      endpoint: GP_ZCL_TYPES.uint8,
+      securityFrameCounter: GP_ZCL_TYPES.uint32,
+      commandId: GP_ZCL_TYPES.uint8,
+      payload: GP_ZCL_TYPES.buffer
     }
   },
   gpPairing: {
     id: 0x01,
     args: {
-      options: ZCLDataTypes.map24,
-      gpdId: ZCLDataTypes.uint32,
+      options: GP_ZCL_TYPES.map24,
+      gpdId: GP_ZCL_TYPES.uint32,
       gpdIeee: GP_DATA_TYPES.eui64,
-      endpoint: ZCLDataTypes.uint8,
+      endpoint: GP_ZCL_TYPES.uint8,
       sinkIeee: GP_DATA_TYPES.eui64,
-      sinkNwkAddress: ZCLDataTypes.uint16,
-      sinkGroupId: ZCLDataTypes.uint16,
-      deviceId: ZCLDataTypes.uint8,
-      frameCounter: ZCLDataTypes.uint32,
+      sinkNwkAddress: GP_ZCL_TYPES.uint16,
+      sinkGroupId: GP_ZCL_TYPES.uint16,
+      deviceId: GP_ZCL_TYPES.uint8,
+      frameCounter: GP_ZCL_TYPES.uint32,
       key: GP_DATA_TYPES.securityKey128
     }
   },
   gpProxyCommissioningMode: {
     id: 0x02,
     args: {
-      options: ZCLDataTypes.map8,
-      commissioningWindow: ZCLDataTypes.uint16,
-      channel: ZCLDataTypes.uint8
+      options: GP_ZCL_TYPES.map8,
+      commissioningWindow: GP_ZCL_TYPES.uint16,
+      channel: GP_ZCL_TYPES.uint8
     }
   },
   gpResponse: {
     id: 0x06,
     args: {
-      options: ZCLDataTypes.map8,
-      tempMaster: ZCLDataTypes.uint16,
-      tempMasterTxChannel: ZCLDataTypes.uint8,
-      gpdId: ZCLDataTypes.uint32,
+      options: GP_ZCL_TYPES.map8,
+      tempMaster: GP_ZCL_TYPES.uint16,
+      tempMasterTxChannel: GP_ZCL_TYPES.uint8,
+      gpdId: GP_ZCL_TYPES.uint32,
       gpdIeee: GP_DATA_TYPES.eui64,
-      endpoint: ZCLDataTypes.uint8,
-      commandId: ZCLDataTypes.uint8,
-      payload: ZCLDataTypes.buffer
+      endpoint: GP_ZCL_TYPES.uint8,
+      commandId: GP_ZCL_TYPES.uint8,
+      payload: GP_ZCL_TYPES.buffer
     }
   },
   gpTranslationTableUpdate: {
     id: 0x07,
     args: {
-      options: ZCLDataTypes.map16,
-      gpdId: ZCLDataTypes.uint32,
+      options: GP_ZCL_TYPES.map16,
+      gpdId: GP_ZCL_TYPES.uint32,
       gpdIeee: GP_DATA_TYPES.eui64,
-      endpoint: ZCLDataTypes.uint8,
-      translations: ZCLDataTypes.buffer
+      endpoint: GP_ZCL_TYPES.uint8,
+      translations: GP_ZCL_TYPES.buffer
     }
   },
   gpTranslationTableRequest: {
     id: 0x08,
     args: {
-      startIndex: ZCLDataTypes.uint8
+      startIndex: GP_ZCL_TYPES.uint8
     }
   },
   gpPairingConfiguration: {
     id: 0x09,
     args: {
-      actions: ZCLDataTypes.map8,
-      options: ZCLDataTypes.map16,
-      gpdId: ZCLDataTypes.uint32,
+      actions: GP_ZCL_TYPES.map8,
+      options: GP_ZCL_TYPES.map16,
+      gpdId: GP_ZCL_TYPES.uint32,
       gpdIeee: GP_DATA_TYPES.eui64,
-      endpoint: ZCLDataTypes.uint8,
-      deviceId: ZCLDataTypes.uint8,
-      groupList: ZCLDataTypes.buffer,
-      assignedAlias: ZCLDataTypes.uint16,
-      forwardingRadius: ZCLDataTypes.uint8,
-      securityOptions: ZCLDataTypes.uint8,
-      frameCounter: ZCLDataTypes.uint32,
+      endpoint: GP_ZCL_TYPES.uint8,
+      deviceId: GP_ZCL_TYPES.uint8,
+      groupList: GP_ZCL_TYPES.buffer,
+      assignedAlias: GP_ZCL_TYPES.uint16,
+      forwardingRadius: GP_ZCL_TYPES.uint8,
+      securityOptions: GP_ZCL_TYPES.uint8,
+      frameCounter: GP_ZCL_TYPES.uint32,
       key: GP_DATA_TYPES.securityKey128,
-      numPairedEndpoints: ZCLDataTypes.uint8,
-      pairedEndpoints: ZCLDataTypes.buffer,
-      actions2: ZCLDataTypes.map8,
-      sinkType: ZCLDataTypes.uint8,
+      numPairedEndpoints: GP_ZCL_TYPES.uint8,
+      pairedEndpoints: GP_ZCL_TYPES.buffer,
+      actions2: GP_ZCL_TYPES.map8,
+      sinkType: GP_ZCL_TYPES.uint8,
       sinkAddress: GP_DATA_TYPES.eui64,
-      sinkGroupId: ZCLDataTypes.uint16
+      sinkGroupId: GP_ZCL_TYPES.uint16
     }
   }
 };


### PR DESCRIPTION
## Summary
- add declared boiler switch energy trigger/condition Flow cards and runtime trigger dispatch
- harden dual irrigation valve DP sends so failed sends do not silently update UI state
- add safe timer fallbacks in TuyaEF00Manager confirmation handling
- make GreenPowerCluster registration resilient to optional/missing zigbee-clusters data types

## Validation
- npm run build
- npm run precommit
- npm run check:diag-history
- npm run diag:build (completed; latest failed build #2553 reported UNKNOWN after navigation timeout)
- node GreenPowerCluster registration smoke test
- Gmail checked: latest crash email is v9.0.177 _inferCapabilityFromValue, already fixed in v9.0.180 test build #2555