### PR TITLE
fix(store): refresh Homey guideline compliance

### DIFF
--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -12,10 +12,10 @@
     "fr": "Unified Smart Home Engine"
   },
   "description": {
-    "en": "Unified Smart Home Engine: High-performance local-first control for Tuya, eWeLink, SmartThings & more",
-    "nl": "Unified Smart Home Engine: Hoogwaardige lokale bediening voor Tuya, eWeLink, SmartThings & meer",
-    "de": "Unified Smart Home Engine: Leistungsstarke lokale Steuerung für Tuya, eWeLink, SmartThings & mehr",
-    "fr": "Unified Smart Home Engine : Contrôle local multi-protocoles pour Tuya, eWeLink, SmartThings & plus"
+    "en": "High-performance local-first control for Tuya, eWeLink, SmartThings and compatible devices",
+    "nl": "Hoogwaardige lokale bediening voor Tuya, eWeLink, SmartThings en compatibele apparaten",
+    "de": "Leistungsstarke lokale Steuerung fuer Tuya, eWeLink, SmartThings und kompatible Geraete",
+    "fr": "Controle local haute performance pour Tuya, eWeLink, SmartThings et appareils compatibles"
   },
   "tags": {
     "en": [
@@ -87,7 +87,7 @@
   "bugs": {
     "url": "https://github.com/dlnraja/com.tuya.zigbee/issues"
   },
-  "brandColor": "#00E6A0",
+  "brandColor": "#008C73",
   "homeyCommunityTopicId": 140352,
   "source": "https://github.com/dlnraja/com.tuya.zigbee",
   "sdk": 3,

--- a/.homeycompose/flow/actions/presence_force_in_zone.json
+++ b/.homeycompose/flow/actions/presence_force_in_zone.json
@@ -10,7 +10,7 @@
     {
       "name": "device",
       "type": "device",
-      "filter": "driverId=presence_detector"
+      "filter": "driver_id=presence_detector"
     },
     {
       "name": "force_state",

--- a/README.de.txt
+++ b/README.de.txt
@@ -1,36 +1,3 @@
-Unified Smart Home Engine fuer Homey — Lokale Tuya Zigbee-Steuerung
+Unified Smart Home Engine ermoeglicht lokale Steuerung fuer viele Tuya Zigbee-, eWeLink-, SmartThings- und kompatible Smart-Home-Geraete auf Homey Pro. Schalter, Sensoren, Steckdosen, Thermostate, Lampen, Abdeckungen, Schlösser und Energiegeraete werden lokal verarbeitet, wenn die jeweilige Hardware dies unterstuetzt.
 
-Diese App bietet einheitliche, lokale Unterstuetzung fuer eine breite Palette von Tuya Zigbee, eWeLink und kompatiblen Smart-Home-Geraeten — ohne Cloud, ohne Internetabhaengigkeit.
-
-Mit ueber 412 Treibern und 33.235+ Geraete-Fingerabdruecken unterstuetzt sie:
-- Intelligente Steckdosen, Steckdosenleisten und Energiemonitore
-- Wandschalter (1- bis 6-fach) und Dimmer
-- Anwesenheits-, Bewegungs-, Kontakt- und Rauchmelder
-- Thermostate, Heizkoerperventile und Klimaregelung
-- Smarte Lampen, LED-Streifen und Lichtcontroller
-- Rolllaeden, Jalousien, Vorhaenge und Garagentore
-- Tuerenschloesser und Sicherheitspanels
-- Luftqualitaetsmonitore (CO2, VOC, PM2.5)
-- Wasserleck-, Regen- und Bodenfeuchtesensoren
-
-FUNKTIONEN:
-- Lokale Steuerung: Alles laeuft auf Ihrem Homey Pro, nichts in der Cloud
-- Hybridmodus: Automatische Erkennung von Tuya DP oder Standard ZCL
-- Intelligente Batterie: Spannungs-zu-Prozent-Konvertierung fuer Geraete ohne native Berichterstattung
-- Flow-Karten: 4.073+ Ausloeseer, Bedingungen und Aktionen in EN, FR, NL, DE
-- Selbstreparatur: Eingebaute Selbstheilung fuer Geraetekonfigurationen
-- Doppelte Fingerabdruckebene: Statische und dynamische Zuordnung fuer maximale Kompatibilitaet
-
-UNTERSTUETZTE PROTOKOLLE:
-- Zigbee (SDK3, Homey Pro 2023+)
-- Lokales LAN/WLAN (eWeLink, Tuya Local)
-
-ERSTE SCHRITTE:
-1. Installieren Sie diese App aus dem Homey App Store
-2. Gehen Sie zu Geraete > Geraet hinzufuegen > Unified Smart Home Engine
-3. Koppeln Sie Ihr Geraet - es wird automatisch erkannt
-
-GEMEINSCHAFT UND SUPPORT:
-- Forum: https://community.homey.app/t/140352
-- Probleme: https://github.com/dlnraja/com.tuya.zigbee/issues
-- Quellcode: https://github.com/dlnraja/com.tuya.zigbee
+Die App kombiniert einen grossen Treiberkatalog mit adaptiver Fingerabdruckerkennung, Tuya-DP- und ZCL-Auswertung, Flow-Ausloesern fuer Tasten und Fernbedienungen, Batterieschaetzungen und selbstheilenden Geraetekarten. Dadurch bleiben viele generische oder umbenannte Geraete ohne Cloudkonto fuer unterstuetzte lokale Geraete nutzbar.

--- a/README.fr.txt
+++ b/README.fr.txt
@@ -1,36 +1,3 @@
-Unified Smart Home Engine pour Homey — Controle local Tuya Zigbee
+Unified Smart Home Engine apporte un controle local a de nombreux appareils Tuya Zigbee, eWeLink, SmartThings et compatibles sur Homey Pro. Associez interrupteurs, capteurs, prises, thermostats, lampes, volets, serrures et appareils de mesure d'energie tout en gardant le traitement sur Homey lorsque le materiel le permet.
 
-Cette application offre un support unifie et local pour une large gamme d'appareils Tuya Zigbee, eWeLink et compatibles — sans cloud, sans dependance internet.
-
-Avec plus de 412 pilotes et 33 235+ empreintes d'appareils, elle couvre :
-- Prises intelligentes, multiprises et moniteurs d'energie
-- Interrupteurs muraux (1 a 6 boutons) et variateurs
-- Detecteurs de presence, mouvement, contact et fumee
-- Thermostats, vannes de radiateur et regulation climatique
-- Ampoules intelligentes, rubans LED et controleurs d'eclairage
-- Volets, stores, rideaux et ouvre-portes de garage
-- Serrures connectees et panneaux de securite
-- Moniteurs qualite de l'air (CO2, COV, PM2.5)
-- Detecteurs de fuite d'eau, pluie et humidite du sol
-
-FONCTIONNALITES :
-- Controle local : tout le traitement sur votre Homey Pro, rien dans le cloud
-- Mode hybride : detection automatique du protocole Tuya DP ou ZCL standard
-- Batterie intelligente : conversion tension/pourcentage pour appareils sans rapport natif
-- Cartes de flux : 4 073+ declencheurs, conditions et actions en EN, FR, NL, DE
-- Auto-reparation : guerison automatique des cartes de configuration
-- Double couche d'empreintes : correspondance statique et dynamique pour compatibilite maximale
-
-PROTOCOLES SUPPORTES :
-- Zigbee (SDK3, Homey Pro 2023+)
-- LAN local/WiFi (eWeLink, Tuya Local)
-
-DEMARRAGE :
-1. Installez cette application depuis le Homey App Store
-2. Allez dans Appareils > Ajouter un appareil > Unified Smart Home Engine
-3. Couplez votre appareil - il sera detecte automatiquement
-
-COMMUNAUTE ET SUPPORT :
-- Forum : https://community.homey.app/t/140352
-- Problemes : https://github.com/dlnraja/com.tuya.zigbee/issues
-- Code source : https://github.com/dlnraja/com.tuya.zigbee
+L'application combine un vaste catalogue de pilotes avec une reconnaissance adaptative des empreintes, l'interpretation Tuya DP et ZCL, des declencheurs Flow pour boutons et telecommandes, des estimations de batterie et des cartes d'appareils auto-reparatrices. Elle vise une compatibilite pratique avec de nombreux appareils generiques ou reetiquetes sans compte cloud pour les appareils locaux pris en charge.

--- a/README.nl.txt
+++ b/README.nl.txt
@@ -1,36 +1,3 @@
-Unified Smart Home Engine voor Homey — Lokale Tuya Zigbee-besturing
+Unified Smart Home Engine biedt lokale bediening voor veel Tuya Zigbee-, eWeLink-, SmartThings- en compatibele smart home-apparaten op Homey Pro. Koppel schakelaars, sensoren, stekkers, thermostaten, lampen, raambekleding, sloten en energiemeters terwijl de afhandeling lokaal op Homey blijft wanneer de hardware dat ondersteunt.
 
-Deze app biedt gecombineerde, lokaal-eerste ondersteuning voor een breed scala aan Tuya Zigbee, eWeLink en compatibele smart home-apparaten — geen cloud vereist, geen internetafhankelijkheid.
-
-Met meer dan 412 stuurprogramma's en 33.235+ vingerafdrukken ondersteunt het een uitgebreide reeks apparaten:
-- Slimme stekkers, stekkerdozen en energiemonitoren
-- Wandschakelaars (1 tot 6 gang) en dimmers
-- Aanwezigheids-, bewegings-, contact- en rookmelders
-- Thermostaten, radiatorkranen en klimaatregelaars
-- Slimme lampen, LED-strips en lichtcontrollers
-- Screens, jaloezieën, gordijnen en garagedeuropeners
-- Deursloten en beveiligingspanelen
-- Luchtkwaliteitsmonitoren (CO2, VOC, PM2.5)
-- Waterlek-, regen- en bodemvochtmelders
-
-KENMERKEN:
-- Lokale bediening: alles verwerkt op uw Homey Pro, niets in de cloud
-- Hybride modus: automatische detectie van Tuya DP of standaard ZCL-protocol
-- Slimme batterij: spanning-naar-percentage conversie voor apparaten zonder native rapportage
-- Flow-kaarten: 4.073+ triggers, voorwaarden en acties in EN, FR, NL, DE
-- Zelfreparatie: ingebouwde herstelcapaciteit voor apparaatconfiguraties
-- Dubbele vingerafdruklaag: statische en dynamische koppeling voor maximale compatibiliteit
-
-ONDERSTEUNDE PROTOCOLLEN:
-- Zigbee (SDK3, Homey Pro 2023+)
-- Lokaal LAN/WiFi (eWeLink, Tuya Local)
-
-AAN DE SLAG:
-1. Installeer deze app vanuit de Homey App Store
-2. Ga naar Apparaten > Apparaat toevoegen > Unified Smart Home Engine
-3. Koppel uw apparaat - het wordt automatisch herkend
-
-GEMEENSCHAP EN ONDERSTEUNING:
-- Forum: https://community.homey.app/t/140352
-- Problemen: https://github.com/dlnraja/com.tuya.zigbee/issues
-- Broncode: https://github.com/dlnraja/com.tuya.zigbee
+De app combineert een brede drivercatalogus met adaptieve vingerafdrukherkenning, Tuya DP- en ZCL-interpretatie, Flow-triggers voor knoppen en afstandsbedieningen, batterijschattingen en zelfherstellende apparaatkaarten. Zo blijven ook veel generieke of opnieuw gelabelde apparaten praktisch bruikbaar zonder cloudaccount voor ondersteunde lokale apparaten.

--- a/README.txt
+++ b/README.txt
@@ -1,36 +1,3 @@
-Unified Smart Home Engine for Homey — Local-First Tuya Zigbee Control
+Unified Smart Home Engine brings local-first control to a broad range of Tuya Zigbee, eWeLink, SmartThings and compatible smart home devices on Homey Pro. Pair switches, sensors, plugs, thermostats, lights, covers, locks and energy devices while keeping device handling on your local Homey whenever the hardware allows it.
 
-This app provides unified, local-first support for a wide variety of Tuya Zigbee, eWeLink, and compatible smart home devices — no cloud required, no internet dependency.
-
-With over 412 drivers and 33,235+ device fingerprints, it covers an extensive range of devices including:
-- Smart plugs, power strips and energy monitors
-- Wall switches (1-gang to 6-gang) and dimmers
-- Presence, motion, contact and smoke sensors
-- Thermostats, radiator valves and climate control
-- Smart bulbs, LED strips and light controllers
-- Covers, blinds, curtains and garage door openers
-- Door locks and security panels
-- Air quality monitors (CO2, VOC, PM2.5)
-- Water leak, rain and soil sensors
-
-KEY FEATURES:
-- Local-only control: all processing happens on your Homey Pro, nothing in the cloud
-- Hybrid mode: auto-detects Tuya DP or standard ZCL protocol per device
-- Smart battery: voltage-to-percentage conversion for devices without native reporting
-- Flow cards: 4,073+ triggers, conditions and actions in EN, FR, NL, DE
-- Auto-repair: built-in self-healing for device configuration maps
-- Dual-layer fingerprinting: static + dynamic matching for maximum device compatibility
-
-SUPPORTED PROTOCOLS:
-- Zigbee (SDK3, Homey Pro 2023+)
-- Local LAN/WiFi (eWeLink, Tuya Local)
-
-GETTING STARTED:
-1. Install this app from the Homey App Store
-2. Go to Devices > Add Device > Unified Smart Home Engine
-3. Pair your device - it will be auto-detected
-
-COMMUNITY AND SUPPORT:
-- Forum: https://community.homey.app/t/140352
-- Issues: https://github.com/dlnraja/com.tuya.zigbee/issues
-- Source: https://github.com/dlnraja/com.tuya.zigbee
+The app combines a large driver catalog with adaptive fingerprint matching, Tuya DP and ZCL interpretation, button and remote Flow triggers, battery estimation fallbacks and self-healing device maps. It is built for practical compatibility with many rebranded or generic devices without requiring a cloud account for supported local devices.

--- a/docs/reports/HOMEY_ONLINE_GUIDELINES_REFERENCE_2026-07-04.md
+++ b/docs/reports/HOMEY_ONLINE_GUIDELINES_REFERENCE_2026-07-04.md
@@ -1,0 +1,43 @@
+# Homey Online Guidelines Reference
+
+Generated: 2026-07-04T09:45:08.035Z
+
+## Official Docs Checked
+
+- Homey App Store Guidelines: https://apps.developer.homey.app/app-store/guidelines (official docs observed 2026-07-04; page refreshed recently (~3 weeks))
+- Homey App Manifest: https://apps.developer.homey.app/the-basics/app/manifest (official docs observed 2026-07-04; page refreshed recently (~1 month))
+- Homey App Permissions: https://apps.developer.homey.app/the-basics/app/permissions (official docs observed 2026-07-04; page refreshed recently (~5 months))
+- Homey Publishing: https://apps.developer.homey.app/app-store/publishing (official docs observed 2026-07-04; validate at publish level before submission)
+- Homey Capabilities: https://apps.developer.homey.app/the-basics/devices/capabilities (official docs observed 2026-07-04; page refreshed recently (~3 months))
+- Homey Flow: https://apps.developer.homey.app/the-basics/flow (official docs observed 2026-07-04; page refreshed recently (~5 months))
+- Homey Zigbee: https://apps.developer.homey.app/wireless/zigbee (official docs observed 2026-07-04; page refreshed recently (~2 months))
+- Homey Compose: https://apps.developer.homey.app/advanced/homey-compose (official docs observed 2026-07-04; app.json is generated from compose files)
+- Node.js 22 Upgrade Guide: https://apps.developer.homey.app/upgrade-guides/node-22 (official docs observed 2026-07-04; Node 22 remains the CI runtime target)
+
+## Open Source Homey Sample
+
+- runely/calendar-homey (2026-06-20): Node 22 engine, Flow-heavy manifest
+- martijnpoppen/com.athom.flowchecker (2026-06-15): Node 22 engine, Flow validation focus
+- runely/jslogic-homey (2026-06-14): Node 22 engine, advanced Flow actions
+- basmilius/homey-flowbits (2026-06-21): Recent Flow-oriented Homey app
+- emilohman/homey-plejd (2026-05-08): Device integration app, recent maintenance
+
+## Audit Summary
+
+- Drivers checked: 430
+- Flow cards checked: 4868
+- Errors: 0
+- Warnings: 0
+
+## Rule Counts
+
+No issues found.
+
+## Error Sample
+
+No errors found.
+
+## Warning Sample
+
+No warnings found.
+

--- a/drivers/presence_detector/driver.flow.compose.json
+++ b/drivers/presence_detector/driver.flow.compose.json
@@ -9,6 +9,12 @@
         "fr": "Présence détectée dans la pièce",
         "de": "Anwesenheit im Raum erkannt"
       },
+      "titleFormatted": {
+        "en": "Presence detected in room",
+        "nl": "Aanwezigheid gedetecteerd in kamer",
+        "fr": "Présence détectée dans la pièce",
+        "de": "Anwesenheit im Raum erkannt"
+      },
       "hint": {
         "en": "Triggers when the virtual presence detector determines the room is occupied",
         "nl": "Triggert wanneer de virtuele aanwezigheidsdetector bepaalt dat de kamer bezet is",
@@ -39,17 +45,17 @@
           "example": "2026-06-15T14:30:00.000Z"
         }
       ],
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     },
     {
       "id": "virtual_presence_cleared",
       "title": {
+        "en": "Presence cleared in room",
+        "nl": "Aanwezigheid opgeheven in kamer",
+        "fr": "Présence terminée dans la pièce",
+        "de": "Anwesenheit im Raum beendet"
+      },
+      "titleFormatted": {
         "en": "Presence cleared in room",
         "nl": "Aanwezigheid opgeheven in kamer",
         "fr": "Présence terminée dans la pièce",
@@ -85,17 +91,17 @@
           "example": "2026-06-15T15:15:00.000Z"
         }
       ],
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     },
     {
       "id": "virtual_presence_confidence_changed",
       "title": {
+        "en": "Confidence changed",
+        "nl": "Vertrouwen gewijzigd",
+        "fr": "Confiance changée",
+        "de": "Vertrauen geändert"
+      },
+      "titleFormatted": {
         "en": "Confidence changed",
         "nl": "Vertrouwen gewijzigd",
         "fr": "Confiance changée",
@@ -120,13 +126,7 @@
           "example": 55
         }
       ],
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     }
   ],
   "conditions": [
@@ -138,19 +138,19 @@
         "fr": "La pièce !{{est|n'est pas}} occupée",
         "de": "Raum !{{ist|ist nicht}} besetzt"
       },
