### PR TITLE
[codex] fix stable battery fallback cascade

### DIFF
--- a/lib/battery/UnifiedBatteryHandler.js
+++ b/lib/battery/UnifiedBatteryHandler.js
@@ -26,10 +26,38 @@
  */
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BATTERY DPs (Tuya) — v5.8.69 unified list
+// BATTERY DPs (Tuya) — merged from historic app versions, Z2M/ZHA patterns,
+// Homey forum diagnostics, and issue #439 follow-up work.
 // ═══════════════════════════════════════════════════════════════════════════════
-const BATTERY_DPS = [4, 10, 14, 15, 21, 100, 101, 102, 104, 105];
+const BATTERY_CORE_PERCENT_DPS = [4, 15, 101];
+const BATTERY_EXTENDED_PERCENT_DPS = [10, 21, 100, 102, 104, 105, 121];
+const BATTERY_PROFILE_ONLY_PERCENT_DPS = [2, 7, 13];
+const BATTERY_PERCENT_DPS = [
+  ...BATTERY_CORE_PERCENT_DPS,
+  ...BATTERY_EXTENDED_PERCENT_DPS,
+];
+const BATTERY_STATE_DPS = [3, 14];
+const BATTERY_DPS = [
+  ...BATTERY_PERCENT_DPS,
+  ...BATTERY_STATE_DPS,
+];
 const VOLTAGE_DPS = [33, 35, 247];
+const STORED_BATTERY_KEYS = [
+  'last_battery_percentage',
+  'last_battery_percent',
+  'lastBatteryPercentage',
+  'battery_percentage',
+  'batteryPercent',
+  'batteryLevel',
+  'battery',
+];
+const STORED_VOLTAGE_KEYS = [
+  'battery_voltage',
+  'batteryVoltage',
+  'last_battery_voltage',
+  'lastBatteryVoltage',
+  'battery_voltage_mv',
+];
 
 // v1.0: Battery Health Intelligence integration
 let BatteryHealthIntelligence;
@@ -359,6 +387,101 @@ class UnifiedBatteryHandler {
     return null;
   }
 
