### PR TITLE
fix(ci): harden Gmail diagnostics auth fallback

### DIFF
--- a/.github/scripts/fetch-gmail-diagnostics.js
+++ b/.github/scripts/fetch-gmail-diagnostics.js
@@ -44,7 +44,8 @@ function parseFetchOptions(argv){
   const reprocess=argFlag(argv,['--reprocess','--replay'])||boolEnv('GMAIL_DIAG_REPROCESS',false);
   const stateLimit=boundedInt(process.env.GMAIL_DIAG_STATE_LIMIT,allHistory?Math.max(5000,maxTotalResults):500,100,20000);
   const autoImplement=argFlag(argv,['--implement','--auto-implement'])||boolEnv('GMAIL_DIAG_AUTO_IMPLEMENT',false);
-  return{allHistory,since,until,maxResults,maxTotalResults,chunkDays,reprocess,stateLimit,autoImplement};
+  const requireAccess=argFlag(argv,['--require-access'])||boolEnv('GMAIL_DIAG_REQUIRE_ACCESS',false);
+  return{allHistory,since,until,maxResults,maxTotalResults,chunkDays,reprocess,stateLimit,autoImplement,requireAccess};
 }
 const load=()=>{try{return JSON.parse(fs.readFileSync(SF,'utf8'))}catch{return{lastCheck:null,processed:[]}}};
 const save=s=>{fs.mkdirSync(SD,{recursive:true});fs.writeFileSync(SF,JSON.stringify(s,null,2))};