+      "titleFormatted": {
+        "en": "Room !{{is|is not}} occupied",
+        "nl": "Kamer !{{is|is niet}} bezet",
+        "fr": "La pièce !{{est|n'est pas}} occupée",
+        "de": "Raum !{{ist|ist nicht}} besetzt"
+      },
       "hint": {
         "en": "Check if the virtual presence detector considers the room occupied",
         "nl": "Controleer of de virtuele aanwezigheidsdetector de kamer als bezet beschouwt",
         "fr": "Vérifier si le détecteur de présence virtuel considère la pièce comme occupée",
         "de": "Prüfen, ob der virtuelle Anwesenheitssensor den Raum als besetzt betrachtet"
       },
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     },
     {
       "id": "virtual_presence_confidence_above",
@@ -160,6 +160,12 @@
         "fr": "Confiance !{{est au-dessus|n'est pas au-dessus}}",
         "de": "Vertrauen !{{ist über|ist nicht über}}"
       },
+      "titleFormatted": {
+        "en": "Confidence !{{is above|is not above}} [[threshold]]",
+        "nl": "Vertrouwen !{{is boven|is niet boven}} [[threshold]]",
+        "fr": "Confiance !{{est au-dessus|n'est pas au-dessus}} [[threshold]]",
+        "de": "Vertrauen !{{ist über|ist nicht über}} [[threshold]]"
+      },
       "hint": {
         "en": "Check if the confidence score exceeds a threshold",
         "nl": "Controleer of de vertrouwensscore een drempel overschrijdt",
@@ -167,11 +173,6 @@
         "de": "Prüfen, ob der Vertrauenswert einen Schwellenwert überschreitet"
       },
       "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        },
         {
           "name": "threshold",
           "type": "number",
@@ -194,23 +195,29 @@
         "fr": "Forcer la présence dans la pièce",
         "de": "Anwesenheit im Raum erzwingen"
       },
