### PR TITLE
fix(stable): restore 2-button battery percentage routing

### DIFF
--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -283,7 +283,8 @@ class ButtonDevice extends AutoAdaptiveDevice {
         const type = buffer[offset + 1];
         const len = buffer.readUInt16BE(offset + 2);
         const end = offset + 4 + len;
-        if (!this._isButtonBatteryDP(dp) || len < 0 || end > buffer.length) {
+        const validDpFrame = dp > 0 && dp <= 200 && type >= 0 && type <= 5 && end <= buffer.length;
+        if (!validDpFrame) {
           break;
         }
 
@@ -294,7 +295,9 @@ class ButtonDevice extends AutoAdaptiveDevice {
         } else if (type === 2 && raw.length > 0 && raw.length <= 4) {
           value = raw.readUIntBE(0, raw.length);
         }
-        reports.push({ dp, value });
+        if (this._isButtonBatteryDP(dp)) {
+          reports.push({ dp, value });
+        }
         offset = end;
       }
     }

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -90,13 +90,45 @@ class ButtonDevice extends AutoAdaptiveDevice {
     const raw = Number(value);
     if (!Number.isFinite(raw)) {return null;}
 
-    if (dp === 3 && raw >= 0 && raw <= 2) {
+    if ((dp === 3 || dp === 14) && raw >= 0 && raw <= 2) {
       return raw === 0 ? 10 : raw === 1 ? 50 : 100;
     }
 
     if (![4, 15, 101].includes(Number(dp))) {return null;}
     if (raw === 255 || raw === 0xFFFF || raw < 0 || raw > 200) {return null;}
     return raw > 100 ? Math.round(raw / 2) : Math.round(raw);
+  }
+
+  _isButtonBatteryDP(dp) {
+    return [3, 4, 14, 15, 101].includes(Number(dp));
+  }
+
+  _hasMissingButtonBatteryValue() {
+    if (!this.hasCapability('measure_battery')) {return false;}
+    const current = this.getCapabilityValue('measure_battery');
+    if (current === null || current === undefined) {return true;}
+    return !Number.isFinite(Number(current));
+  }
+
+  _coerceButtonBatteryDPValue(value) {
+    if (value === null || value === undefined) {return null;}
+    if (typeof value === 'number' || typeof value === 'boolean') {return Number(value);}
+    if (typeof value === 'string' && value.trim() !== '') {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    }
+    if (Buffer.isBuffer(value)) {
+      if (value.length === 0) {return null;}
+      if (value.length <= 4) {return value.readUIntBE(0, value.length);}
+      return value[value.length - 1];
+    }
+    if (Array.isArray(value)) {
+      return this._coerceButtonBatteryDPValue(Buffer.from(value));
+    }
+    if (typeof value === 'object') {
+      return this._coerceButtonBatteryDPValue(value.value ?? value.dpValue ?? value.data ?? value.raw);
+    }
+    return null;
   }
 
   _getButtonPowerClusters() {
@@ -200,6 +232,137 @@ class ButtonDevice extends AutoAdaptiveDevice {
     } catch (err) {
       this.log(`[BUTTON-BATTERY] ⚠️ Press counter update failed: ${err.message}`);
     }
+  }
+
+  _extractButtonBatteryDPReports(...args) {
+    const reports = [];
+    const visit = (payload) => {
+      if (payload === null || payload === undefined) {return;}
+
+      if (Buffer.isBuffer(payload)) {
+        this._extractButtonBatteryDPReportsFromBuffer(payload, reports);
+        return;
+      }
+
+      if (Array.isArray(payload)) {
+        if (payload.length >= 2 && this._isButtonBatteryDP(payload[0])) {
+          reports.push({ dp: Number(payload[0]), value: payload[1] });
+          return;
+        }
+        payload.forEach(visit);
+        return;
+      }
+
+      if (typeof payload !== 'object') {return;}
+
+      const grouped = payload.datapoints || payload.dps || payload.dataPoints || payload.dpValues;
+      if (Array.isArray(grouped)) {
+        grouped.forEach(visit);
+      } else if (Buffer.isBuffer(grouped)) {
+        this._extractButtonBatteryDPReportsFromBuffer(grouped, reports);
+      }
+
+      const dp = payload.dpId ?? payload.dpID ?? payload.dp ?? payload.datapoint ?? payload.id;
+      if (!this._isButtonBatteryDP(dp)) {return;}
+
+      const value = payload.value ?? payload.dpValue ?? payload.data ?? payload.rawValue ?? payload.raw;
+      reports.push({ dp: Number(dp), value });
+    };
+
+    args.forEach(visit);
+    return reports;
+  }
+
+  _extractButtonBatteryDPReportsFromBuffer(buffer, reports) {
+    if (!Buffer.isBuffer(buffer) || buffer.length < 5) {return;}
+
+    for (const initialOffset of [0, 1, 2]) {
+      let offset = initialOffset;
+      while (offset + 4 <= buffer.length) {
+        const dp = buffer[offset];
+        const type = buffer[offset + 1];
+        const len = buffer.readUInt16BE(offset + 2);
+        const end = offset + 4 + len;
+        if (!this._isButtonBatteryDP(dp) || len < 0 || end > buffer.length) {
+          break;
+        }
+
+        const raw = buffer.slice(offset + 4, end);
+        let value = raw;
+        if (type === 1 || type === 4) {
+          value = raw[0];
+        } else if (type === 2 && raw.length > 0 && raw.length <= 4) {
+          value = raw.readUIntBE(0, raw.length);
+        }
+        reports.push({ dp, value });
+        offset = end;
+      }
+    }
+  }
+
+  async _handleButtonBatteryDPEvent(...args) {
+    const reports = this._extractButtonBatteryDPReports(...args);
+    let handled = false;
+
+    for (const { dp, value } of reports) {
+      handled = (await this._handleTuyaBatteryDP(dp, value)) || handled;
+    }
+
+    return handled;
+  }
+
+  async _setupButtonBatteryDPListeners(zclNode = this.zclNode) {
+    if (this._buttonBatteryDPListenersBound || !this.hasCapability('measure_battery')) {return false;}
+
+    let bound = 0;
+    const endpoints = zclNode?.endpoints || {};
+    const tuyaEvents = ['dataReport', 'response', 'report', 'datapoint', 'dp', 'data'];
+
+    for (const endpoint of Object.values(endpoints)) {
+      const cluster = endpoint?.clusters?.tuya ||
+        endpoint?.clusters?.tuyaSpecific ||
+        endpoint?.clusters?.manuSpecificTuya ||
+        endpoint?.clusters?.[0xEF00] ||
+        endpoint?.clusters?.[61184] ||
+        endpoint?.clusters?.['61184'];
+
+      if (!cluster || typeof cluster.on !== 'function') {continue;}
+      for (const eventName of tuyaEvents) {
+        try {
+          cluster.on(eventName, (...eventArgs) => {
+            this._handleButtonBatteryDPEvent(...eventArgs).catch((err) => {
+              this.log(`[BUTTON-BATTERY] ⚠️ Tuya ${eventName} battery handler failed: ${err.message}`);
+            });
+          });
+          bound += 1;
+        } catch (_err) {
+          // Some SDK cluster shims expose a partial event API; ignore unsupported events.
+        }
+      }
+    }
+
+    const manager = this.tuyaEF00Manager;
+    if (manager && typeof manager.on === 'function' && !manager._buttonBatteryDPBound) {
+      for (const eventName of ['dpReport', 'datapoint', 'dp', 'report', 'data']) {
+        try {
+          manager.on(eventName, (...eventArgs) => {
+            this._handleButtonBatteryDPEvent(...eventArgs).catch((err) => {
+              this.log(`[BUTTON-BATTERY] ⚠️ Manager ${eventName} battery handler failed: ${err.message}`);
+            });
+          });
+          bound += 1;
+        } catch (_err) {
+          // Optional manager event.
+        }
+      }
+      manager._buttonBatteryDPBound = true;
+    }
+
+    if (bound > 0) {
+      this._buttonBatteryDPListenersBound = true;
+      this.log(`[BUTTON-BATTERY] ✅ Bound ${bound} Tuya DP battery listeners`);
+    }
+    return bound > 0;
   }
 
   async _setButtonCapabilityState(capability, value) {
@@ -350,6 +513,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
       }
     }
     // v5.11.201 : read battery on wake (sleepy devices)