+  static getTuyaBatteryDPs(options = {}) {
+    const dps = new Set(BATTERY_DPS);
+    const profile = options.profile || null;
+
+    if (profile?.dpId !== null && profile?.dpId !== undefined) {
+      dps.add(Number(profile.dpId));
+    }
+    if (profile?.dpIdState !== null && profile?.dpIdState !== undefined) {
+      dps.add(Number(profile.dpIdState));
+    }
+    if (options.includeProfileOnly === true) {
+      for (const dp of BATTERY_PROFILE_ONLY_PERCENT_DPS) {
+        dps.add(dp);
+      }
+    }
+
+    return [...dps]
+      .filter(dp => Number.isFinite(dp) && dp > 0)
+      .sort((a, b) => a - b);
+  }
+
+  static getTuyaVoltageDPs() {
+    return [...VOLTAGE_DPS];
+  }
+
+  static isTuyaBatteryDP(dp, options = {}) {
+    return UnifiedBatteryHandler.getTuyaBatteryDPs(options).includes(Number(dp));
+  }
+
+  static isTuyaVoltageDP(dp) {
+    return VOLTAGE_DPS.includes(Number(dp));
+  }
+
+  static coerceNumericValue(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'boolean') return value ? 1 : 0;
+    if (typeof value === 'number') {
+      if (Number.isFinite(value)) return value;
+      return null;
+    }
+    if (typeof value === 'string' && value.trim() !== '') {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    }
+    if (Buffer.isBuffer(value)) {
+      if (value.length === 0) return null;
+      if (value.length <= 4) return value.readUIntBE(0, value.length);
+      return value[value.length - 1];
+    }
+    if (Array.isArray(value)) {
+      return UnifiedBatteryHandler.coerceNumericValue(Buffer.from(value));
+    }
+    if (typeof value === 'object') {
+      return UnifiedBatteryHandler.coerceNumericValue(value.value ?? value.dpValue ?? value.data ?? value.raw);
+    }
+    return null;
+  }
+
+  static normalizeVoltage(rawVoltage) {
+    const raw = UnifiedBatteryHandler.coerceNumericValue(rawVoltage);
+    if (!Number.isFinite(raw) || raw <= 0) return null;
+
+    if (raw >= 800 && raw <= 6000) return raw / 1000;
+    if (raw > 100 && raw <= 600) return raw / 100;
+    if (raw >= 20 && raw <= 60) return raw / 10;
+    if (raw >= 0.8 && raw <= 15) return raw;
+    return null;
+  }
+
+  static normalizeStoredBattery(value) {
+    const numeric = UnifiedBatteryHandler.coerceNumericValue(value);
+    if (!Number.isFinite(numeric)) return null;
+    if (numeric === 255 || numeric === 0xFFFF || numeric < 0 || numeric > 200) return null;
+    return numeric > 100 ? Math.round(numeric / 2) : Math.round(numeric);
+  }
+
+  static normalizeBatteryType(batteryType) {
+    if (!batteryType) return 'CR2032';
+    const key = String(batteryType).trim();
+    const aliases = {
+      cr2032: 'CR2032',
+      cr2450: 'CR2450',
+      cr123a: 'CR123A',
+      aaa: 'AAA',
+      aaa_alkaline: '2xAAA',
+      aa: 'AA',
+      aa_alkaline: '2xAA',
+      lipo: 'Li-ion',
+      li_ion: 'Li-ion',
+      lithium_ion: 'Li-ion',
+      unknown: 'CR2032',
+    };
+    return aliases[key.toLowerCase()] || key;
+  }
+
   /**
    * v5: Calculate percentage from voltage — interpolation sur courbes + température
    * @param {number} voltage - Tension en volts
@@ -367,7 +490,8 @@ class UnifiedBatteryHandler {
    * @returns {number} Pourcentage 0-100
    */
   static calculateFromVoltage(voltage, batteryType = 'CR2032', temperature = 20) {
-    const specs = UnifiedBatteryHandler.BATTERY_SPECS[batteryType];
+    const normalizedType = UnifiedBatteryHandler.normalizeBatteryType(batteryType);
+    const specs = UnifiedBatteryHandler.BATTERY_SPECS[normalizedType];
     if (!specs) {
       // Fallback sécurisé CR2032
       return UnifiedBatteryHandler.calculateFromVoltage(voltage, 'CR2032', temperature);
@@ -403,14 +527,81 @@ class UnifiedBatteryHandler {
   /**
    * v5: Convertir Tuya DP value en pourcentage selon l'algorithme du profil
    */
-  static calculateFromTuyaDP(dpValue, algorithm = 'direct') {
+  static calculateFromTuyaDP(dpValue, algorithm = 'direct', options = {}) {
     if (dpValue === null || dpValue === undefined || isNaN(dpValue)) return null;
     switch (algorithm) {
       case 'multiply_2': return Math.round(Math.max(0, Math.min(100, dpValue * 2)));
       case 'divide_2': return Math.round(Math.max(0, Math.min(100, dpValue / 2)));
+      case 'div2': return Math.round(Math.max(0, Math.min(100, dpValue / 2)));
+      case 'enum3':
+      case 'battery_state':
+        return { 0: 10, 1: 50, 2: 100 }[Number(dpValue)] ?? null;
+      case 'enum4':
+        return { 0: 5, 1: 20, 2: 60, 3: 100 }[Number(dpValue)] ?? null;
+      case 'low_bool':
+        return Number(dpValue) ? 10 : 100;
+      case 'millivolt':
+      case 'mv': {
+        const voltage = UnifiedBatteryHandler.normalizeVoltage(dpValue);
+        const batteryType = options.batteryType || options.chemistry || 'CR2032';
+        return voltage === null ? null : UnifiedBatteryHandler.calculateFromVoltage(voltage, batteryType, options.temperature);
+      }
       case 'direct':
       default: return Math.round(Math.max(0, Math.min(100, dpValue)));
     }
+  }
+
+  static normalizeTuyaBatteryValue(dp, value, options = {}) {
+    const dpId = Number(dp);
+    const raw = UnifiedBatteryHandler.coerceNumericValue(value);
+    if (!Number.isFinite(dpId) || !Number.isFinite(raw)) return null;
+
+    const profile = options.profile || null;
+    const lastValue = Number(options.lastValue);
+    const hasLastValue = Number.isFinite(lastValue);
+    const profileMatches =
+      Number(profile?.dpId) === dpId ||
+      Number(profile?.dpIdState) === dpId ||
+      options.profileMatch === true;
+    const stateMode = options.stateMode || profile?.stateMode || null;
+
+    if (UnifiedBatteryHandler.isTuyaVoltageDP(dpId)) {
+      const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+      if (voltage === null) return null;
+      const batteryType = options.batteryType || profile?.chemistry || 'CR2032';
+      return UnifiedBatteryHandler.calculateFromVoltage(voltage, batteryType, options.temperature);
+    }
+
+    if (BATTERY_STATE_DPS.includes(dpId) || (profileMatches && profile?.algorithm === 'enum3')) {
+      if (typeof value === 'boolean' || stateMode === 'low_bool' || profile?.algorithm === 'low_bool') {
+        if (raw === 1) return 10;
+        return hasLastValue ? Math.max(20, Math.round(lastValue)) : 100;
+      }
+      if (raw >= 0 && raw <= 2) {
+        return raw === 0 ? 10 : raw === 1 ? 50 : 100;
+      }
+      return null;
+    }
+
+    if (profileMatches && profile?.algorithm) {
+      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(raw, profile.algorithm, {
+        batteryType: options.batteryType || profile.chemistry,
+        temperature: options.temperature,
+      });
+      if (profileResult !== null) return profileResult;
+    }
+
+    const percentDp =
+      BATTERY_PERCENT_DPS.includes(dpId) ||
+      (profileMatches && BATTERY_PROFILE_ONLY_PERCENT_DPS.includes(dpId));
+    if (!percentDp) return null;
+
+    if (BATTERY_EXTENDED_PERCENT_DPS.includes(dpId) && raw <= 2 && !profileMatches) {
+      return null;
+    }
+    if (raw === 255 || raw === 0xFFFF || raw < 0 || raw > 200) return null;
+
+    return raw > 100 ? Math.round(raw / 2) : Math.round(raw);
   }
 
   static normalizeZigbeeValue(rawValue, options = {}) {
@@ -683,19 +874,31 @@ class UnifiedBatteryHandler {
 
   async _restoreStoredBattery() {
     try {
-      const stored = await this.device.getStoreValue?.('last_battery_percentage');
-      const storedVoltage = await this.device.getStoreValue?.('battery_voltage');
-      if (stored !== null && stored !== undefined && typeof stored === 'number') {
+      let storedPercent = null;
+      for (const key of STORED_BATTERY_KEYS) {
+        const stored = await this.device.getStoreValue?.(key);
+        storedPercent = UnifiedBatteryHandler.normalizeStoredBattery(stored);
+        if (storedPercent !== null) break;
+      }
+
+      let storedVoltage = null;
+      for (const key of STORED_VOLTAGE_KEYS) {
+        const stored = await this.device.getStoreValue?.(key);
+        storedVoltage = UnifiedBatteryHandler.normalizeVoltage(stored);
+        if (storedVoltage !== null) break;
+      }
+
+      if (storedPercent !== null) {
         const current = this.device.getCapabilityValue?.('measure_battery');
         if (current === null || current === undefined) {
-          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${stored}%`);
-          this.lastValue = stored;
+          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${storedPercent}%`);
+          this.lastValue = storedPercent;
           if (this.device.hasCapability?.('measure_battery')) {
-            await this.device.setCapabilityValue('measure_battery', stored).catch(() => {});
+            await this.device.setCapabilityValue('measure_battery', storedPercent).catch(() => {});
           }
         }
       }
-      if (storedVoltage !== null && storedVoltage !== undefined) {
+      if (storedVoltage !== null) {
         this.lastVoltage = storedVoltage;
       }
     } catch { /* ignore */ }
@@ -742,16 +945,22 @@ class UnifiedBatteryHandler {
         if (cluster) {
           const attrs = await cluster.readAttributes(['batteryPercentageRemaining', 'batteryVoltage']).catch(() => ({}));
           if (attrs.batteryPercentageRemaining !== undefined) {
-            const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining);
+            const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining, {
+              batteryType: this.batteryType,
+              treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+            });
             if (percent !== null) this._updateBattery(percent);
           }
           if (attrs.batteryVoltage !== undefined) {
-            this._updateVoltage(attrs.batteryVoltage / 10);
+            const voltage = UnifiedBatteryHandler.normalizeVoltage(attrs.batteryVoltage);
+            if (voltage !== null) this._updateVoltage(voltage);
           }
         }
       }
       if (this.source?.includes('tuya') && this.device.tuyaEF00Manager) {
-        await this.device.tuyaEF00Manager.requestDP(4).catch(() => {});
+        for (const dp of UnifiedBatteryHandler.getTuyaBatteryDPs({ profile: this._profile })) {
+          await this.device.tuyaEF00Manager.requestDP(dp).catch(() => {});
+        }
       }
     } catch { /* silent (sleeping device) */ }
   }
@@ -838,25 +1047,33 @@ class UnifiedBatteryHandler {
       try {
         const attrs = await cluster.readAttributes(['batteryPercentageRemaining', 'batteryVoltage']);
         if (attrs.batteryPercentageRemaining !== undefined) {
-          const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining);
+          const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining, {
+            batteryType: this.batteryType,
+            treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+          });
           if (percent !== null) {
             this._updateBattery(percent);
           }
         }
         if (attrs.batteryVoltage !== undefined) {
-          this._updateVoltage(attrs.batteryVoltage / 10);
+          const voltage = UnifiedBatteryHandler.normalizeVoltage(attrs.batteryVoltage);
+          if (voltage !== null) this._updateVoltage(voltage);
         }
       } catch { /* normal for sleeping */ }
 
       cluster.on('attr.batteryPercentageRemaining', (value) => {
-        const percent = UnifiedBatteryHandler.normalizeZigbeeValue(value);
+        const percent = UnifiedBatteryHandler.normalizeZigbeeValue(value, {
+          batteryType: this.batteryType,
+          treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+        });
         if (percent !== null) {
           this._updateBattery(percent);
         }
       });
 
       cluster.on('attr.batteryVoltage', (value) => {
-        this._updateVoltage(value / 10);
+        const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+        if (voltage !== null) this._updateVoltage(voltage);
       });
 
       try {
@@ -880,10 +1097,10 @@ class UnifiedBatteryHandler {
     const bindManager = () => {
       const ef00Manager = this.device.tuyaEF00Manager;
       if (ef00Manager) {
-        BATTERY_DPS.forEach(dp => {
+        UnifiedBatteryHandler.getTuyaBatteryDPs({ profile: this._profile }).forEach(dp => {
           ef00Manager.on(`dp-${dp}`, (value) => this._handleTuyaBatteryDP(dp, value));
         });
-        VOLTAGE_DPS.forEach(dp => {
+        UnifiedBatteryHandler.getTuyaVoltageDPs().forEach(dp => {
           ef00Manager.on(`dp-${dp}`, (value) => this._handleTuyaVoltageDP(dp, value));
         });
         this.device.log('[BATTERY-UNIFIED] ✅ Tuya DP listeners registered');
@@ -909,7 +1126,12 @@ class UnifiedBatteryHandler {
 
   _handleTuyaBatteryDP(dp, value) {
     // v9.1.0: Use normalization to handle inconsistent reporting patterns
-    let percent = this._normalizeBatteryValue(value, dp);
+    let percent = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dp, value, {
+      profile: this._profile,
+      batteryType: this.batteryType,
+      lastValue: this.lastValue,
+      temperature: this.temperature,
+    });
 
     // Validate the normalized value
     if (!this._validateBatteryValue(percent, this.lastValue)) {
@@ -922,12 +1144,9 @@ class UnifiedBatteryHandler {
   }
 
   _handleTuyaVoltageDP(dp, value) {
-    let voltage = value;
-    if (dp === 247) { voltage = value / 1000; }
-    else if (value > 100) { voltage = value / 100; }
-    else if (value > 10) { voltage = value / 10; }
+    const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
 
-    if (voltage > 0 && voltage < 20) {
+    if (voltage !== null) {
       this.device.log(`[BATTERY-UNIFIED] 🔶 Tuya voltage DP${dp}: ${voltage}V`);
       this._updateVoltage(voltage);
     }
@@ -974,10 +1193,19 @@ class UnifiedBatteryHandler {
     if (this.device.hasCapability?.('measure_battery')) {
       const current = this.device.getCapabilityValue?.('measure_battery');
       if (current === null || current === undefined) {
-        const stored = this.device.getStoreValue?.('last_battery_percentage');
-        if (stored !== null && stored !== undefined && typeof stored === 'number') {
-          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${stored}%`);
-          this._updateBattery(stored, true);
+        let storedPercent = null;
+        for (const key of STORED_BATTERY_KEYS) {
+          storedPercent = UnifiedBatteryHandler.normalizeStoredBattery(this.device.getStoreValue?.(key));
+          if (storedPercent !== null) break;
+        }
+        if (storedPercent !== null) {
+          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${storedPercent}%`);
+          this._updateBattery(storedPercent, true);
+        } else {
+          this.device.log('[BATTERY-UNIFIED] 🔋 No stored battery, using marked 50% estimate until first report');
+          this.device.setStoreValue?.('last_battery_estimated', true).catch(() => {});
+          this.device.setStoreValue?.('last_battery_source', 'estimated-default').catch(() => {});
+          this._updateBattery(50, true);
         }
       }
     }
@@ -1423,30 +1651,44 @@ class UnifiedBatteryHandler {
    * Called before updating battery to handle common reporting inconsistencies
    */
   _normalizeBatteryValue(value, dpId = null) {
-    if (value === null || value === undefined || typeof value !== 'number') {
-      return value;
+    const cascaded = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dpId, value, {
+      profile: this._profile,
+      batteryType: this.batteryType,
+      lastValue: this.lastValue,
+      temperature: this.temperature,
+    });
+    if (cascaded !== null) {
+      return cascaded;
+    }
+
+    const numeric = UnifiedBatteryHandler.coerceNumericValue(value);
+    if (!Number.isFinite(numeric)) {
+      return null;
     }
 
     // Check profile-specific algorithm first
     if (this._profile && this._profile.algorithm) {
-      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(value, this._profile.algorithm);
+      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(numeric, this._profile.algorithm, {
+        batteryType: this.batteryType || this._profile.chemistry,
+        temperature: this.temperature,
+      });
       if (profileResult !== null) {
-        this.device.log(`[BATTERY-NORM] Profile algorithm '${this._profile.algorithm}': ${value} -> ${profileResult}`);
+        this.device.log(`[BATTERY-NORM] Profile algorithm '${this._profile.algorithm}': ${numeric} -> ${profileResult}`);
         return profileResult;
       }
     }
 
     // Check for known reporting patterns
     for (const [patternName, pattern] of Object.entries(UnifiedBatteryHandler.BATTERY_REPORTING_PATTERNS)) {
-      if (pattern.detect(value, this.lastValue)) {
-        const normalized = pattern.correct(value);
-        this.device.log(`[BATTERY-NORM] Pattern '${patternName}' detected: ${value} -> ${normalized} (${pattern.notes})`);
+      if (pattern.detect(numeric, this.lastValue)) {
+        const normalized = pattern.correct(numeric);
+        this.device.log(`[BATTERY-NORM] Pattern '${patternName}' detected: ${numeric} -> ${normalized} (${pattern.notes})`);
         return normalized;
       }
     }
 
     // Ensure value is within valid range
-    return Math.max(0, Math.min(100, Math.round(value)));
+    return Math.max(0, Math.min(100, Math.round(numeric)));
   }
 
   /**

--- a/lib/devices/ButtonDevice.js
+++ b/lib/devices/ButtonDevice.js
@@ -151,6 +151,9 @@ class ButtonDevice extends AutoAdaptiveDevice {
   }
 
   _normalizeButtonBatteryVoltage(rawVoltage) {
+    if (UnifiedBatteryHandler?.normalizeVoltage) {
+      return UnifiedBatteryHandler.normalizeVoltage(rawVoltage);
+    }
     const raw = Number(rawVoltage);
     if (!Number.isFinite(raw) || raw <= 0) {return null;}
 

--- a/lib/devices/TuyaUnifiedDevice.js
+++ b/lib/devices/TuyaUnifiedDevice.js
@@ -3,6 +3,7 @@
 const TuyaZigbeeDevice = require('../tuya/TuyaZigbeeDevice');
 const { BoundCluster } = require('zigbee-clusters');
 const BatteryCalculator = require('../battery/BatteryCalculator');
+const UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
 const { getAppVersionPrefixed } = require('../utils/AppVersion');
 const { IntelligentDeviceLearner } = require('../IntelligentDeviceLearner');
 const { ensureManufacturerSettings } = require('../helpers/ManufacturerNameHelper');
@@ -1274,8 +1275,20 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
       19: { capability: 'measure_humidity', transform: v => v, pattern: 'humid-dp19' },
 
       // Battery
-      14: { capability: 'measure_battery', transform: v => this._enumToBattery(v), pattern: 'batt-state' },
-      15: { capability: 'measure_battery', transform: v => Math.min(100, Math.max(0, v)), pattern: 'batt-pct' },
+      14: {
+        capability: 'measure_battery',
+        transform: v => UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, v, {
+          lastValue: this.getCapabilityValue?.('measure_battery'),
+        }) ?? this._enumToBattery(v),
+        pattern: 'batt-state',
+      },
+      15: {
+        capability: 'measure_battery',
+        transform: v => UnifiedBatteryHandler.normalizeTuyaBatteryValue(15, v, {
+          lastValue: this.getCapabilityValue?.('measure_battery'),
+        }) ?? Math.min(100, Math.max(0, v)),
+        pattern: 'batt-pct',
+      },
 
       // On/Off
       6: { capability: 'onoff', transform: v => !!v, pattern: 'onoff-dp6' },
@@ -1312,7 +1325,12 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
       }
       // Looks like battery (0-100)
       if (value >= 0 && value <= 100 && this.hasCapability('measure_battery') && dpId >= 10) {
-        return { capability: 'measure_battery', transform: v => v, pattern: 'auto-batt' };
+        const battery = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dpId, value, {
+          lastValue: this.getCapabilityValue?.('measure_battery'),
+        });
+        if (battery !== null) {
+          return { capability: 'measure_battery', transform: () => battery, pattern: 'auto-batt' };
+        }
       }
     }
 
@@ -1334,18 +1352,28 @@ class TuyaUnifiedDevice extends TuyaZigbeeDevice {
    */
   async _handleBatteryDP(dpId, value) {
     const config = this.batteryConfig;
-    let percentage;
+    let percentage = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dpId, value, {
+      profile: {
+        dpId: config.dpId,
+        dpIdState: config.dpIdState,
+        algorithm: config.algorithm,
+        chemistry: config.chemistry,
+      },
+      batteryType: config.chemistry,
+      lastValue: this.getCapabilityValue?.('measure_battery'),
+    });
 
     this.log(`[BATTERY] DP${dpId} raw=${value}`);
 
-    // Determine algorithm based on which DP we received
-    if (dpId === config.dpIdState) {
+    // Determine algorithm based on which DP we received if the unified cascade
+    // does not already know this historic Tuya/ZCL form.
+    if (percentage === null && dpId === config.dpIdState) {
       // Battery state enum (low/medium/high)
       percentage = BatteryCalculator.calculate(value, {
         algorithm: BatteryCalculator.ALGORITHM.ENUM_3,
       });
       this.log(`[BATTERY] State enum: ${value} → ${percentage}%`);
-    } else if (dpId === config.dpId) {
+    } else if (percentage === null && dpId === config.dpId) {
       // Battery percentage/voltage
       percentage = BatteryCalculator.calculate(value, {
         algorithm: config.algorithm,

--- a/lib/helpers/BatteryRouter.js
+++ b/lib/helpers/BatteryRouter.js
@@ -15,9 +15,10 @@
  */
 
 const { CLUSTER } = require('zigbee-clusters');
+const UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
 
 // Battery-related DPs from Tuya devices
-const TUYA_BATTERY_DPS = [4, 10, 14, 15, 101, 105];
+const TUYA_BATTERY_DPS = UnifiedBatteryHandler.getTuyaBatteryDPs();
 const TUYA_VOLTAGE_DP = 247;
 
 /**
@@ -125,11 +126,32 @@ async function resolveBatterySource(device) {
 async function configureBatteryReporting(device, batteryInfo) {
   device.log(`[BATTERY-ROUTER] Configuring ${batteryInfo.source} reporting...`);
 
-  // Set default value immediately to avoid null KPI
+  // Restore a real historical value first to avoid null KPI on sleepy devices.
   const currentBattery = device.getCapabilityValue?.('measure_battery');
   if (currentBattery === null || currentBattery === undefined) {
-    await device.setCapabilityValue('measure_battery', 100).catch(() => { });
-    device.log('[BATTERY-ROUTER] 📊 Set default battery = 100% (pending first report)');
+    const storedKeys = [
+      'last_battery_percentage',
+      'last_battery_percent',
+      'lastBatteryPercentage',
+      'battery_percentage',
+      'batteryPercent',
+      'batteryLevel',
+      'battery',
+    ];
+    let restored = null;
+    for (const key of storedKeys) {
+      restored = UnifiedBatteryHandler.normalizeStoredBattery(device.getStoreValue?.(key));
+      if (restored !== null) break;
+    }
+    if (restored !== null) {
+      await device.setCapabilityValue('measure_battery', restored).catch(() => { });
+      device.log(`[BATTERY-ROUTER] 📊 Restored stored battery = ${restored}%`);
+    } else {
+      await device.setCapabilityValue('measure_battery', 50).catch(() => { });
+      await device.setStoreValue?.('last_battery_estimated', true).catch(() => {});
+      await device.setStoreValue?.('last_battery_source', 'estimated-router').catch(() => {});
+      device.log('[BATTERY-ROUTER] 📊 Set estimated battery = 50% pending first report');
+    }
   }
 
   switch (batteryInfo.source) {
@@ -188,8 +210,7 @@ async function _configureZCLBattery(device) {
       },
       report: 'batteryPercentageRemaining',
       reportParser: (value) => {
-        // ZCL reports 0-200 (half percentage), convert to 0-100
-        return Math.round(value / 2);
+        return UnifiedBatteryHandler.normalizeZigbeeValue(value);
       }
     });
     device.log('[BATTERY-ROUTER] ✅ ZCL battery capability registered');
@@ -208,9 +229,13 @@ async function _configureTuyaDPBattery(device, dps) {
   if (device.tuyaEF00Manager) {
     for (const dp of dps) {
       device.tuyaEF00Manager.on(`dp-${dp}`, async (value) => {
-        const batteryValue = Math.min(100, Math.max(0, Number(value) || 0));
+        const batteryValue = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dp, value, {
+          lastValue: device.getCapabilityValue?.('measure_battery'),
+        });
+        if (batteryValue === null) return;
         device.log(`[BATTERY-ROUTER] 🔋 Tuya DP${dp} battery: ${batteryValue}%`);
         await device.setCapabilityValue('measure_battery', parseFloat(batteryValue)).catch(() => { });
+        await device.setStoreValue?.('last_battery_percentage', batteryValue).catch(() => {});
       });
     }
     device.log('[BATTERY-ROUTER] ✅ Tuya DP battery listeners registered');
@@ -218,9 +243,11 @@ async function _configureTuyaDPBattery(device, dps) {
 
   // Also listen for generic dpReport event
   device.on('tuya_dp_battery', async (value) => {
-    const batteryValue = Math.min(100, Math.max(0, Number(value) || 0));
+    const batteryValue = UnifiedBatteryHandler.normalizeStoredBattery(value);
+    if (batteryValue === null) return;
     device.log(`[BATTERY-ROUTER] 🔋 tuya_dp_battery event: ${batteryValue}%`);
     await device.setCapabilityValue('measure_battery', parseFloat(batteryValue)).catch(() => { });
+    await device.setStoreValue?.('last_battery_percentage', batteryValue).catch(() => {});
   });
 }
 
@@ -233,12 +260,18 @@ async function _configureVoltageBattery(device) {
   // Listen for DP 247 voltage reports
   if (device.tuyaEF00Manager) {
     device.tuyaEF00Manager.on(`dp-${TUYA_VOLTAGE_DP}`, async (value) => {
-      // Convert mV to V
-      const voltage = Number(value) / 1000;
+      const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+      if (voltage === null) return;
       device.log(`[BATTERY-ROUTER] ⚡ Voltage DP247: ${voltage}V`);
 
       if (device.hasCapability('measure_voltage')) {
         await device.setCapabilityValue('measure_voltage', parseFloat(voltage)).catch(() => { });
+      }
+      if (device.hasCapability('measure_battery')) {
+        const percent = UnifiedBatteryHandler.calculateFromVoltage(voltage, getRecommendedBatteryType(device));
+        await device.setCapabilityValue('measure_battery', parseFloat(percent)).catch(() => { });
+        await device.setStoreValue?.('battery_voltage', voltage).catch(() => {});
+        await device.setStoreValue?.('last_battery_percentage', percent).catch(() => {});
       }
     });
   }

--- a/lib/managers/SmartBatteryManager.js
+++ b/lib/managers/SmartBatteryManager.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { safeMultiply, safeParse } = require('../utils/tuyaUtils.js');
+const UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
 
 /**
  * SmartBatteryManager v5.12.0 (Enriched Hardened Edition)
@@ -14,7 +15,7 @@ const { safeMultiply, safeParse } = require('../utils/tuyaUtils.js');
  * 5. Improved Bidirectional Synthesis between alarm_battery and measure_battery.
  */
 
-const BATTERY_DPS = [4, 10, 14, 15, 21, 100, 101, 102, 104, 105];
+const BATTERY_DPS = UnifiedBatteryHandler.getTuyaBatteryDPs();
 
 class SmartBatteryManager {
   constructor(device) {
@@ -130,29 +131,54 @@ class SmartBatteryManager {
   }
 
   _restoreFromStore() {
-    const stored = this.device.getStoreValue('last_battery_percentage');
-    if (stored !== null && typeof stored === 'number') {
-      this.device.log(`[BATTERY] Restored last known value: ${stored}%`);
-      this._lastValue = stored;
+    const storeKeys = [
+      'last_battery_percentage',
+      'last_battery_percent',
+      'lastBatteryPercentage',
+      'battery_percentage',
+      'batteryPercent',
+      'batteryLevel',
+      'battery',
+    ];
+    let storedPercent = null;
+    for (const key of storeKeys) {
+      storedPercent = UnifiedBatteryHandler.normalizeStoredBattery(this.device.getStoreValue(key));
+      if (storedPercent !== null) break;
+    }
+    if (storedPercent !== null) {
+      this.device.log(`[BATTERY] Restored last known value: ${storedPercent}%`);
+      this._lastValue = storedPercent;
       // We don't setCapabilityValue here to avoid flow triggers on app restart,
       // but we keep it in memory for delta checks.
     }
   }
 
   async handleDP(dpId, value) {
-    if (!BATTERY_DPS.includes(dpId)) return false;
+    if (!BATTERY_DPS.includes(Number(dpId)) && !UnifiedBatteryHandler.isTuyaVoltageDP(dpId)) return false;
     
     this.device.log(`[BATTERY] Received DP ${dpId} with raw value: ${value}`);
 
-    if (typeof value === 'boolean') {
+    if (typeof value === 'boolean' && Number(dpId) === 14) {
       await this.setAlarmBattery(value);
+      await this.setBatteryDirect(value ? 10 : (this._lastValue ?? 100));
       return true;
     }
 
-    let percent = value;
-    if (dpId === 101 || dpId === 104 || dpId === 105) {
-      percent = this._voltageToPercent(value);
+    if (UnifiedBatteryHandler.isTuyaVoltageDP(dpId)) {
+      const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+      const percent = voltage === null ? null : UnifiedBatteryHandler.calculateFromVoltage(voltage, this._detectBatteryType());
+      if (percent !== null) {
+        await this.setBattery(percent);
+        return true;
+      }
+      return false;
     }
+
+    const percent = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dpId, value, {
+      lastValue: this._lastValue,
+      batteryType: this._detectBatteryType(),
+    });
+    if (percent === null) return false;
     
     await this.setBattery(percent);
     return true;
@@ -230,10 +256,21 @@ class SmartBatteryManager {
 
   _voltageToPercent(mV) {
     if (mV === null || mV === undefined) return null;
-    if (mV < 10) mV = mV * 1000;
-    else if (mV < 100) mV = mV * 100;
+    const normalizedVoltage = UnifiedBatteryHandler.normalizeVoltage(mV);
+    if (normalizedVoltage === null) return null;
+    mV = Math.round(normalizedVoltage * 1000);
     const curve = this._selectCurve(mV);
     return this._interpolateCurve(mV, curve);
+  }
+
+  _detectBatteryType() {
+    const d = (this.device?.driver?.id || '').toLowerCase();
+    if (d.includes('trv') || d.includes('thermostat') || d.includes('radiator')) return '2xAA';
+    if (d.includes('lock')) return '4xAAA';
+    if (d.includes('siren')) return '2xAA';
+    if (d.includes('soil') || d.includes('climate')) return '2xAAA';
+    if (d.includes('motion') || d.includes('pir')) return 'CR2450';
+    return 'CR2032';
   }
 
   _selectCurve(mV) {

--- a/lib/tuya-engine/converters/battery.js
+++ b/lib/tuya-engine/converters/battery.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const UnifiedBatteryHandler = require('../../battery/UnifiedBatteryHandler');
+
 /**
  * Battery Converter - SDK3 Optimized
  *
@@ -36,15 +38,7 @@
  * @returns {number} - Battery percentage (0..100)
  */
 function fromZclBatteryPercentageRemaining(raw) {
-  if (raw == null || isNaN(raw)) return null;
-
-  // Clamp to valid range (0..200)
-  const clamped = Math.max(0, Math.min(200, raw));
-
-  // Convert to 0..100 %
-  const percentage = Math.round(clamped / 2);
-
-  return Math.max(0, Math.min(100, percentage));
+  return UnifiedBatteryHandler.normalizeZigbeeValue(raw);
 }
 
 /**
@@ -54,10 +48,7 @@ function fromZclBatteryPercentageRemaining(raw) {
  * @returns {number} - Battery percentage (0..100)
  */
 function fromDP(value) {
-  if (value == null || isNaN(value)) return null;
-
-  // Tuya reports 0..100 directly
-  return Math.max(0, Math.min(100, Math.round(value)));
+  return UnifiedBatteryHandler.normalizeStoredBattery(value);
 }
 
 /**

--- a/lib/tuya/TuyaZigbeeDevice.js
+++ b/lib/tuya/TuyaZigbeeDevice.js
@@ -411,11 +411,16 @@ class TuyaZigbeeDevice extends ZigBeeDeviceWithDiagnostics {
    * parseTuyaBatteryValue - Parse Tuya battery value (0-100 or 0-200)
    */
   parseTuyaBatteryValue(value) {
-    if (typeof value !== 'number') return null;
+    try {
+      const UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
+      return UnifiedBatteryHandler.normalizeZigbeeValue(value);
+    } catch (_err) {
+      if (typeof value !== 'number') return null;
 
-    // Tuya devices report battery in 0-100 or 0-200 scale
-    const percentage = value <= 100 ? value : value / 2;
-    return Math.max(0, Math.min(100, Math.round(percentage)));
+      // Tuya devices report battery in 0-100 or 0-200 scale
+      const percentage = value <= 100 ? value : value / 2;
+      return Math.max(0, Math.min(100, Math.round(percentage)));
+    }
   }
 
   /**

--- a/lib/utils/battery-reader.js
+++ b/lib/utils/battery-reader.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
+
 /**
  * Battery Reader - Enhanced battery & voltage reading with fallbacks
  * Handles: standard clusters, voltage fallback, Tuya DP protocol
@@ -43,16 +45,16 @@ async function readBattery(device, zclNode) {
 
       // Check if we've EVER received a real battery DP
       const hasReceivedBatteryDP = device.getStoreValue('has_received_battery_dp');
-      const storedBattery = device.getStoreValue('last_battery_percent');
+      const storedBattery = getStoredBattery(device);
 
-      if (hasReceivedBatteryDP && storedBattery !== null && storedBattery !== undefined) {
+      if (hasReceivedBatteryDP && storedBattery !== null) {
         result.percent = storedBattery;
         result.source = 'tuya_dp_stored';
         device.log(`[BATTERY-READER] ✅ Using confirmed battery: ${storedBattery}%`);
       } else {
         result.source = 'tuya_dp_pending';
         result.percent = null; // Don't show fake 100% - wait for real DP
-        device.log('[BATTERY-READER] ⏳ Waiting for battery DP (4/14/15/101)');
+        device.log('[BATTERY-READER] ⏳ Waiting for battery DP cascade');
       }
       return result;
     }
@@ -66,7 +68,7 @@ async function readBattery(device, zclNode) {
       try {
         const attrs = await ep1.clusters.genPowerCfg.readAttributes(['batteryPercentageRemaining']);
         if (attrs && typeof attrs.batteryPercentageRemaining === 'number') {
-          result.percent = Math.round(attrs.batteryPercentageRemaining / 2); // 0-200 → 0-100
+          result.percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining);
           result.source = 'cluster_0x0001_percent';
           device.log(`[BATTERY-READER] ✅ Read batteryPercentageRemaining: ${attrs.batteryPercentageRemaining} → ${result.percent}%`);
           return result;
@@ -79,7 +81,8 @@ async function readBattery(device, zclNode) {
       try {
         const attrs = await ep1.clusters.genPowerCfg.readAttributes(['batteryVoltage']);
         if (attrs && typeof attrs.batteryVoltage === 'number') {
-          result.voltage = attrs.batteryVoltage / 10; // Zigbee: 0.1V units → V
+          result.voltage = UnifiedBatteryHandler.normalizeVoltage(attrs.batteryVoltage);
+          if (result.voltage === null) throw new Error(`Unsupported batteryVoltage format: ${attrs.batteryVoltage}`);
           result.percent = voltageToPercent(result.voltage);
           result.source = 'cluster_0x0001_voltage';
           device.log(`[BATTERY-READER] ✅ Read batteryVoltage: ${attrs.batteryVoltage} → ${result.voltage}V (${result.percent}%)`);
@@ -97,8 +100,8 @@ async function readBattery(device, zclNode) {
     }
 
     // METHOD 3: Stored value fallback (previous successful read)
-    const storedBattery = device.getStoreValue('last_battery_percent');
-    if (storedBattery !== null && storedBattery !== undefined && storedBattery > 0) {
+    const storedBattery = getStoredBattery(device);
+    if (storedBattery !== null && storedBattery > 0) {
       result.percent = storedBattery;
       result.source = 'stored_value';
       device.log(`[BATTERY-READER] ℹ️  Using stored battery value: ${result.percent}%`);
@@ -136,14 +139,26 @@ async function readBattery(device, zclNode) {
  * @returns {number} - Percentage 0-100
  */
 function voltageToPercent(voltage) {
-  if (!voltage || voltage <= 0) return 0;
+  const normalizedVoltage = UnifiedBatteryHandler.normalizeVoltage(voltage);
+  if (normalizedVoltage === null) return 0;
+  return UnifiedBatteryHandler.calculateFromVoltage(normalizedVoltage, 'CR2032');
+}
 
-  // Standard CR2032 curve: 3.0V (full) to 2.0V (empty)
-  const vMax = 3.0;
-  const vMin = 2.0;
-
-  const percent = Math.min(100, Math.max(0, Math.round((voltage - vMin) * 100 / (vMax - vMin))));
-  return percent;
+function getStoredBattery(device) {
+  const keys = [
+    'last_battery_percentage',
+    'last_battery_percent',
+    'lastBatteryPercentage',
+    'battery_percentage',
+    'batteryPercent',
+    'batteryLevel',
+    'battery',
+  ];
+  for (const key of keys) {
+    const normalized = UnifiedBatteryHandler.normalizeStoredBattery(device.getStoreValue?.(key));
+    if (normalized !== null) return normalized;
+  }
+  return null;
 }
 
 /**

--- a/scripts/ci/check-button-flow-routing.js
+++ b/scripts/ci/check-button-flow-routing.js
@@ -522,6 +522,30 @@ function validateIssue439Ts1201IrRouting() {
   }
 }
 
+function validateUnifiedBatteryCascade() {
+  const handlerPath = path.join(ROOT, 'lib', 'battery', 'UnifiedBatteryHandler.js');
+  const source = fs.existsSync(handlerPath) ? fs.readFileSync(handlerPath, 'utf8') : '';
+  const requiredSnippets = [
+    'BATTERY_CORE_PERCENT_DPS = [4, 15, 101]',
+    'BATTERY_EXTENDED_PERCENT_DPS = [10, 21, 100, 102, 104, 105, 121]',
+    'BATTERY_PROFILE_ONLY_PERCENT_DPS = [2, 7, 13]',
+    'BATTERY_STATE_DPS = [3, 14]',
+    'const VOLTAGE_DPS = [33, 35, 247]',
+    'normalizeTuyaBatteryValue',
+    'normalizeVoltage',
+    'normalizeStoredBattery',
+    'STORED_BATTERY_KEYS',
+    'raw <= 2 && !profileMatches',
+    'getTuyaBatteryDPs({ profile: this._profile })',
+  ];
+
+  for (const snippet of requiredSnippets) {
+    if (!source.includes(snippet)) {
+      addError('UnifiedBatteryHandler', 'Unified battery cascade lost historical fallback coverage', { snippet });
+    }
+  }
+}
+
 function run() {
   const helperPath = path.join(ROOT, 'lib', 'FlowCardHelper.js');
   const helperText = fs.existsSync(helperPath) ? fs.readFileSync(helperPath, 'utf8') : '';
@@ -539,6 +563,7 @@ function run() {
   validateSwitchButtonCapabilityFallback();
   validateButtonRuntimeCoverage();
   validateIssue439Ts1201IrRouting();
+  validateUnifiedBatteryCascade();
 
   const driverDirs = fs.readdirSync(DRIVERS_DIR, { withFileTypes: true })
     .filter(entry => entry.isDirectory())

--- a/test/critical/unified-battery-cascade.test.js
+++ b/test/critical/unified-battery-cascade.test.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const assert = require('assert');
+const UnifiedBatteryHandler = require('../../lib/battery/UnifiedBatteryHandler');
+
+describe('unified battery cascade', function() {
+  it('keeps the merged Tuya battery DP matrix explicit and conflict-aware', function() {
+    const dps = UnifiedBatteryHandler.getTuyaBatteryDPs();
+
+    for (const dp of [3, 4, 10, 14, 15, 21, 100, 101, 102, 104, 105, 121]) {
+      assert(dps.includes(dp), `DP${dp} must stay in the common battery cascade`);
+    }
+
+    assert(!dps.includes(2), 'DP2 must remain profile-only because it often carries humidity/position');
+    assert(!dps.includes(7), 'DP7 must remain profile-only because it often carries luminance/valve battery');
+    assert(UnifiedBatteryHandler.getTuyaBatteryDPs({ includeProfileOnly: true }).includes(2));
+    assert.deepStrictEqual(UnifiedBatteryHandler.getTuyaVoltageDPs(), [33, 35, 247]);
+  });
+
+  it('normalizes ZCL 0-200 values without losing sentinel handling', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(200), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(200, { treat200AsSentinel: true }), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(150), 75);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(255), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(0xFFFF), null);
+  });
+
+  it('normalizes Tuya DP percent, enum, boolean-low, profile-only, and voltage forms', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 0), 10);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 1), 50);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 2), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, true, { stateMode: 'low_bool' }), 10);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, false, { stateMode: 'low_bool' }), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(15, 200), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(121, 88), 88);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(102, 1), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(2, 77), null);
+    assert.strictEqual(
+      UnifiedBatteryHandler.normalizeTuyaBatteryValue(2, 77, { profile: { dpId: 2, algorithm: 'direct' } }),
+      77
+    );
+    const voltagePercent = UnifiedBatteryHandler.normalizeTuyaBatteryValue(33, 3000);
+    assert(voltagePercent >= 90 && voltagePercent <= 100, `3.0V should resolve near full battery, got ${voltagePercent}`);
+  });
+
+  it('accepts historical voltage formats used by ZCL and Tuya DP devices', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(3000), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(1500), 1.5);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(300), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(30), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(20), 2);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(3), 3);
+  });
+
+  it('restores old app store keys before falling back to estimates', async function() {
+    const values = {};
+    const store = {
+      batteryPercent: '84',
+      battery_voltage_mv: 3000,
+    };
+    const device = {
+      getStoreValue: key => store[key],
+      getCapabilityValue: () => null,
+      hasCapability: cap => cap === 'measure_battery',
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+      log: () => {},
+      error: () => {},
+    };
+    const handler = new UnifiedBatteryHandler(device);
+
+    await handler._restoreStoredBattery();
+
+    assert.strictEqual(values.measure_battery, 84);
+    assert.strictEqual(handler.lastValue, 84);
+    assert.strictEqual(handler.lastVoltage, 3);
+  });
+
+  it('uses a marked 50 percent estimate when no real battery value exists yet', function() {
+    const values = {};
+    const store = {};
+    const device = {
+      getStoreValue: key => store[key],
+      setStoreValue: async (key, value) => {
+        store[key] = value;
+      },
+      getCapabilityValue: () => null,
+      hasCapability: cap => cap === 'measure_battery',
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+      emit: () => {},
+      log: () => {},
+      error: () => {},
+    };
+    const handler = new UnifiedBatteryHandler(device);
+
+    handler._setDefaultBattery();
+
+    assert.strictEqual(values.measure_battery, 50);
+    assert.strictEqual(store.last_battery_estimated, true);
+    assert.strictEqual(store.last_battery_source, 'estimated-default');
+  });
+});


### PR DESCRIPTION
## What changed

- Unified the historical battery fallback cascade across `UnifiedBatteryHandler`, `TuyaUnifiedDevice`, `SmartBatteryManager`, `BatteryRouter`, legacy converters, and battery reader helpers.
- Added support for the old and current Tuya/ZCL battery modes: ZCL 0-200, Tuya percent DPs, DP14/DP3 enum or low-battery state, voltage DPs 33/35/247, old store keys, and marked estimated fallback values.
- Kept ambiguous DPs such as DP2/DP7/DP13 profile-only so humidity, luminance, valve, and position values are not hijacked as battery globally.
- Added CI/runtime guard coverage and targeted Mocha tests for the cascade.

## Why

The app had several battery implementations from older pushes that were only partially merged into the current runtime. Buttons had the newest cascade, but generic Tuya/TS0601 helpers could still miss battery reports, misread voltage units, or leave Homey showing an unknown battery value.

## Validation

- `npm test`
- `npm run precommit`
- `npm run validate:recursive`
- `npm run validate:publish`
- `npm run check:button-flows`