+      "titleFormatted": {
+        "en": "Force presence in room",
+        "nl": "Aanwezigheid forceren in kamer",
+        "fr": "Forcer la présence dans la pièce",
+        "de": "Anwesenheit im Raum erzwingen"
+      },
       "hint": {
         "en": "Manually trigger presence detection for the room",
         "nl": "Handmatig aanwezigheidsdetectie activeren voor de kamer",
         "fr": "Déclencher manuellement la détection de présence pour la pièce",
         "de": "Die Anwesenheitserkennung für den Raum manuell auslösen"
       },
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     },
     {
       "id": "virtual_presence_force_clear",
       "title": {
+        "en": "Clear presence in room",
+        "nl": "Aanwezigheid wissen in kamer",
+        "fr": "Effacer la présence dans la pièce",
+        "de": "Anwesenheit im Raum löschen"
+      },
+      "titleFormatted": {
         "en": "Clear presence in room",
         "nl": "Aanwezigheid wissen in kamer",
         "fr": "Effacer la présence dans la pièce",
@@ -222,13 +229,7 @@
         "fr": "Effacer manuellement l'état de présence de la pièce",
         "de": "Den Anwesenheitsstatus des Raums manuell löschen"
       },
-      "args": [
-        {
-          "type": "device",
-          "name": "device",
-          "filter": "driverId=presence_detector"
-        }
-      ]
+      "args": []
     }
   ]
 }

