### PR TITLE
[codex] Preserve GreenPower map24 width

### DIFF
--- a/lib/zigbee/GreenPowerCluster.js
+++ b/lib/zigbee/GreenPowerCluster.js
@@ -28,7 +28,7 @@ const GP_ZCL_TYPES = {
   data16: typeOr('data16', 'uint16'),
   map8: typeOr('map8', 'uint8'),
   map16: typeOr('map16', 'uint16'),
-  map24: typeOr('map24', 'uint32'),
+  map24: typeOr('map24', 'uint24'),
   buffer: typeOr('buffer', 'string'),
   eui64: typeOr('EUI64', 'buffer'),
   longOctetStr: typeOr('longOctetStr', 'buffer'),


### PR DESCRIPTION
## Summary
- refine the GreenPowerCluster fallback so map24 falls back to uint24 instead of uint32
- keeps 3-byte Green Power option fields from shifting later payload bytes when map24 is unavailable

## Validation
- node --check lib/zigbee/GreenPowerCluster.js
- GreenPowerCluster registration smoke test
- npm run check:timer-context
- npm run check:flows
- npm run precommit