@@ -392,7 +393,7 @@ function runSummary(fetchOptions,extra={}){
   return{mode:fetchOptions.allHistory?'all-history':'recent',since:fetchOptions.since||'rolling-30-days',
     until:fetchOptions.until||'now',chunkDays:fetchOptions.chunkDays,maxTotalResults:fetchOptions.maxTotalResults,
     maxResults:fetchOptions.maxResults,reprocess:fetchOptions.reprocess,stateLimit:fetchOptions.stateLimit,
-    ...extra};
+    requireAccess:fetchOptions.requireAccess,...extra};
 }
 
 function writeAccessFailureReport(fetchOptions,code,message,extra={}){
@@ -426,6 +427,17 @@ function writeAccessFailureReport(fetchOptions,code,message,extra={}){
   fs.writeFileSync(HF,JSON.stringify(health,null,2));
 }
 
+function finishAccessFailure(fetchOptions,code,message,extra={}){
+  writeAccessFailureReport(fetchOptions,code,message,extra);
+  const hint='Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and, when OAuth fallback is used, GMAIL_REFRESH_TOKEN secrets.';
+  if(fetchOptions.requireAccess){
+    console.error('::error::'+message+' '+hint);
+    process.exit(1);
+  }
+  console.log('::warning::'+message+' '+hint+' Continuing because GMAIL_DIAG_REQUIRE_ACCESS is false.');
+  process.exit(0);
+}
+
 async function main(){
   const fetchOptions=parseFetchOptions(process.argv.slice(2));
   const e=process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL;
@@ -435,14 +447,12 @@ async function main(){
   if(!hasImapCredentials&&!hasOAuthCredentials){
     const msg='Gmail credentials missing. Set GMAIL_EMAIL/GMAIL_APP_PASSWORD or Gmail OAuth secrets, then rerun Gmail diagnostics.';
     console.error('Gmail credentials missing. Set IMAP credentials or GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET + GMAIL_REFRESH_TOKEN.');
-    writeAccessFailureReport(fetchOptions,'missing_gmail_credentials',msg,{mode:'imap+oauth'});
-    process.exit(1);
+    finishAccessFailure(fetchOptions,'missing_gmail_credentials',msg,{mode:'imap+oauth'});
   }
   if(hasImapCredentials&&!imap&&!hasOAuthCredentials){
     const msg='gmail-imap-reader is unavailable. Install the IMAP dependencies before rerunning Gmail diagnostics.';
     console.error('gmail-imap-reader not available. npm install imapflow');
-    writeAccessFailureReport(fetchOptions,'imap_reader_unavailable',msg);
-    process.exit(1);
+    finishAccessFailure(fetchOptions,'imap_reader_unavailable',msg);
   }
   console.log('Gmail diagnostics mode — IMAP primary, OAuth fallback:',hasOAuthCredentials?'available':'unavailable');
   if(hasImapCredentials)console.log('IMAP primary — connecting as',safeAlias('account',e));
@@ -505,8 +515,7 @@ async function main(){
       ? 'IMAP and OAuth Gmail access both failed before diagnostics could be fetched. Refresh Gmail IMAP app password and OAuth refresh token secrets, then rerun Gmail Diagnostics.'
       : 'IMAP connection failed before diagnostics could be fetched. Refresh the Gmail app credential, then rerun Gmail Diagnostics.';
     console.error('::error::Gmail diagnostics could not authenticate. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and, if using OAuth fallback, GMAIL_REFRESH_TOKEN secrets.');
-    writeAccessFailureReport(fetchOptions,code,msg,{windows:windows.length,fetched:0,mode:hasOAuthCredentials?'imap+oauth':'imap'});
-    process.exit(1);
+    finishAccessFailure(fetchOptions,code,msg,{windows:windows.length,fetched:0,mode:hasOAuthCredentials?'imap+oauth':'imap'});
   }
   if(imapConnectionFailed){
     console.log('::warning::At least one IMAP window failed, but diagnostics were fetched via',Array.from(modesUsed).join('+')||'fallback');

--- a/.github/scripts/gmail-token-keepalive.js
+++ b/.github/scripts/gmail-token-keepalive.js
@@ -1,90 +1,136 @@
 #!/usr/bin/env node
 'use strict';
-// v5.12.6: IMAP health checker — OAuth removed entirely
+// v5.13.3: Gmail auth health checker - IMAP primary with OAuth fallback.
 const fs=require('fs'),path=require('path');
 const privacy=require('./privacy-redactor');
 const SD=path.join(__dirname,'..','state');
 const HF=path.join(SD,'gmail-token-health.json');
+const ALERT=path.join(SD,'_gmail_alert.txt');
 let imap=null;try{imap=require('./gmail-imap-reader')}catch{}
+let oauth=null;try{oauth=require('./gmail-oauth-reader')}catch{}
+
+function readHealth(){
+  try{return JSON.parse(fs.readFileSync(HF,'utf8'))}catch{return{mode:'gmail',checks:[],lastOk:null,consecutiveFails:0}}
+}
+
+function hasImapCredentials(){
+  return Boolean((process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL)&&(process.env.GMAIL_APP_PASSWORD||process.env.HOMEY_PASSWORD));
+}
+
+function hasOAuthCredentials(){
+  return Boolean(oauth&&oauth.hasOAuthCredentials&&oauth.hasOAuthCredentials());
+}
+
+function safeWriteJson(file,obj){
+  const safe=privacy.redactObject(obj);
+  privacy.assertNoLeaks(safe,file);
+  fs.writeFileSync(file,JSON.stringify(safe,null,2));
+}
+
+function appendCheck(health,check){
+  health.checks=(health.checks||[]).concat(privacy.redactObject(check)).slice(-30);
+}
+
+function writeAlert(health,imapResult,oauthResult){
+  const lines=[
+    'Gmail diagnostics authentication failed '+health.consecutiveFails+' consecutive time(s).',
+    'IMAP: '+imapResult.code,
+    'OAuth: '+oauthResult.code,
+    '',
+    'Refresh GitHub Actions secrets:',
+    '1. GMAIL_EMAIL',
+    '2. GMAIL_APP_PASSWORD from https://myaccount.google.com/apppasswords',
+    '3. GMAIL_REFRESH_TOKEN if OAuth fallback is still used',
+    '',
+    'No secret values were written to this report.'
+  ];
+  const alert=privacy.redact(lines.join('\n'));
+  privacy.assertNoLeaks(alert,ALERT);
+  fs.writeFileSync(ALERT,alert);
+}
+
+async function tryImap(){
+  if(!hasImapCredentials())return{ok:false,mode:'imap',code:'missing_imap_credentials',message:'GMAIL_EMAIL/GMAIL_APP_PASSWORD not configured'};
+  if(!imap)return{ok:false,mode:'imap',code:'imap_reader_unavailable',message:'gmail-imap-reader unavailable'};
+  const email=process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL;
+  console.log('IMAP health check - connecting as',privacy.alias('account',email));
+  try{
+    const emails=await imap.readViaIMAP({maxResults:5});
+    if(Array.isArray(emails))return{ok:true,mode:'imap',count:emails.length};
+    return{ok:false,mode:'imap',code:'imap_null_response',message:'IMAP returned no response'};
+  }catch(err){
+    return{ok:false,mode:'imap',code:'imap_read_failed',message:privacy.redact(err.message)};
+  }
+}
+
+async function tryOAuth(){
+  if(!hasOAuthCredentials())return{ok:false,mode:'oauth',code:'missing_oauth_credentials',message:'Gmail OAuth secrets not configured'};
+  console.log('OAuth health check - using refresh-token fallback');
+  try{
+    const emails=await oauth.readViaOAuth({maxResults:5});
+    if(Array.isArray(emails))return{ok:true,mode:'oauth',count:emails.length};
+    return{ok:false,mode:'oauth',code:'oauth_null_response',message:'OAuth returned no response'};
+  }catch(err){
+    return{ok:false,mode:'oauth',code:'oauth_read_failed',message:privacy.redact(err.message)};
+  }
+}
 
 async function main(){
   fs.mkdirSync(SD,{recursive:true});
   const now=new Date().toISOString();
-  let health;try{health=JSON.parse(fs.readFileSync(HF,'utf8'))}catch{health={mode:'imap',checks:[],lastOk:null,consecutiveFails:0}}
+  const health=readHealth();
 
-  const e=process.env.GMAIL_EMAIL||process.env.HOMEY_EMAIL;
-  const p=process.env.GMAIL_APP_PASSWORD||process.env.HOMEY_PASSWORD;
-
-  if(!e||!p){
-    console.error('IMAP credentials missing.');
-    console.error('Setup (30 seconds):');
-    console.error('  1. https://myaccount.google.com/apppasswords');
-    console.error('  2. Generate App Password for Mail');
-    console.error('  3. gh secret set GMAIL_EMAIL');
-    console.error('  4. gh secret set GMAIL_APP_PASSWORD');
-    console.log('::error::Set GMAIL_EMAIL + GMAIL_APP_PASSWORD for email diagnostics (see SECRETS.md)');
-    health.mode='imap';health.checks=(health.checks||[]).concat({time:now,ok:false,err:'missing_creds'}).slice(-30);
-    health.consecutiveFails=(health.consecutiveFails||0)+1;health.lastFail=now;
-    health=privacy.redactObject(health);privacy.assertNoLeaks(health,HF);
-    fs.writeFileSync(HF,JSON.stringify(health,null,2));
-    process.exitCode = 1;
+  const imapResult=await tryImap();
+  if(imapResult.ok){
+    console.log('IMAP OK:',imapResult.count,'emails fetched (health check)');
+    health.mode='imap';
+    health.lastOk=now;
+    health.consecutiveFails=0;
+    health.emailsFetched=imapResult.count;
+    health.requiresSecretRefresh=false;
+    health.action='none';
+    delete health.lastFail;
+    appendCheck(health,{time:now,ok:true,mode:'imap',count:imapResult.count});
+    safeWriteJson(HF,health);
+    console.log('Health saved. Mode: imap | Consecutive fails:',health.consecutiveFails);
     return;
   }
 
-  if(!imap){
-    console.error('imapflow not installed. Run: npm install imapflow');
-    health.checks=(health.checks||[]).concat({time:now,ok:false,err:'no_imapflow'}).slice(-30);
-    health.consecutiveFails=(health.consecutiveFails||0)+1;health.lastFail=now;
-    health=privacy.redactObject(health);privacy.assertNoLeaks(health,HF);
-    fs.writeFileSync(HF,JSON.stringify(health,null,2));
-    process.exitCode = 1;
+  console.log('::warning::IMAP health failed: '+imapResult.code);
+  const oauthResult=await tryOAuth();
+  if(oauthResult.ok){
+    console.log('OAuth OK:',oauthResult.count,'emails fetched (health check)');
+    health.mode='oauth';
+    health.lastOk=now;
+    health.lastImapFail=now;
+    health.consecutiveFails=0;
+    health.emailsFetched=oauthResult.count;
+    health.requiresSecretRefresh=imapResult.code!=='missing_imap_credentials';
+    health.action=health.requiresSecretRefresh?'refresh_imap_app_password':'none';
+    appendCheck(health,{time:now,ok:true,mode:'oauth',count:oauthResult.count,imapFallbackReason:imapResult.code});
+    safeWriteJson(HF,health);
+    console.log('Health saved. Mode: oauth fallback | Consecutive fails:',health.consecutiveFails);
     return;
   }
 
-  console.log('IMAP health check — connecting as',privacy.alias('account',e));
-  try{
-    const emails=await imap.readViaIMAP({maxResults:5});
-    if(emails&&emails.length>=0){
-      console.log('IMAP OK:',emails.length,'emails fetched (health check)');
-      health.mode='imap';
-      health.lastOk=now;
-      health.consecutiveFails=0;
-      health.emailsFetched=emails.length;
-      health.checks=(health.checks||[]).concat({time:now,ok:true,mode:'imap',count:emails.length}).slice(-30);
-      // Clear any old OAuth fields
-      delete health.tokenSetDate;delete health.daysLeft;delete health.daysOld;
-      delete health.expiryEstimate;delete health.testingMode;
-      delete health.refreshTokenExpiresH;delete health.refreshTokenExpiresAt;
-      console.log('IMAP health: OK (no token expiry, permanent)');
-    } else {
-      throw new Error('IMAP returned null — connection failed');
-    }
-  }catch(err){
-    process.exitCode = 1;
-    console.error('IMAP FAILED:',privacy.redact(err.message));
-    health.checks=(health.checks||[]).concat({time:now,ok:false,err:privacy.redact(err.message)}).slice(-30);
-    health.consecutiveFails=(health.consecutiveFails||0)+1;health.lastFail=now;
-    if(health.consecutiveFails>=3){
-      console.log('::warning::IMAP has failed '+health.consecutiveFails+' times. Check GMAIL_APP_PASSWORD.');
-      const alertF=path.join(SD,'_imap_alert.txt');
-      if(!fs.existsSync(alertF)){
-        const alert='IMAP connection failed '+health.consecutiveFails+' times.\nLast error: '+privacy.redact(err.message)+'\n\nCheck:\n1. 2FA enabled on Google account\n2. App Password valid: https://myaccount.google.com/apppasswords\n3. gh secret set GMAIL_APP_PASSWORD with fresh password';
-        privacy.assertNoLeaks(alert,alertF);
-        fs.writeFileSync(alertF,alert);
-      }
-    }
-  }
-
-  health=privacy.redactObject(health);privacy.assertNoLeaks(health,HF);
-  fs.writeFileSync(HF,JSON.stringify(health,null,2));
-  console.log('Health saved. Mode: imap | Consecutive fails:',health.consecutiveFails);
+  console.error('Gmail auth health failed. IMAP:',imapResult.code,'OAuth:',oauthResult.code);
+  health.mode='imap+oauth';
+  health.lastFail=now;
+  health.consecutiveFails=(Number(health.consecutiveFails)||0)+1;
+  health.requiresSecretRefresh=true;
+  health.action='refresh_gmail_actions_secrets';
+  health.errorCode=oauthResult.code==='missing_oauth_credentials'?imapResult.code:'gmail_auth_failed';
+  appendCheck(health,{time:now,ok:false,mode:'imap+oauth',imap:imapResult.code,oauth:oauthResult.code});
+  safeWriteJson(HF,health);
+  if(health.consecutiveFails>=3)writeAlert(health,imapResult,oauthResult);
+  console.log('::error::Gmail diagnostics authentication failed. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and GMAIL_REFRESH_TOKEN secrets.');
+  process.exitCode=1;
 }
+
 main()
-  .then(() => {
-    if (process.exitCode) setImmediate(() => process.exit(process.exitCode));
-  })
-  .catch(e => {
-    console.error(e.message);
-    process.exitCode = 1;
-    setImmediate(() => process.exit(process.exitCode));
+  .then(()=>{if(process.exitCode)setImmediate(()=>process.exit(process.exitCode))})
+  .catch(e=>{
+    console.error(privacy.redact(e.message));
+    process.exitCode=1;
+    setImmediate(()=>process.exit(process.exitCode));
   });

--- a/.github/workflows/auto-publish-on-push.yml
+++ b/.github/workflows/auto-publish-on-push.yml
@@ -475,7 +475,11 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GMAIL_DIAG_AI_MAX: "0"
+          GMAIL_DIAG_REQUIRE_ACCESS: "false"
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           HOMEY_PAT_API: ${{ secrets.HOMEY_PAT_API }}
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}

--- a/.github/workflows/fetch-diags.yml
+++ b/.github/workflows/fetch-diags.yml
@@ -33,6 +33,11 @@ on:
         type: boolean
         default: false
         required: false
+      require_access:
+        description: "Fail the workflow when Gmail IMAP and OAuth diagnostics access are both unavailable"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write
@@ -75,6 +80,7 @@ jobs:
           GMAIL_DIAG_CHUNK_DAYS: ${{ github.event.inputs.chunk_days || '0' }}
           GMAIL_DIAG_STATE_LIMIT: ${{ github.event.inputs.max_total_results || '5000' }}
           GMAIL_DIAG_REPROCESS: ${{ github.event.inputs.reprocess || 'false' }}
+          GMAIL_DIAG_REQUIRE_ACCESS: ${{ github.event.inputs.require_access || 'false' }}
           GMAIL_DIAG_AI_MAX: "0"
           DRY_RUN: "true"
         run: |
@@ -108,7 +114,7 @@ jobs:
           fi
 
       - name: Assert Gmail diagnostics access
-        if: always() && steps.gmail_fetch.outputs.exit_code != '0'
+        if: always() && steps.gmail_fetch.outputs.exit_code != '0' && github.event.inputs.require_access == 'true'
         run: |
           echo "::error::Gmail diagnostics could not authenticate via IMAP or OAuth fallback. Refresh GMAIL_EMAIL/GMAIL_APP_PASSWORD and GMAIL_REFRESH_TOKEN secrets, then rerun Fetch Homey Diagnostics."
           exit 1

--- a/.github/workflows/gmail-diagnostics.yml
+++ b/.github/workflows/gmail-diagnostics.yml
@@ -42,6 +42,11 @@ on:
         type: boolean
         default: false
         required: false
+      require_access:
+        description: "Fail the workflow when Gmail IMAP and OAuth diagnostics access are both unavailable"
+        type: boolean
+        default: false
+        required: false
 
 permissions:
   contents: write
@@ -71,14 +76,17 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci --prefer-offline --no-audit || npm install
-      - name: IMAP health preflight
+      - name: Gmail auth health preflight
         continue-on-error: true
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
         run: node .github/scripts/gmail-token-keepalive.js
-      # v5.12.7: IMAP-only diagnostics with health preflight
-      - name: Fetch diagnostics via IMAP
+      # v5.13.3: IMAP diagnostics with OAuth fallback and health preflight
+      - name: Fetch diagnostics via Gmail
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
@@ -103,6 +111,7 @@ jobs:
           GMAIL_DIAG_STATE_LIMIT: ${{ github.event.inputs.max_total_results || '5000' }}
           GMAIL_DIAG_REPROCESS: ${{ github.event.inputs.reprocess || 'false' }}
           GMAIL_DIAG_AUTO_IMPLEMENT: ${{ github.event.inputs.auto_implement || 'false' }}
+          GMAIL_DIAG_REQUIRE_ACCESS: ${{ github.event.inputs.require_access || 'false' }}
           DRY_RUN: ${{ github.event.inputs.auto_implement == 'true' && 'false' || 'true' }}
         run: node .github/scripts/fetch-gmail-diagnostics.js
       - name: Privacy gate for Gmail outputs

--- a/.github/workflows/gmail-token-keepalive.yml
+++ b/.github/workflows/gmail-token-keepalive.yml
@@ -1,10 +1,10 @@
-name: Gmail IMAP Health Check
+name: Gmail Auth Health Check
 # <!-- badges:start -->
-# [![Gmail IMAP Health Check](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml/badge.svg)](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml)
+# [![Gmail Auth Health Check](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml/badge.svg)](https://github.com/dlnraja/com.tuya.zigbee/actions/workflows/gmail-token-keepalive.yml)
 # <!-- badges:end -->
 
 
-# v5.12.7: IMAP-only daily health check
+# v5.13.3: IMAP primary daily health check with OAuth fallback
 on:
   schedule:
     - cron: '0 8 * * *'  # Daily 08:00 UTC
@@ -27,7 +27,7 @@ defaults:
     shell: bash
 
 jobs:
-  imap-health:
+  gmail-auth-health:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -39,34 +39,41 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: npm
       - run: npm ci --prefer-offline --no-audit || npm install
-      - name: IMAP health check
+      - name: Gmail auth health check
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
         run: node .github/scripts/gmail-token-keepalive.js
       - name: Commit health state
         if: always()
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          node .github/scripts/privacy-redactor.js .github/state/gmail-token-health.json .github/state/_imap_alert.txt
+          node .github/scripts/privacy-redactor.js .github/state/gmail-token-health.json .github/state/_gmail_alert.txt .github/state/_imap_alert.txt
           git add .github/state/gmail-token-health.json 2>/dev/null || true
           if ! git diff --staged --quiet; then
-            git commit -m "IMAP health $(date -u +%Y-%m-%d) [skip ci]"
+            git commit -m "Gmail auth health $(date -u +%Y-%m-%d) [skip ci]"
             bash scripts/ci/verified-git-push.sh master
           else
-            echo "No IMAP health changes to push"
+            echo "No Gmail auth health changes to push"
           fi
-      - name: Alert if IMAP failing
+      - name: Alert if Gmail auth failing
         continue-on-error: true
         if: always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ -f ".github/state/_imap_alert.txt" ]; then
-            node .github/scripts/privacy-redactor.js .github/state/_imap_alert.txt
-            gh issue create -R dlnraja/com.tuya.zigbee --title "[Alert] IMAP connection failing" \
-              --body "$(cat .github/state/_imap_alert.txt)" \
+          ALERT=".github/state/_gmail_alert.txt"
+          if [ ! -f "$ALERT" ] && [ -f ".github/state/_imap_alert.txt" ]; then
+            ALERT=".github/state/_imap_alert.txt"
+          fi
+          if [ -f "$ALERT" ]; then
+            node .github/scripts/privacy-redactor.js "$ALERT"
+            gh issue create -R dlnraja/com.tuya.zigbee --title "[Alert] Gmail diagnostics authentication failing" \
+              --body "$(cat "$ALERT")" \
               --label "automation" 2>/dev/null || true
-            rm -f .github/state/_imap_alert.txt
+            rm -f .github/state/_gmail_alert.txt .github/state/_imap_alert.txt
           fi

--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -186,7 +186,11 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GMAIL_DIAG_AI_MAX: "0"
+          GMAIL_DIAG_REQUIRE_ACCESS: "false"
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           HOMEY_PAT_API: ${{ secrets.HOMEY_PAT_API }}
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -303,7 +303,11 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GMAIL_DIAG_AI_MAX: "0"
+          GMAIL_DIAG_REQUIRE_ACCESS: "false"
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           HOMEY_PAT_API: ${{ secrets.HOMEY_PAT_API }}
           HOMEY_PAT: ${{ secrets.HOMEY_PAT }}

--- a/.github/workflows/sunday-master.yml
+++ b/.github/workflows/sunday-master.yml
@@ -246,11 +246,15 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           HOMEY_EMAIL: ${{ secrets.HOMEY_EMAIL }}
           HOMEY_PASSWORD: ${{ secrets.HOMEY_PASSWORD }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GMAIL_DIAG_AI_MAX: "0"
+          GMAIL_DIAG_REQUIRE_ACCESS: "false"
           DRY_RUN: "true"
         run: node .github/scripts/fetch-gmail-diagnostics.js
       - name: Privacy gate for Gmail diagnostics

--- a/.github/workflows/tuya-deep-diag.yml
+++ b/.github/workflows/tuya-deep-diag.yml
@@ -40,6 +40,11 @@ on:
         type: boolean
         default: false
         required: false
+      require_access:
+        description: "Fail the workflow when Gmail IMAP and OAuth diagnostics access are both unavailable"
+        type: boolean
+        default: false
+        required: false
       download_archives:
         description: "Download build archives during dashboard comparison"
         type: boolean
@@ -85,6 +90,9 @@ jobs:
         env:
           GMAIL_EMAIL: ${{ secrets.GMAIL_EMAIL }}
           GMAIL_APP_PASSWORD: ${{ secrets.GMAIL_APP_PASSWORD }}
+          GMAIL_CLIENT_ID: ${{ secrets.GMAIL_CLIENT_ID }}
+          GMAIL_CLIENT_SECRET: ${{ secrets.GMAIL_CLIENT_SECRET }}
+          GMAIL_REFRESH_TOKEN: ${{ secrets.GMAIL_REFRESH_TOKEN }}
           GMAIL_DIAG_AI_MAX: "0"
           GMAIL_DIAG_ALL_HISTORY: ${{ github.event.inputs.all_history || 'false' }}
           GMAIL_DIAG_SINCE: ${{ github.event.inputs.since || '' }}
@@ -94,6 +102,7 @@ jobs:
           GMAIL_DIAG_CHUNK_DAYS: ${{ github.event.inputs.chunk_days || '0' }}
           GMAIL_DIAG_STATE_LIMIT: ${{ github.event.inputs.max_total_results || '5000' }}
           GMAIL_DIAG_REPROCESS: ${{ github.event.inputs.reprocess || 'false' }}
+          GMAIL_DIAG_REQUIRE_ACCESS: ${{ github.event.inputs.require_access || 'false' }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GH_PAT: ${{ secrets.GH_PAT }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- make Gmail diagnostics fetch support a strict mode while soft-failing scheduled/publish jobs with sanitized state
- replace IMAP-only health check with IMAP primary + OAuth fallback
- pass OAuth secrets through Gmail-related workflows and keep privacy gates active

## Verification
- node --check Gmail diagnostics scripts
- npm run check:yaml --if-present
- npm run check:diag-history --if-present
- npm run security:diagnostics --if-present
- npm run precommit --if-present
- temp smoke test: non-strict fetch exits 0, strict fetch exits 1, auth health exits 1 without secrets