--- a/scripts/ci/homey-online-guidelines-audit.js
+++ b/scripts/ci/homey-online-guidelines-audit.js
@@ -11,15 +11,18 @@ const DRIVERS_DIR = path.join(ROOT, 'drivers');
 const APP_JS = path.join(ROOT, 'app.js');
 const API_JS = path.join(ROOT, 'api.js');
 const FLOW_CARD_PATCH = 'lib/drivers/ZigBeeDriverFlowCardPatch';
+const README_FILES = ['README.txt', 'README.nl.txt', 'README.de.txt', 'README.fr.txt'];
 
 const DOC_SOURCES = [
-  { name: 'Homey App Store Guidelines', url: 'https://apps.developer.homey.app/app-store/guidelines', freshness: 'last updated 21 days ago on 2026-07-01' },
-  { name: 'Homey Capabilities', url: 'https://apps.developer.homey.app/the-basics/devices/capabilities', freshness: 'last updated 3 months ago on 2026-07-01' },
-  { name: 'Homey Flow', url: 'https://apps.developer.homey.app/the-basics/flow', freshness: 'last updated 5 months ago on 2026-07-01' },
-  { name: 'Homey Flow Tokens', url: 'https://apps.developer.homey.app/the-basics/flow/tokens', freshness: 'last updated 3 months ago on 2026-07-01' },
-  { name: 'Homey Zigbee', url: 'https://apps.developer.homey.app/wireless/zigbee', freshness: 'last updated 2 months ago on 2026-07-01' },
-  { name: 'Homey Compose', url: 'https://apps.developer.homey.app/advanced/homey-compose', freshness: 'last updated 4 months ago on 2026-07-01' },
-  { name: 'Node.js 22 Upgrade Guide', url: 'https://apps.developer.homey.app/upgrade-guides/node-22', freshness: 'last updated 7 months ago on 2026-07-01' },
+  { name: 'Homey App Store Guidelines', url: 'https://apps.developer.homey.app/app-store/guidelines', freshness: 'official docs observed 2026-07-04; page refreshed recently (~3 weeks)' },
+  { name: 'Homey App Manifest', url: 'https://apps.developer.homey.app/the-basics/app/manifest', freshness: 'official docs observed 2026-07-04; page refreshed recently (~1 month)' },
+  { name: 'Homey App Permissions', url: 'https://apps.developer.homey.app/the-basics/app/permissions', freshness: 'official docs observed 2026-07-04; page refreshed recently (~5 months)' },
+  { name: 'Homey Publishing', url: 'https://apps.developer.homey.app/app-store/publishing', freshness: 'official docs observed 2026-07-04; validate at publish level before submission' },
+  { name: 'Homey Capabilities', url: 'https://apps.developer.homey.app/the-basics/devices/capabilities', freshness: 'official docs observed 2026-07-04; page refreshed recently (~3 months)' },
+  { name: 'Homey Flow', url: 'https://apps.developer.homey.app/the-basics/flow', freshness: 'official docs observed 2026-07-04; page refreshed recently (~5 months)' },
+  { name: 'Homey Zigbee', url: 'https://apps.developer.homey.app/wireless/zigbee', freshness: 'official docs observed 2026-07-04; page refreshed recently (~2 months)' },
+  { name: 'Homey Compose', url: 'https://apps.developer.homey.app/advanced/homey-compose', freshness: 'official docs observed 2026-07-04; app.json is generated from compose files' },
+  { name: 'Node.js 22 Upgrade Guide', url: 'https://apps.developer.homey.app/upgrade-guides/node-22', freshness: 'official docs observed 2026-07-04; Node 22 remains the CI runtime target' },
 ];
 
 const OPEN_SOURCE_SAMPLES = [
@@ -31,6 +34,12 @@ const OPEN_SOURCE_SAMPLES = [
 ];
 
 const TOKEN_TYPES = new Set(['boolean', 'image', 'number', 'string', 'uri']);
+const ALLOWED_APP_CATEGORIES = new Set(['lights', 'video', 'music', 'appliances', 'security', 'climate', 'tools', 'internet', 'localization', 'energy']);
+const APP_IMAGE_SIZES = {
+  small: [250, 175],
+  large: [500, 350],
+  xlarge: [1000, 700],
+};
 const ARG_TYPES = new Set([
   'autocomplete',
   'checkbox',
@@ -115,6 +124,31 @@ function titleText(title) {
   return '';
 }
 
+function localizedEntries(value) {
+  if (typeof value === 'string') return [['en', value]];
+  if (value && typeof value === 'object') return Object.entries(value).filter(([, text]) => typeof text === 'string');
+  return [];
+}
+
+function wordCount(text) {
+  return String(text || '').trim().split(/\s+/).filter(Boolean).length;
+}
+
+function readPngSize(file) {
+  if (!fs.existsSync(file)) return null;
+  const data = fs.readFileSync(file);
+  if (data.length < 24 || data.toString('ascii', 1, 4) !== 'PNG') return null;
+  return { width: data.readUInt32BE(16), height: data.readUInt32BE(20) };
+}
+
+function hexLuminance(hex) {
+  const match = String(hex || '').trim().match(/^#?([0-9a-f]{6})$/i);
+  if (!match) return null;
+  const parts = match[1].match(/.{2}/g).map(value => Number.parseInt(value, 16) / 255);
+  const linear = parts.map(value => (value <= 0.03928 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * linear[0] + 0.7152 * linear[1] + 0.0722 * linear[2];
+}
+
 function addIssue(report, type, code, scope, message, details) {
   report[type].push({ code, scope, message, details });
   report.summaryByCode[code] = (report.summaryByCode[code] || 0) + 1;
@@ -183,9 +217,79 @@ function auditManifest(app, pkg, report) {
       pushError(report, 'APP_REQUIRED_FIELD', 'app.json', `Missing required app manifest field: ${field}`);
     }
   }
+  if (!ALLOWED_APP_CATEGORIES.has(app.category)) {
+    pushError(report, 'APP_CATEGORY_INVALID', 'app.json', 'App category must be one of the current Homey App Store categories', { category: app.category });
+  }
+  if (!Array.isArray(app.platforms) || app.platforms.length === 0) {
+    pushError(report, 'APP_PLATFORMS_REQUIRED', 'app.json', 'App manifest must declare supported Homey platforms');
+  }
+  if (app.platforms && app.platforms.includes('cloud') && (!app.support || !String(app.support).startsWith('https://'))) {
+    pushWarning(report, 'CLOUD_SUPPORT_URL_RECOMMENDED', 'app.json', 'Verified/cloud apps need a support URL; keep local-only apps on platforms: ["local"] unless cloud is intentionally supported');
+  }
+  if (!Array.isArray(app.permissions)) {
+    pushError(report, 'APP_PERMISSIONS_ARRAY_REQUIRED', 'app.json', 'permissions must be an array; leave it empty when the app needs no privileged Homey APIs');
+  } else if (app.permissions.length > 0) {
+    pushWarning(report, 'APP_PERMISSIONS_MINIMIZE', 'app.json', 'Homey docs recommend requesting only permissions the app actually needs; new permissions also affect automatic updates', { permissions: app.permissions });
+  }
+  if (app.brandColor !== undefined) {
+    const luminance = hexLuminance(app.brandColor);
+    if (luminance === null) pushError(report, 'APP_BRAND_COLOR_INVALID', 'app.json', 'brandColor must be a HEX color string');
+    else if (luminance > 0.55) pushWarning(report, 'APP_BRAND_COLOR_TOO_BRIGHT', 'app.json', 'Homey Manifest docs say brandColor must not be very bright', { brandColor: app.brandColor, luminance: Number(luminance.toFixed(3)) });
+  }
+  const names = localizedEntries(app.name);
+  for (const [lang, name] of names) {
+    if (wordCount(name) > 4) pushWarning(report, 'APP_NAME_TOO_LONG', `app.json:name.${lang}`, 'Homey App Store guidelines recommend a short name of 4 words or less', { name });
+    if (/\b(homey|athom)\b/i.test(name)) pushError(report, 'APP_NAME_RESERVED_WORD', `app.json:name.${lang}`, 'App names may not use Homey or Athom trademarks', { name });
+    if (/\b(zigbee|z-wave|infrared|433\s*mhz|868\s*mhz)\b/i.test(name)) pushWarning(report, 'APP_NAME_PROTOCOL_WORD', `app.json:name.${lang}`, 'App Store guidelines discourage protocol names in app names', { name });
+  }
+  const englishName = titleText(app.name).toLowerCase();
+  for (const [lang, description] of localizedEntries(app.description)) {
+    const trimmed = description.trim();
+    if (trimmed.length > 150) pushWarning(report, 'APP_DESCRIPTION_TOO_LONG', `app.json:description.${lang}`, 'Description should be a concise App Store one-liner', { length: trimmed.length });
+    if (/https?:\/\//i.test(trimmed)) pushError(report, 'APP_DESCRIPTION_URL', `app.json:description.${lang}`, 'Description must not contain URLs');
+    if (englishName && trimmed.toLowerCase().includes(englishName)) pushWarning(report, 'APP_DESCRIPTION_REPEATS_NAME', `app.json:description.${lang}`, 'Description should not repeat the app name; use a short value proposition instead', { description: trimmed });
+    if (/^(adds support|integrates|control .+ with\b)/i.test(trimmed)) pushWarning(report, 'APP_DESCRIPTION_GENERIC_SUPPORT', `app.json:description.${lang}`, 'Avoid generic "adds support" or "integrates" phrasing in the App Store description', { description: trimmed });
+  }
+  for (const [key, expected] of Object.entries(APP_IMAGE_SIZES)) {
+    const rel = app.images && app.images[key];
+    if (!rel) {
+      if (key !== 'xlarge') pushError(report, 'APP_IMAGE_REQUIRED', `app.json:images.${key}`, 'App Store requires small and large app images');
+      continue;
+    }
+    const size = readPngSize(path.join(ROOT, String(rel).replace(/^\//, '')));
+    if (!size) {
+      pushError(report, 'APP_IMAGE_UNREADABLE', `app.json:images.${key}`, 'App image must be a readable PNG file', { image: rel });
+      continue;
+    }
+    if (size.width !== expected[0] || size.height !== expected[1]) {
+      pushError(report, 'APP_IMAGE_SIZE_INVALID', `app.json:images.${key}`, 'App Store app image has the wrong resolution', { image: rel, actual: `${size.width}x${size.height}`, expected: `${expected[0]}x${expected[1]}` });
+    }
+  }
 
   if (fs.existsSync(API_JS) && (!app.api || Object.keys(app.api).length === 0)) {
     pushError(report, 'APP_API_SECTION_REQUIRED', 'app.json', 'api.js exists, so app.json must declare a top-level api section for Homey ManagerApi');
+  }
+}
+
+function auditReadmes(report) {
+  for (const file of README_FILES) {
+    const full = path.join(ROOT, file);
+    if (!fs.existsSync(full)) {
+      if (file === 'README.txt') pushError(report, 'README_REQUIRED', file, 'Homey App Store requires README.txt');
+      continue;
+    }
+    const text = fs.readFileSync(full, 'utf8').trim();
+    const paragraphs = text.split(/\r?\n\s*\r?\n/).filter(Boolean);
+    if (/https?:\/\/|www\./i.test(text)) pushError(report, 'README_URL_FORBIDDEN', file, 'Homey App Store guidelines do not allow URLs in readme.txt');
+    if (/^\s{0,3}(#{1,6}\s|[-*+]\s|\d+\.\s)/m.test(text) || /(```|__|\*\*)/.test(text)) {
+      pushError(report, 'README_MARKDOWN_FORBIDDEN', file, 'Homey readme.txt is plain text; Markdown/list formatting is not rendered and is not allowed');
+    }
+    if (/\b(changelog|release notes|what'?s new|version\s+\d+\.\d+)/i.test(text)) {
+      pushError(report, 'README_CHANGELOG_FORBIDDEN', file, 'Use .homeychangelog.json for changes; do not put a changelog in the readme');
+    }
+    if (paragraphs.length > 2 || text.length > 1200) {
+      pushWarning(report, 'README_TOO_LONG', file, 'Homey App Store guidelines recommend one or two concise paragraphs', { paragraphs: paragraphs.length, length: text.length });
+    }
   }
 }
 
@@ -380,6 +484,7 @@ function main() {
   const app = readJson(APP_JSON);
   const pkg = readJson(PACKAGE_JSON);
   auditManifest(app, pkg, report);
+  auditReadmes(report);
   auditRuntimeCrashGates(report);
 
   const drivers = collectDrivers(app, report);


### PR DESCRIPTION
## Summary
- refresh Homey App Store guideline checks from official 2026 docs
- align App Store descriptions, brand color and plain-text readmes
- add Homey guideline reference report
- fix virtual presence Flow titleFormatted metadata and duplicate device args
- align presence force Flow filter with Homey driver_id syntax

## Validation
- npm run precommit --if-present
- npm run validate:publish --if-present
- npm run build && npm run prepare-publish
- npm run check:homey-guidelines -- --json

## Notes
- publish payload gate passes after prepare-publish: build directory 29.86 MB / 32 MB, prepared publish 20.33 MB / 24 MB
- fingerprint warnings are existing runtime-only/non-target manifest warnings