+    await this._setupButtonBatteryDPListeners(zclNode).catch(() => {});
     if (this._readBatteryWhileAwake) {
       await this._readBatteryWhileAwake().catch(() => {});
     }
@@ -446,6 +610,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
     // v5.7.19: Universal scene mode switching for TS004F/TS0044 devices
     // Moved from button_wireless_4 to base class so ALL button drivers benefit
     await this._universalSceneModeSwitch(zclNode);
+    await this._setupButtonBatteryDPListeners(zclNode);
 
     // Note: Physical and Virtual button detection is now automatically
     // initialized by the root TuyaZigbeeDevice.js base class (v7.1.0)
@@ -456,14 +621,15 @@ class ButtonDevice extends AutoAdaptiveDevice {
     _batTimer(async () => {
       try {
         if (this._destroyed) return;
-        if (this.hasCapability('measure_battery') && this.getCapabilityValue('measure_battery') === null) {
+        if (this._hasMissingButtonBatteryValue()) {
           // Try restore from store first (instant)
           const stored = this.getStoreValue('last_battery_percentage');
-          if (stored !== null && typeof stored === 'number') {
-            await this.safeSetCapabilityValue('measure_battery', stored).catch((err) => {
+          const storedBattery = Number(stored);
+          if (stored !== null && stored !== undefined && Number.isFinite(storedBattery)) {
+            await this.safeSetCapabilityValue('measure_battery', storedBattery).catch((err) => {
               this.log(`[BUTTON-BATTERY] ⚠️ Failed to set stored battery: ${err.message}`);
             });
-            this.log(`[BUTTON-BATTERY] ✅ Restored from store: ${stored}%`);
+            this.log(`[BUTTON-BATTERY] ✅ Restored from store: ${storedBattery}%`);
           } else {
             // Try ZCL read (device may still be awake)
             await this._readBatteryWhileAwake();
@@ -1012,8 +1178,8 @@ class ButtonDevice extends AutoAdaptiveDevice {
 
         if (tuyaCluster && typeof tuyaCluster.dataQuery === 'function') {
           this.log('[BUTTON-BATTERY] 📡 Trying Tuya DP for battery...');
-          // Request battery DP (common DPs: 4, 15, 101, 3)
-          for (const dp of [4, 15, 101, 3]) {
+          // Request battery DP (common DPs: 4, 15, 101, plus state DPs 3/14)
+          for (const dp of [4, 15, 101, 3, 14]) {
             try {
               await tuyaCluster.dataQuery({ dp });
             } catch (e) {
@@ -1042,7 +1208,7 @@ class ButtonDevice extends AutoAdaptiveDevice {
 
     // METHOD 4: Estimated fallback so Homey never stays at '?' indefinitely.
     // Replaced automatically by real ZCL/DP data on the next successful report.
-    if (!batteryRead && this.getCapabilityValue('measure_battery') == null) {
+    if (!batteryRead && this._hasMissingButtonBatteryValue()) {
       const estimated = await this._estimateButtonBatteryFallback();
       if (estimated !== null) {
         batteryRead = await this._setButtonBattery(estimated, 'estimated fallback');
@@ -1059,20 +1225,61 @@ class ButtonDevice extends AutoAdaptiveDevice {
    * v5.5.225: Handle battery report from Tuya DP
    */
   async _handleTuyaBatteryDP(dp, value) {
-    if (!this.hasCapability('measure_battery')) {return;}
+    if (!this.hasCapability('measure_battery')) {return false;}
 
-    const battery = this._normalizeButtonDpBattery(Number(dp), value);
-    if (battery === null) {return;}
+    const battery = this._normalizeButtonDpBattery(Number(dp), this._coerceButtonBatteryDPValue(value));
+    if (battery === null) {return false;}
 
     // v5.8.70: Anti-flood — dedup + 5min throttle
     const prev = Number(this.getCapabilityValue('measure_battery'));
-    if (Number.isFinite(prev) && prev === battery) {return;}
+    const previousWasEstimated = this.getStoreValue('last_battery_estimated') === true;
+    if (Number.isFinite(prev) && prev === battery && !previousWasEstimated) {return true;}
     const now = Date.now();
     if (!this._battLastDP) {this._battLastDP = 0;}
-    if (Number.isFinite(prev) && (now - this._battLastDP) < 300000 && Math.abs(battery - prev) < 2) {return;}
+    if (Number.isFinite(prev) && !previousWasEstimated && (now - this._battLastDP) < 300000 && Math.abs(battery - prev) < 2) {return true;}
     this._battLastDP = now;
 
     await this._setButtonBattery(battery, `Tuya DP${dp}`);
+    return true;
+  }
+
+  async _onDPReceived(dpId, value, dpType = null) {
+    if (this._isButtonBatteryDP(dpId)) {
+      await this._handleTuyaBatteryDP(dpId, value).catch((err) => {
+        this.log(`[BUTTON-BATTERY] ⚠️ DP${dpId} pre-route failed: ${err.message}`);
+      });
+    }
+
+    if (typeof super._onDPReceived === 'function') {
+      return super._onDPReceived(dpId, value, dpType);
+    }
+    return undefined;
+  }
+
+  async _handleDeviceSpecificDP(dpId, value, mapping) {
+    if (this._isButtonBatteryDP(dpId)) {
+      await this._handleTuyaBatteryDP(dpId, value).catch((err) => {
+        this.log(`[BUTTON-BATTERY] ⚠️ DP${dpId} specific-route failed: ${err.message}`);
+      });
+    }
+
+    if (typeof super._handleDeviceSpecificDP === 'function') {
+      return super._handleDeviceSpecificDP(dpId, value, mapping);
+    }
+    return undefined;
+  }
+
+  async onTuyaDP(dpId, value, dpType) {
+    if (this._isButtonBatteryDP(dpId)) {
+      await this._handleTuyaBatteryDP(dpId, value).catch((err) => {
+        this.log(`[BUTTON-BATTERY] ⚠️ onTuyaDP DP${dpId} failed: ${err.message}`);
+      });
+    }
+
+    if (typeof super.onTuyaDP === 'function') {
+      return super.onTuyaDP(dpId, value, dpType);
+    }
+    return undefined;
   }
 
   /**

--- a/scripts/ci/check-button-flow-routing.js
+++ b/scripts/ci/check-button-flow-routing.js
@@ -446,6 +446,11 @@ function validateButtonRuntimeCoverage() {
     '_pulseButtonCapability',
     '_recordButtonPressForBatteryEstimate',
     '_estimateButtonBatteryFallback',
+    '_setupButtonBatteryDPListeners',
+    '_isButtonBatteryDP',
+    '_hasMissingButtonBatteryValue',
+    '_onDPReceived',
+    '_handleDeviceSpecificDP',
     'last_battery_estimated',
     'remote_button_pressed',
   ];

--- a/test/button-flow-runtime-routing.test.js
+++ b/test/button-flow-runtime-routing.test.js
@@ -58,6 +58,8 @@ describe('button flow runtime routing guards', function() {
     assert.match(source, /_handleDeviceSpecificDP\s*\(dpId, value, mapping\)/);
     assert.match(source, /onTuyaDP\s*\(dpId, value, dpType\)/);
     assert.match(source, /_hasMissingButtonBatteryValue\s*\(/);
+    assert.match(source, /const validDpFrame = dp > 0 && dp <= 200/);
+    assert.match(source, /if \(this\._isButtonBatteryDP\(dp\)\) \{\s+reports\.push\(\{ dp, value \}\)/);
     assert.match(source, /_handleTuyaBatteryDP\(dpId, value\)/);
   });
 

--- a/test/button-flow-runtime-routing.test.js
+++ b/test/button-flow-runtime-routing.test.js
@@ -48,6 +48,19 @@ describe('button flow runtime routing guards', function() {
     assert.match(source, /_tryCard\('button_release'/);
   });
 
+  it('routes 2-button TS0042 battery DPs before Homey can stay on unknown battery', function() {
+    const source = read('lib/devices/ButtonDevice.js');
+
+    assert.match(source, /_isButtonBatteryDP\s*\(dp\)/);
+    assert.match(source, /\[3, 4, 14, 15, 101\]\.includes\(Number\(dp\)\)/);
+    assert.match(source, /_setupButtonBatteryDPListeners\s*\(/);
+    assert.match(source, /_onDPReceived\s*\(dpId, value, dpType = null\)/);
+    assert.match(source, /_handleDeviceSpecificDP\s*\(dpId, value, mapping\)/);
+    assert.match(source, /onTuyaDP\s*\(dpId, value, dpType\)/);
+    assert.match(source, /_hasMissingButtonBatteryValue\s*\(/);
+    assert.match(source, /_handleTuyaBatteryDP\(dpId, value\)/);
+  });
+
   it('keeps multi-endpoint button command capture broad across SDK event styles', function() {
     const source = read('lib/zigbee/MultiEndpointCommandListener.js');
     const base = read('lib/devices/BaseUnifiedDevice.js');


### PR DESCRIPTION
## Summary
- route TS0042/two-button Tuya battery DPs (3/4/14/15/101) explicitly through ButtonDevice before generic discovery can miss or misclassify them
- bind Tuya DP battery listeners on init and wake/rejoin, including cluster and EF00 manager event formats
- treat null/undefined/non-numeric battery values as missing so Homey does not stay on '?' and real DP/ZCL values replace estimated fallback
- add CI/test guards for the two-button battery route

## Validation
- node -c lib/devices/ButtonDevice.js
- npm test -- --grep "button flow runtime routing guards"
- npm run check:button-flows
- npm run precommit
- npm run validate:publish
- npm run validate:recursive
