### PR TITLE
fix(stable): harden button UI pulses and battery fallback

### DIFF
--- a/lib/ButtonRemoteManager.js
+++ b/lib/ButtonRemoteManager.js
@@ -199,6 +199,12 @@ class ButtonRemoteManager {
   static triggerFlow(device, button, scene) {
     device.log(`[BUTTON-MGR] 🎯 Triggering flow: button=${button}, scene=${scene}`);
 
+    if (typeof device._pulseButtonCapability === 'function') {
+      device._pulseButtonCapability(button).catch(err => {
+        device.log(`[BUTTON-MGR] ⚠️ Button capability pulse failed: ${err.message}`);
+      });
+    }
+
     const triggerCard = device.homey.flow.getDeviceTriggerCard('remote_button_pressed');
     if (!triggerCard) {
       device.error('[BUTTON-MGR] ❌ Flow trigger card "remote_button_pressed" not found!');

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -139,6 +139,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
     const value = Math.max(0, Math.min(100, Math.round(Number(percent))));
     if (!Number.isFinite(value)) {return false;}
 
+    const isEstimated = /estimate|estimated|fallback/i.test(String(source));
     this.log(`[BUTTON-BATTERY] ✅ ${source}: ${value}%`);
     if (typeof this._updateBattery === 'function') {
       await this._updateBattery(value);
@@ -149,6 +150,96 @@ class ButtonDevice extends AutoAdaptiveDevice {
       await this.setStoreValue('last_battery_percentage', value).catch(() => {});
     }
     await this.setStoreValue('last_battery_time', Date.now()).catch(() => {});
+    await this.setStoreValue('last_battery_source', source).catch(() => {});
+    await this.setStoreValue('last_battery_estimated', isEstimated).catch(() => {});
+    return true;
+  }
+
+  async _estimateButtonBatteryFallback() {
+    if (!this.hasCapability('measure_battery')) {return null;}
+
+    const currentRaw = this.getCapabilityValue('measure_battery');
+    if (currentRaw !== null && currentRaw !== undefined) {
+      const current = Number(currentRaw);
+      if (Number.isFinite(current)) {return Math.max(0, Math.min(100, Math.round(current)));}
+    }
+
+    const now = Date.now();
+    let startedAt = Number(this.getStoreValue('button_battery_estimate_started_at')) || 0;
+    if (!startedAt) {
+      startedAt = now;
+      await this.setStoreValue('button_battery_estimate_started_at', startedAt).catch(() => {});
+    }
+
+    const storedPresses = Number(this.getStoreValue('button_press_count')) || 0;
+    const livePresses = Number(this._buttonPressCount) || 0;
+    const pressCount = Math.max(storedPresses, livePresses);
+    const ageDays = Math.max(0, (now - startedAt) / 86400000);
+    const manufacturer = MfrHelper.getManufacturerName(this);
+    const modelId = MfrHelper.getModelId(this);
+    const isRemote = /TS004|button|remote/i.test(`${manufacturer} ${modelId}`);
+    const dailyDrain = isRemote ? 0.06 : 0.1;
+    const pressDrain = isRemote ? 0.003 : 0.005;
+
+    return Math.max(5, Math.min(100, Math.round(100 - (ageDays * dailyDrain) - (pressCount * pressDrain))));
+  }
+
+  async _recordButtonPressForBatteryEstimate(button, type) {
+    try {
+      const now = Date.now();
+      const stored = Number(this.getStoreValue('button_press_count')) || 0;
+      this._buttonPressCount = Math.max(Number(this._buttonPressCount) || 0, stored) + 1;
+      this._lastButtonPressForBatteryEstimate = { button, type, ts: now };
+
+      if (!this.getStoreValue('button_battery_estimate_started_at')) {
+        await this.setStoreValue('button_battery_estimate_started_at', now).catch(() => {});
+      }
+      if (this._buttonPressCount <= 3 || this._buttonPressCount % 10 === 0) {
+        await this.setStoreValue('button_press_count', this._buttonPressCount).catch(() => {});
+      }
+    } catch (err) {
+      this.log(`[BUTTON-BATTERY] ⚠️ Press counter update failed: ${err.message}`);
+    }
+  }
+
+  async _setButtonCapabilityState(capability, value) {
+    if (!capability || !this.hasCapability(capability)) {return false;}
+    try {
+      if (typeof this._safeSetCapability === 'function') {
+        return await this._safeSetCapability(capability, value);
+      }
+      await this.safeSetCapabilityValue(capability, value);
+      return true;
+    } catch (err) {
+      this.log(`[BUTTON] ⚠️ Could not set ${capability}: ${err.message}`);
+      return false;
+    }
+  }
+
+  async _pulseButtonCapability(buttonNumber = 1, pulseMs = 500) {
+    const button = Math.max(1, Number(buttonNumber) || 1);
+    const capabilities = [`button.${button}`];
+    if (button === 1) {
+      capabilities.push('button');
+    }
+
+    const activeCaps = [...new Set(capabilities)].filter(capability => this.hasCapability(capability));
+    if (!activeCaps.length) {return false;}
+
+    let pulsed = false;
+    for (const capability of activeCaps) {
+      pulsed = (await this._setButtonCapabilityState(capability, true)) || pulsed;
+    }
+    if (!pulsed) {return false;}
+
+    const setTimer = this.homey?.setTimeout ? this.homey.setTimeout.bind(this.homey) : globalThis.setTimeout;
+    setTimer(() => {
+      if (this._destroyed) {return;}
+      for (const capability of activeCaps) {
+        this._setButtonCapabilityState(capability, false).catch(() => {});
+      }
+    }, pulseMs);
+
     return true;
   }
 
@@ -946,6 +1037,16 @@ class ButtonDevice extends AutoAdaptiveDevice {
       }
     }
 
+    // METHOD 4: Estimated fallback so Homey never stays at '?' indefinitely.
+    // Replaced automatically by real ZCL/DP data on the next successful report.
+    if (!batteryRead && this.getCapabilityValue('measure_battery') == null) {
+      const estimated = await this._estimateButtonBatteryFallback();
+      if (estimated !== null) {
+        batteryRead = await this._setButtonBattery(estimated, 'estimated fallback');
+        this.log('[BUTTON-BATTERY] ℹ️ Estimated fallback set until real battery report arrives');
+      }
+    }
+
     if (!batteryRead) {
       this.log('[BUTTON-BATTERY] ⚠️ Could not read battery (device may have gone back to sleep)');
     }
@@ -1150,15 +1251,8 @@ class ButtonDevice extends AutoAdaptiveDevice {
 
     this._lastTriggerTime[`${button}_${type}`] = now;
 
-    // v5.5.430: Reset button capability to false after trigger (fixes "stays true" issue)
-    const buttonCapId = `button.${button}`;
-    if (this.hasCapability(buttonCapId)) {
-      await this.safeSetCapabilityValue(buttonCapId, true).catch(() => {});
-      this.homey.setTimeout(async () => {
-        if (this._destroyed) return;
-        await this.safeSetCapabilityValue(buttonCapId, false).catch(() => {});
-      }, 500);
-    }
+    await this._recordButtonPressForBatteryEstimate(button, type);
+    await this._pulseButtonCapability(button);
 
     this.log(`[BUTTON-FLOW] triggerButtonPress(btn=${button}, type=${type})`);
     if (typeof this._triggerPhysicalFlow === 'function') {
@@ -1268,6 +1362,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       if (type === 'single') {
         const btnNum = Number(button) || 1;
         const btnStr = button.toString();
+        await this._tryCard('remote_button_pressed', { button: btnNum, scene: type }, { button: btnNum, scene: type });
         await this._tryCard('button_pressed', { button: btnNum }, { button: btnNum });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_pressed`, { button: btnStr }, { button: btnStr });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_${button}_pressed`);
@@ -1277,6 +1372,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       } else if (type === 'double') {
         const btnNum = Number(button) || 1;
         const btnStr = button.toString();
+        await this._tryCard('remote_button_pressed', { button: btnNum, scene: type }, { button: btnNum, scene: type });
         await this._tryCard('button_double_press', { button: btnNum }, { button: btnNum });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_${button}_double`);
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_double_press`, { button: btnStr }, { button: btnStr });
@@ -1286,6 +1382,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       } else if (type === 'long') {
         const btnNum = Number(button) || 1;
         const btnStr = button.toString();
+        await this._tryCard('remote_button_pressed', { button: btnNum, scene: type }, { button: btnNum, scene: type });
         await this._tryCard('button_long_press', { button: btnNum }, { button: btnNum });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_${button}_long`);
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_long_press`, { button: btnStr }, { button: btnStr });
@@ -1295,6 +1392,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       } else if (type === 'multi') {
         const btnNum = Number(button) || 1;
         const btnStr = button.toString();
+        await this._tryCard('remote_button_pressed', { button: btnNum, scene: 'triple' }, { button: btnNum, scene: 'triple' });
         await this._tryCard('button_multi_press', { button: btnNum, count }, { button: btnNum, count });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_multi_press`, { button: btnStr, count }, { button: btnStr, count });
         if (count === 3) {
@@ -1304,6 +1402,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       } else if (type === 'release') {
         const btnNum = Number(button) || 1;
         const btnStr = button.toString();
+        await this._tryCard('remote_button_pressed', { button: btnNum, scene: type }, { button: btnNum, scene: type });
         await this._tryCard('button_release', { button: btnNum }, { button: btnNum });
         await this._tryCard(`${driverId}_button_${gangCount}gang_button_${button}_release`);
         await this._tryCard(`${driverId}_button_release`, { button: btnStr }, { button: btnStr });

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -208,6 +208,9 @@ class ButtonDevice extends AutoAdaptiveDevice {
       if (typeof this._safeSetCapability === 'function') {
         return await this._safeSetCapability(capability, value);
       }
+      if (typeof this._safeSetCapabilityFallback === 'function') {
+        return await this._safeSetCapabilityFallback(capability, value);
+      }
       await this.safeSetCapabilityValue(capability, value);
       return true;
     } catch (err) {

--- a/scripts/ci/check-button-flow-routing.js
+++ b/scripts/ci/check-button-flow-routing.js
@@ -439,6 +439,30 @@ function validateSwitchButtonCapabilityFallback() {
   }
 }
 
+function validateButtonRuntimeCoverage() {
+  const buttonDevicePath = path.join(ROOT, 'lib', 'devices', 'ButtonDevice.js');
+  const source = fs.existsSync(buttonDevicePath) ? fs.readFileSync(buttonDevicePath, 'utf8') : '';
+  const requiredSnippets = [
+    '_pulseButtonCapability',
+    '_recordButtonPressForBatteryEstimate',
+    '_estimateButtonBatteryFallback',
+    'last_battery_estimated',
+    'remote_button_pressed',
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!source.includes(snippet)) {
+      addError('ButtonDevice', 'Button runtime lost stable UI/battery fallback coverage', { snippet });
+    }
+  }
+
+  const legacyManagerPath = path.join(ROOT, 'lib', 'ButtonRemoteManager.js');
+  const legacySource = fs.existsSync(legacyManagerPath) ? fs.readFileSync(legacyManagerPath, 'utf8') : '';
+  if (!legacySource.includes('_pulseButtonCapability')) {
+    addError('ButtonRemoteManager', 'Legacy remote manager no longer pulses visible button capabilities');
+  }
+}
+
 function run() {
   const helperPath = path.join(ROOT, 'lib', 'FlowCardHelper.js');
   const helperText = fs.existsSync(helperPath) ? fs.readFileSync(helperPath, 'utf8') : '';
@@ -454,6 +478,7 @@ function run() {
   validateKnownTs0014WallSwitchRouting();
   validateForumSoilSensorRouting();
   validateSwitchButtonCapabilityFallback();
+  validateButtonRuntimeCoverage();
 
   const driverDirs = fs.readdirSync(DRIVERS_DIR, { withFileTypes: true })
     .filter(entry => entry.isDirectory())


### PR DESCRIPTION
## Summary
- pulse visible button capabilities through a shared ButtonDevice helper, including legacy button fallback
- trigger the generic remote_button_pressed flow from the stable ButtonDevice router for single/double/long/multi/release paths
- replace indefinite unknown button battery values with a marked estimated fallback until real ZCL/Tuya DP data arrives
- extend check:button-flows to guard stable button UI and battery fallback coverage

## Validation
- npm run check:button-flows
- npm run precommit
- npm run validate:recursive
- npm run validate:publish