### PR TITLE
Fix battery cascade for local and legacy devices

### DIFF
--- a/lib/battery/UnifiedBatteryHandler.js
+++ b/lib/battery/UnifiedBatteryHandler.js
@@ -26,10 +26,38 @@
  */
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// BATTERY DPs (Tuya) — v5.8.69 unified list
+// BATTERY DPs (Tuya) — merged from historic app versions, Z2M/ZHA patterns,
+// Homey forum diagnostics, and issue #439 follow-up work.
 // ═══════════════════════════════════════════════════════════════════════════════
-const BATTERY_DPS = [4, 10, 14, 15, 21, 100, 101, 102, 104, 105];
+const BATTERY_CORE_PERCENT_DPS = [4, 15, 101];
+const BATTERY_EXTENDED_PERCENT_DPS = [10, 21, 100, 102, 104, 105, 121];
+const BATTERY_PROFILE_ONLY_PERCENT_DPS = [2, 7, 13];
+const BATTERY_PERCENT_DPS = [
+  ...BATTERY_CORE_PERCENT_DPS,
+  ...BATTERY_EXTENDED_PERCENT_DPS,
+];
+const BATTERY_STATE_DPS = [3, 14];
+const BATTERY_DPS = [
+  ...BATTERY_PERCENT_DPS,
+  ...BATTERY_STATE_DPS,
+];
 const VOLTAGE_DPS = [33, 35, 247];
+const STORED_BATTERY_KEYS = [
+  'last_battery_percentage',
+  'last_battery_percent',
+  'lastBatteryPercentage',
+  'battery_percentage',
+  'batteryPercent',
+  'batteryLevel',
+  'battery',
+];
+const STORED_VOLTAGE_KEYS = [
+  'battery_voltage',
+  'batteryVoltage',
+  'last_battery_voltage',
+  'lastBatteryVoltage',
+  'battery_voltage_mv',
+];
 
 // v1.0: Battery Health Intelligence integration
 let BatteryHealthIntelligence;
@@ -361,6 +389,101 @@ class UnifiedBatteryHandler {
     return null;
   }
 
+  static getTuyaBatteryDPs(options = {}) {
+    const dps = new Set(BATTERY_DPS);
+    const profile = options.profile || null;
+
+    if (profile?.dpId !== null && profile?.dpId !== undefined) {
+      dps.add(Number(profile.dpId));
+    }
+    if (profile?.dpIdState !== null && profile?.dpIdState !== undefined) {
+      dps.add(Number(profile.dpIdState));
+    }
+    if (options.includeProfileOnly === true) {
+      for (const dp of BATTERY_PROFILE_ONLY_PERCENT_DPS) {
+        dps.add(dp);
+      }
+    }
+
+    return [...dps]
+      .filter(dp => Number.isFinite(dp) && dp > 0)
+      .sort((a, b) => a - b);
+  }
+
+  static getTuyaVoltageDPs() {
+    return [...VOLTAGE_DPS];
+  }
+
+  static isTuyaBatteryDP(dp, options = {}) {
+    return UnifiedBatteryHandler.getTuyaBatteryDPs(options).includes(Number(dp));
+  }
+
+  static isTuyaVoltageDP(dp) {
+    return VOLTAGE_DPS.includes(Number(dp));
+  }
+
+  static coerceNumericValue(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'boolean') return value ? 1 : 0;
+    if (typeof value === 'number') {
+      if (Number.isFinite(value)) return value;
+      return null;
+    }
+    if (typeof value === 'string' && value.trim() !== '') {
+      const numeric = Number(value);
+      return Number.isFinite(numeric) ? numeric : null;
+    }
+    if (Buffer.isBuffer(value)) {
+      if (value.length === 0) return null;
+      if (value.length <= 4) return value.readUIntBE(0, value.length);
+      return value[value.length - 1];
+    }
+    if (Array.isArray(value)) {
+      return UnifiedBatteryHandler.coerceNumericValue(Buffer.from(value));
+    }
+    if (typeof value === 'object') {
+      return UnifiedBatteryHandler.coerceNumericValue(value.value ?? value.dpValue ?? value.data ?? value.raw);
+    }
+    return null;
+  }
+
+  static normalizeVoltage(rawVoltage) {
+    const raw = UnifiedBatteryHandler.coerceNumericValue(rawVoltage);
+    if (!Number.isFinite(raw) || raw <= 0) return null;
+
+    if (raw >= 800 && raw <= 6000) return raw / 1000;
+    if (raw > 100 && raw <= 600) return raw / 100;
+    if (raw >= 20 && raw <= 60) return raw / 10;
+    if (raw >= 0.8 && raw <= 15) return raw;
+    return null;
+  }
+
+  static normalizeStoredBattery(value) {
+    const numeric = UnifiedBatteryHandler.coerceNumericValue(value);
+    if (!Number.isFinite(numeric)) return null;
+    if (numeric === 255 || numeric === 0xFFFF || numeric < 0 || numeric > 200) return null;
+    return numeric > 100 ? Math.round(numeric / 2) : Math.round(numeric);
+  }
+
+  static normalizeBatteryType(batteryType) {
+    if (!batteryType) return 'CR2032';
+    const key = String(batteryType).trim();
+    const aliases = {
+      cr2032: 'CR2032',
+      cr2450: 'CR2450',
+      cr123a: 'CR123A',
+      aaa: 'AAA',
+      aaa_alkaline: '2xAAA',
+      aa: 'AA',
+      aa_alkaline: '2xAA',
+      lipo: 'Li-ion',
+      li_ion: 'Li-ion',
+      lithium_ion: 'Li-ion',
+      unknown: 'CR2032',
+    };
+    return aliases[key.toLowerCase()] || key;
+  }
+
   /**
    * v5: Calculate percentage from voltage — interpolation sur courbes + température
    * @param {number} voltage - Tension en volts
@@ -369,7 +492,8 @@ class UnifiedBatteryHandler {
    * @returns {number} Pourcentage 0-100
    */
   static calculateFromVoltage(voltage, batteryType = 'CR2032', temperature = 20) {
-    const specs = UnifiedBatteryHandler.BATTERY_SPECS[batteryType];
+    const normalizedType = UnifiedBatteryHandler.normalizeBatteryType(batteryType);
+    const specs = UnifiedBatteryHandler.BATTERY_SPECS[normalizedType];
     if (!specs) {
       // Fallback sécurisé CR2032
       return UnifiedBatteryHandler.calculateFromVoltage(voltage, 'CR2032', temperature);
@@ -405,11 +529,25 @@ class UnifiedBatteryHandler {
   /**
    * v5: Convertir Tuya DP value en pourcentage selon l'algorithme du profil
    */
-  static calculateFromTuyaDP(dpValue, algorithm = 'direct') {
+  static calculateFromTuyaDP(dpValue, algorithm = 'direct', options = {}) {
     if (dpValue === null || dpValue === undefined || isNaN(dpValue)) return null;
     switch (algorithm) {
       case 'multiply_2': return Math.round(Math.max(0, Math.min(100, dpValue * 2)));
       case 'divide_2': return Math.round(Math.max(0, Math.min(100, dpValue / 2)));
+      case 'div2': return Math.round(Math.max(0, Math.min(100, dpValue / 2)));
+      case 'enum3':
+      case 'battery_state':
+        return { 0: 10, 1: 50, 2: 100 }[Number(dpValue)] ?? null;
+      case 'enum4':
+        return { 0: 5, 1: 20, 2: 60, 3: 100 }[Number(dpValue)] ?? null;
+      case 'low_bool':
+        return Number(dpValue) ? 10 : 100;
+      case 'millivolt':
+      case 'mv': {
+        const voltage = UnifiedBatteryHandler.normalizeVoltage(dpValue);
+        const batteryType = options.batteryType || options.chemistry || 'CR2032';
+        return voltage === null ? null : UnifiedBatteryHandler.calculateFromVoltage(voltage, batteryType, options.temperature);
+      }
       case 'direct':
       default: return Math.round(Math.max(0, Math.min(100, dpValue)));
     }
@@ -418,26 +556,84 @@ class UnifiedBatteryHandler {
   // Z2M #11470: Manufacturers that legitimately use value 200 (not a sentinel)
   static BATTERY_200_WHITELIST = new Set(['_TZ3000_lqmvrwa2']);
 
+  static normalizeTuyaBatteryValue(dp, value, options = {}) {
+    const dpId = Number(dp);
+    const raw = UnifiedBatteryHandler.coerceNumericValue(value);
+    if (!Number.isFinite(dpId) || !Number.isFinite(raw)) return null;
+
+    const profile = options.profile || null;
+    const lastValue = options.lastValue === null || options.lastValue === undefined
+      ? null
+      : Number(options.lastValue);
+    const hasLastValue = Number.isFinite(lastValue);
+    const profileMatches =
+      Number(profile?.dpId) === dpId ||
+      Number(profile?.dpIdState) === dpId ||
+      options.profileMatch === true;
+    const stateMode = options.stateMode || profile?.stateMode || null;
+
+    if (UnifiedBatteryHandler.isTuyaVoltageDP(dpId)) {
+      const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+      if (voltage === null) return null;
+      const batteryType = options.batteryType || profile?.chemistry || 'CR2032';
+      return UnifiedBatteryHandler.calculateFromVoltage(voltage, batteryType, options.temperature);
+    }
+
+    if (BATTERY_STATE_DPS.includes(dpId) || (profileMatches && profile?.algorithm === 'enum3')) {
+      if (typeof value === 'boolean' || stateMode === 'low_bool' || profile?.algorithm === 'low_bool') {
+        if (raw === 1) return 10;
+        return hasLastValue ? Math.max(20, Math.round(lastValue)) : 100;
+      }
+      if (raw >= 0 && raw <= 2) {
+        return raw === 0 ? 10 : raw === 1 ? 50 : 100;
+      }
+      return null;
+    }
+
+    if (raw === 255 || raw === 0xFFFF || raw < 0) return null;
+
+    if (profileMatches && profile?.algorithm) {
+      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(raw, profile.algorithm, {
+        batteryType: options.batteryType || profile.chemistry,
+        temperature: options.temperature,
+      });
+      if (profileResult !== null) return profileResult;
+    }
+
+    const percentDp =
+      BATTERY_PERCENT_DPS.includes(dpId) ||
+      (profileMatches && BATTERY_PROFILE_ONLY_PERCENT_DPS.includes(dpId));
+    if (!percentDp) return null;
+
+    if (BATTERY_EXTENDED_PERCENT_DPS.includes(dpId) && raw <= 2 && !profileMatches) {
+      return null;
+    }
+    if (raw > 200) return null;
+
+    return raw > 100 ? Math.round(raw / 2) : Math.round(raw);
+  }
+
   static normalizeZigbeeValue(rawValue, options = {}) {
     if (rawValue === null || rawValue === undefined || isNaN(rawValue)) return null;
-    const treat200AsSentinel = options.treat200AsSentinel !== false; // default true
+    const treat200AsSentinel = options.treat200AsSentinel === true;
     const manufacturer = options.manufacturer || '';
+
+    // v9.0.89: Filter ZCL sentinels before voltage heuristics.
+    // 255 must stay "unknown", not become a fake 2.55V battery reading.
+    if (rawValue === 255 || rawValue === 0xFFFF) return null;  // 255/65535 = unknown/invalid
+    if (rawValue === 200) {
+        // Z2M pattern: filter 200 only for profiles that explicitly mark it unavailable.
+        if (treat200AsSentinel && !UnifiedBatteryHandler.BATTERY_200_WHITELIST.has(manufacturer)) {
+            return null; // 200 = "not available" sentinel
+        }
+        return 100; // ZCL standard 200 = 100%
+    }
 
     // v9.0.87: Smart Heuristic for Voltage sent as Percentage (Z2M/ZHA quirk)
     // Some sensors send 3000 (meaning 3000mV) in the percentage attribute
     if (rawValue > 200 && rawValue < 4000) {
         const voltage = rawValue > 1000 ? rawValue / 1000 : rawValue / 10;
         return UnifiedBatteryHandler.calculateFromVoltage(voltage, options.batteryType || 'CR2032');
-    }
-
-    // v9.0.87: Filter ZCL sentinels (Z2M #11470)
-    if (rawValue === 255 || rawValue === 0xFFFF) return null;  // 255/65535 = unknown/invalid
-    if (rawValue === 200) {
-        // Z2M pattern: filter 200 when batteryVoltage < 30, except whitelisted manufacturers
-        if (treat200AsSentinel && !UnifiedBatteryHandler.BATTERY_200_WHITELIST.has(manufacturer)) {
-            return null; // 200 = "not available" sentinel
-        }
-        return 100; // ZCL standard 200 = 100%
     }
 
     // v9.0.87: 0-50 scale anomaly (TZE200_vvmbj46n and similar)
@@ -701,9 +897,19 @@ class UnifiedBatteryHandler {
 
   async _restoreStoredBattery() {
     try {
-      const stored = await this.device.getStoreValue?.('last_battery_percentage');
-      const storedVoltage = await this.device.getStoreValue?.('battery_voltage');
-      if (stored !== null && stored !== undefined && typeof stored === 'number') {
+      let stored = null;
+      for (const key of STORED_BATTERY_KEYS) {
+        stored = UnifiedBatteryHandler.normalizeStoredBattery(await this.device.getStoreValue?.(key));
+        if (stored !== null) break;
+      }
+
+      let storedVoltage = null;
+      for (const key of STORED_VOLTAGE_KEYS) {
+        storedVoltage = UnifiedBatteryHandler.normalizeVoltage(await this.device.getStoreValue?.(key));
+        if (storedVoltage !== null) break;
+      }
+
+      if (stored !== null) {
         const current = this.device.getCapabilityValue?.('measure_battery');
         if (current === null || current === undefined) {
           this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${stored}%`);
@@ -713,7 +919,7 @@ class UnifiedBatteryHandler {
           }
         }
       }
-      if (storedVoltage !== null && storedVoltage !== undefined) {
+      if (storedVoltage !== null) {
         this.lastVoltage = storedVoltage;
       }
     } catch { /* ignore */ }
@@ -760,16 +966,22 @@ class UnifiedBatteryHandler {
         if (cluster) {
           const attrs = await cluster.readAttributes(['batteryPercentageRemaining', 'batteryVoltage']).catch(() => ({}));
           if (attrs.batteryPercentageRemaining !== undefined) {
-            const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining);
-            if (percent !== null) this._updateBattery(percent);
+            const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining, {
+              batteryType: this.batteryType,
+              treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+            });
+            if (percent !== null) this._updateBattery(percent, false, { source: 'poll-zcl-percentage', estimated: false });
           }
           if (attrs.batteryVoltage !== undefined) {
-            this._updateVoltage(attrs.batteryVoltage / 10);
+            const voltage = UnifiedBatteryHandler.normalizeVoltage(attrs.batteryVoltage);
+            if (voltage !== null) this._updateVoltage(voltage);
           }
         }
       }
       if (this.source?.includes('tuya') && this.device.tuyaEF00Manager) {
-        await this.device.tuyaEF00Manager.requestDP(4).catch(() => {});
+        for (const dp of UnifiedBatteryHandler.getTuyaBatteryDPs({ profile: this._profile })) {
+          await this.device.tuyaEF00Manager.requestDP(dp).catch(() => {});
+        }
       }
     } catch { /* silent (sleeping device) */ }
   }
@@ -856,25 +1068,33 @@ class UnifiedBatteryHandler {
       try {
         const attrs = await cluster.readAttributes(['batteryPercentageRemaining', 'batteryVoltage']);
         if (attrs.batteryPercentageRemaining !== undefined) {
-          const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining);
+          const percent = UnifiedBatteryHandler.normalizeZigbeeValue(attrs.batteryPercentageRemaining, {
+            batteryType: this.batteryType,
+            treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+          });
           if (percent !== null) {
-            this._updateBattery(percent);
+            this._updateBattery(percent, false, { source: 'zcl-read-percentage', estimated: false });
           }
         }
         if (attrs.batteryVoltage !== undefined) {
-          this._updateVoltage(attrs.batteryVoltage / 10);
+          const voltage = UnifiedBatteryHandler.normalizeVoltage(attrs.batteryVoltage);
+          if (voltage !== null) this._updateVoltage(voltage);
         }
       } catch { /* normal for sleeping */ }
 
       cluster.on('attr.batteryPercentageRemaining', (value) => {
-        const percent = UnifiedBatteryHandler.normalizeZigbeeValue(value);
+        const percent = UnifiedBatteryHandler.normalizeZigbeeValue(value, {
+          batteryType: this.batteryType,
+          treat200AsSentinel: this._profile?.zcl200IsPercent === false,
+        });
         if (percent !== null) {
-          this._updateBattery(percent);
+          this._updateBattery(percent, false, { source: 'zcl-report-percentage', estimated: false });
         }
       });
 
       cluster.on('attr.batteryVoltage', (value) => {
-        this._updateVoltage(value / 10);
+        const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+        if (voltage !== null) this._updateVoltage(voltage);
       });
 
       try {
@@ -936,16 +1156,12 @@ class UnifiedBatteryHandler {
     }
 
     this.device.log(`[BATTERY-UNIFIED] 🔶 Tuya DP${dp}: ${percent}%`);
-    this._updateBattery(percent);
+    this._updateBattery(percent, false, { source: `tuya-dp-${dp}`, estimated: false });
   }
 
   _handleTuyaVoltageDP(dp, value) {
-    let voltage = value;
-    if (dp === 247) { voltage = value / 1000; }
-    else if (value > 100) { voltage = value / 100; }
-    else if (value > 10) { voltage = value / 10; }
-
-    if (voltage > 0 && voltage < 20) {
+    const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+    if (voltage !== null) {
       this.device.log(`[BATTERY-UNIFIED] 🔶 Tuya voltage DP${dp}: ${voltage}V`);
       this._updateVoltage(voltage);
     }
@@ -980,7 +1196,7 @@ class UnifiedBatteryHandler {
       this.device.log(`[BATTERY-UNIFIED] 🔋 Battery alarm: ${isLow ? 'LOW' : 'OK'}`);
     }
     if (isLow && this.device.hasCapability?.('measure_battery') && this.lastValue === null) {
-      this._updateBattery(5);
+      this._updateBattery(5, true, { source: 'ias-low-alarm-estimate', estimated: true });
     }
   }
 
@@ -992,10 +1208,22 @@ class UnifiedBatteryHandler {
     if (this.device.hasCapability?.('measure_battery')) {
       const current = this.device.getCapabilityValue?.('measure_battery');
       if (current === null || current === undefined) {
-        const stored = this.device.getStoreValue?.('last_battery_percentage');
-        if (stored !== null && stored !== undefined && typeof stored === 'number') {
-          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${stored}%`);
-          this._updateBattery(stored, true);
+        let storedPercent = null;
+        for (const key of STORED_BATTERY_KEYS) {
+          storedPercent = UnifiedBatteryHandler.normalizeStoredBattery(this.device.getStoreValue?.(key));
+          if (storedPercent !== null) break;
+        }
+        if (storedPercent !== null) {
+          this.device.log(`[BATTERY-UNIFIED] 🔄 Restored stored battery: ${storedPercent}%`);
+          this._updateBattery(storedPercent, true, {
+            source: 'stored',
+            estimated: this.device.getStoreValue?.('last_battery_estimated') === true,
+          });
+        } else {
+          this.device.log('[BATTERY-UNIFIED] 🔋 No stored battery, using marked 50% estimate until first report');
+          this.device.setStoreValue?.('last_battery_estimated', true).catch(() => {});
+          this.device.setStoreValue?.('last_battery_source', 'estimated-default').catch(() => {});
+          this._updateBattery(50, true, { source: 'estimated-default', estimated: true });
         }
       }
     }
@@ -1005,27 +1233,41 @@ class UnifiedBatteryHandler {
   // v8: _updateBattery + v5: Smoothing (EMA), Health, Anti-flood
   // ═════════════════════════════════════════════════════════════════════════════
 
-  _updateBattery(percent, force = false) {
+  _updateBattery(percent, force = false, meta = {}) {
+    if (force && typeof force === 'object') {
+      meta = force;
+      force = meta.force === true;
+    }
+
+    const numericPercent = Number(percent);
+    if (!Number.isFinite(numericPercent)) {return;}
+
+    const source = meta.source || null;
+    const hasEstimatedFlag = Object.prototype.hasOwnProperty.call(meta, 'estimated');
+    const isEstimated = meta.estimated === true;
+    const percentValue = Math.max(0, Math.min(100, Math.round(numericPercent)));
     const prev = this.device.getCapabilityValue?.('measure_battery');
 
     // Anti-flood & Anti-fluctuation (v8 & v9.0.86)
     if (!force) {
-      if (prev === percent) {return;}
+      if (prev === percentValue) {return;}
       const now = Date.now();
       const elapsed = now - this._lastBattUpdate;
-      const change = prev !== null ? Math.abs(percent - prev) : 100;
+      const previous = Number(prev);
+      const hasPrevious = prev !== null && prev !== undefined && Number.isFinite(previous);
+      const change = hasPrevious ? Math.abs(percentValue - previous) : 100;
       
       // v9.0.87: Reject sudden >50% drops/spikes unless value is 0 (dead battery)
       // Also trigger flow card for user notification (battery anomaly detection)
-      if (prev !== null && change > 50 && percent > 0 && elapsed < 86400000) {
-        this.device.log(`[BATTERY-UNIFIED] ⚠️ Rejected abnormal battery fluctuation: ${prev}% -> ${percent}%`);
+      if (hasPrevious && change > 50 && percentValue > 0 && elapsed < 86400000) {
+        this.device.log(`[BATTERY-UNIFIED] ⚠️ Rejected abnormal battery fluctuation: ${prev}% -> ${percentValue}%`);
         // Trigger battery anomaly flow card (if registered) — fire-and-forget
         try {
           const card = this.device.homey.flow.getDeviceTriggerCard('battery_anomaly_detected');
           if (card) {
             card.trigger(this.device, {
               previous_value: prev,
-              current_value: percent,
+              current_value: percentValue,
               change: change,
               elapsed_seconds: Math.round(elapsed / 1000),
             }).catch(() => {});
@@ -1039,7 +1281,7 @@ class UnifiedBatteryHandler {
     }
 
     // v5: Exponential Moving Average smoothing
-    const smoothed = this._applySmoothing(percent, force);
+    const smoothed = this._applySmoothing(percentValue, force);
 
     this.lastValue = smoothed;
 
@@ -1054,6 +1296,13 @@ class UnifiedBatteryHandler {
 
     // v5: Store periodically (defensive)
     this.device.setStoreValue?.('last_battery_percentage', Math.round(smoothed)).catch(() => {});
+    this.device.setStoreValue?.('last_battery_time', Date.now()).catch(() => {});
+    if (source) {
+      this.device.setStoreValue?.('last_battery_source', source).catch(() => {});
+    }
+    if (hasEstimatedFlag) {
+      this.device.setStoreValue?.('last_battery_estimated', isEstimated).catch(() => {});
+    }
 
     // v1.0: Feed to Battery Health Intelligence
     this._updateBatteryHealthIntelligence(smoothed);
@@ -1137,7 +1386,7 @@ class UnifiedBatteryHandler {
     if (this.lastValue === null && voltage > 0) {
       const percent = UnifiedBatteryHandler.calculateFromVoltage(voltage, this.batteryType, this.temperature);
       if (percent !== null) {
-        this._updateBattery(percent);
+        this._updateBattery(percent, false, { source: 'voltage-derived', estimated: false });
       }
     }
   }
@@ -1454,13 +1703,30 @@ class UnifiedBatteryHandler {
    * Called before updating battery to handle common reporting inconsistencies
    */
   _normalizeBatteryValue(value, dpId = null) {
+    const normalized = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dpId, value, {
+      profile: this._profile,
+      profileMatch: this._profile &&
+        (Number(this._profile.dpId) === Number(dpId) || Number(this._profile.dpIdState) === Number(dpId)),
+      batteryType: this.batteryType,
+      lastValue: this.lastValue,
+      temperature: this.temperature,
+    });
+    if (normalized !== null) return normalized;
+
     if (value === null || value === undefined || typeof value !== 'number') {
       return value;
     }
 
+    if (value === 255 || value === 0xFFFF || value < 0) {
+      return null;
+    }
+
     // Check profile-specific algorithm first
     if (this._profile && this._profile.algorithm) {
-      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(value, this._profile.algorithm);
+      const profileResult = UnifiedBatteryHandler.calculateFromTuyaDP(value, this._profile.algorithm, {
+        batteryType: this.batteryType || this._profile.chemistry,
+        temperature: this.temperature,
+      });
       if (profileResult !== null) {
         this.device.log(`[BATTERY-NORM] Profile algorithm '${this._profile.algorithm}': ${value} -> ${profileResult}`);
         return profileResult;

--- a/lib/tuya-local/TuyaLocalDevice.js
+++ b/lib/tuya-local/TuyaLocalDevice.js
@@ -10,6 +10,13 @@ const { getDeviceCache, removeDeviceCache } = require('../managers/DPCache');
 const { smartParse } = require('../managers/SmartDivisorManager');
 const { allowsCloudFallback, normalizeWiFiConnectionPolicy } = require('../wifi/WiFiConnectionPolicy');
 
+let UnifiedBatteryHandler;
+try {
+  UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
+} catch (_e) {
+  UnifiedBatteryHandler = null;
+}
+
 class TuyaLocalDevice extends Homey.Device {
   /** Override: capability-to-DP mappings [{capability, dp, toDevice, fromDevice}] */
   get capabilityMap() {
@@ -30,21 +37,7 @@ class TuyaLocalDevice extends Homey.Device {
               if (cfg.multiplier) {return v / cfg.multiplier;}
               return v;
             }),
-            fromDevice: cfg.transform || ((v) => {
-              // v9.0.40: SmartDivisorManager auto-detection for WiFi devices
-              // Fixes 1000x energy bug (raw kWh*100 values shown as-is)
-              if (cfg.smartDivisor === true) {
-                return smartParse(v, dpNum, {
-                  manufacturerName: this.getSetting?.('zb_manufacturer_name') || '',
-                  capability: cfg.capability,
-                  deviceId: this.getData?.()?.id || '',
-                  protocol: 'wifi',
-                });
-              }
-              if (cfg.divisor) {return v / cfg.divisor;}
-              if (cfg.multiplier) {return v * cfg.multiplier;}
-              return v;
-            })
+            fromDevice: (v) => this._fromDeviceValue(cfg.capability, dpNum, cfg, v)
           });
         }
       }
@@ -302,13 +295,97 @@ class TuyaLocalDevice extends Homey.Device {
     for (const cap of this.capabilityMap) {
       if (data.dps[cap.dp] !== undefined) {
         const value = cap.fromDevice ? cap.fromDevice(data.dps[cap.dp]) : data.dps[cap.dp];
-        await this.safeSetCapabilityValue(cap.capability, value).catch(this.error);
+        if (cap.capability === 'measure_battery' && (value === null || value === undefined)) {
+          this.log(`[WIFI-BATTERY] Ignored invalid DP${cap.dp} battery value: ${data.dps[cap.dp]}`);
+          continue;
+        }
+        await this._setLocalCapabilityValue(cap.capability, value).catch(this.error);
+        if (cap.capability === 'measure_battery') {
+          await this.setStoreValue?.('last_battery_percentage', Math.round(Number(value))).catch(() => {});
+          await this.setStoreValue?.('last_battery_time', Date.now()).catch(() => {});
+          await this.setStoreValue?.('last_battery_source', `wifi-dp-${cap.dp}`).catch(() => {});
+          await this.setStoreValue?.('last_battery_estimated', false).catch(() => {});
+        }
       }
     }
   }
 
   async _processDPUpdate(_dps) {
     // Optional subclass hook for generic/raw DP drivers.
+  }
+
+  _fromDeviceValue(capability, dp, cfg, rawValue) {
+    if (capability === 'measure_battery') {
+      return this._normalizeLocalBatteryValue(dp, rawValue, cfg);
+    }
+
+    if (cfg.transform) return cfg.transform(rawValue);
+    if (cfg.smartDivisor === true) {
+      return smartParse(rawValue, dp, {
+        manufacturerName: this.getSetting?.('zb_manufacturer_name') || '',
+        capability: cfg.capability,
+        deviceId: this.getData?.()?.id || '',
+        protocol: 'wifi',
+      });
+    }
+    if (cfg.divisor) {return rawValue / cfg.divisor;}
+    if (cfg.multiplier) {return rawValue * cfg.multiplier;}
+    return rawValue;
+  }
+
+  _normalizeLocalBatteryValue(dp, rawValue, cfg = {}) {
+    if (!UnifiedBatteryHandler) {
+      const numeric = Number(rawValue);
+      if (!Number.isFinite(numeric) || numeric < 0 || numeric > 200 || numeric === 255 || numeric === 0xFFFF) {
+        return null;
+      }
+      return numeric > 100 ? Math.round(numeric / 2) : Math.round(numeric);
+    }
+
+    const transformed = cfg.transform ? cfg.transform(rawValue) : rawValue;
+    const settings = this.getSettings?.() || {};
+    const store = this.getStore?.() || {};
+    const data = this.getData?.() || {};
+    const manufacturer = cfg.manufacturerName ||
+      settings.zb_manufacturer_name ||
+      settings.manufacturerName ||
+      store.manufacturerName ||
+      data.manufacturerName ||
+      '';
+    const modelId = cfg.modelId ||
+      settings.zb_model_id ||
+      settings.modelId ||
+      store.modelId ||
+      data.modelId ||
+      '';
+    const lookedUpProfile = UnifiedBatteryHandler.lookupBatteryProfile?.(manufacturer, modelId);
+    const profile = cfg.batteryProfile || lookedUpProfile || {
+      dpId: Number(dp),
+      algorithm: cfg.batteryAlgorithm || cfg.algorithm || 'direct',
+      chemistry: cfg.batteryType || cfg.chemistry || 'CR2032',
+    };
+
+    const normalized = UnifiedBatteryHandler.normalizeTuyaBatteryValue(Number(dp), transformed, {
+      profile,
+      profileMatch: true,
+      batteryType: cfg.batteryType || profile.chemistry || 'CR2032',
+      lastValue: this.getCapabilityValue?.('measure_battery'),
+      temperature: this.getCapabilityValue?.('measure_temperature') || settings.temperature,
+      stateMode: cfg.stateMode,
+    });
+
+    if (normalized === null) {
+      return UnifiedBatteryHandler.normalizeStoredBattery(transformed);
+    }
+
+    return normalized;
+  }
+
+  async _setLocalCapabilityValue(capability, value) {
+    if (typeof this.safeSetCapabilityValue === 'function') {
+      return this.safeSetCapabilityValue(capability, value);
+    }
+    return this.setCapabilityValue(capability, value);
   }
 
   async _setDP(dp, value) {

--- a/test/critical/unified-battery-cascade.test.js
+++ b/test/critical/unified-battery-cascade.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const assert = require('assert');
+const UnifiedBatteryHandler = require('../../lib/battery/UnifiedBatteryHandler');
+
+describe('unified battery cascade', function() {
+  it('keeps the merged Tuya battery DP matrix explicit and conflict-aware', function() {
+    const dps = UnifiedBatteryHandler.getTuyaBatteryDPs();
+
+    for (const dp of [3, 4, 10, 14, 15, 21, 100, 101, 102, 104, 105, 121]) {
+      assert(dps.includes(dp), `DP${dp} must stay in the common battery cascade`);
+    }
+
+    assert(!dps.includes(2), 'DP2 must remain profile-only because it often carries humidity/position');
+    assert(!dps.includes(7), 'DP7 must remain profile-only because it often carries luminance/valve battery');
+    assert(UnifiedBatteryHandler.getTuyaBatteryDPs({ includeProfileOnly: true }).includes(2));
+    assert.deepStrictEqual(UnifiedBatteryHandler.getTuyaVoltageDPs(), [33, 35, 247]);
+  });
+
+  it('normalizes ZCL 0-200 values without losing sentinel handling', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(200), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(200, { treat200AsSentinel: true }), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(150), 75);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(255), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeZigbeeValue(0xFFFF), null);
+  });
+
+  it('normalizes Tuya DP percent, enum, boolean-low, profile-only, and voltage forms', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 0), 10);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 1), 50);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, 2), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, true, { stateMode: 'low_bool' }), 10);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, false, { stateMode: 'low_bool' }), 100);
+    assert.strictEqual(
+      UnifiedBatteryHandler.normalizeTuyaBatteryValue(14, false, { stateMode: 'low_bool', lastValue: null }),
+      100
+    );
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(15, 200), 100);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(121, 88), 88);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(102, 1), null);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeTuyaBatteryValue(2, 77), null);
+    assert.strictEqual(
+      UnifiedBatteryHandler.normalizeTuyaBatteryValue(2, 77, { profile: { dpId: 2, algorithm: 'direct' } }),
+      77
+    );
+    const voltagePercent = UnifiedBatteryHandler.normalizeTuyaBatteryValue(33, 3000);
+    assert(voltagePercent >= 90 && voltagePercent <= 100, `3.0V should resolve near full battery, got ${voltagePercent}`);
+  });
+
+  it('accepts historical voltage formats used by ZCL and Tuya DP devices', function() {
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(3000), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(1500), 1.5);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(300), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(30), 3);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(20), 2);
+    assert.strictEqual(UnifiedBatteryHandler.normalizeVoltage(3), 3);
+  });
+
+  it('restores old app store keys before falling back to estimates', async function() {
+    const values = {};
+    const store = {
+      batteryPercent: '84',
+      battery_voltage_mv: 3000,
+    };
+    const device = {
+      getStoreValue: key => store[key],
+      getCapabilityValue: () => null,
+      hasCapability: cap => cap === 'measure_battery',
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+      log: () => {},
+      error: () => {},
+    };
+    const handler = new UnifiedBatteryHandler(device);
+
+    await handler._restoreStoredBattery();
+
+    assert.strictEqual(values.measure_battery, 84);
+    assert.strictEqual(handler.lastValue, 84);
+    assert.strictEqual(handler.lastVoltage, 3);
+  });
+
+  it('uses a marked 50 percent estimate when no real battery value exists yet', function() {
+    const values = {};
+    const store = {};
+    const device = {
+      getStoreValue: key => store[key],
+      setStoreValue: async (key, value) => {
+        store[key] = value;
+      },
+      getCapabilityValue: () => null,
+      hasCapability: cap => cap === 'measure_battery',
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+      emit: () => {},
+      log: () => {},
+      error: () => {},
+    };
+    const handler = new UnifiedBatteryHandler(device);
+
+    handler._setDefaultBattery();
+
+    assert.strictEqual(values.measure_battery, 50);
+    assert.strictEqual(store.last_battery_estimated, true);
+    assert.strictEqual(store.last_battery_source, 'estimated-default');
+  });
+
+  it('replaces estimated battery state with real Tuya DP metadata', function() {
+    const values = { measure_battery: 50 };
+    const store = { last_battery_estimated: true };
+    const device = {
+      getStoreValue: key => store[key],
+      setStoreValue: async (key, value) => {
+        store[key] = value;
+      },
+      getCapabilityValue: capability => values[capability] ?? null,
+      hasCapability: cap => cap === 'measure_battery',
+      setCapabilityValue: async (cap, value) => {
+        values[cap] = value;
+      },
+      emit: () => {},
+      log: () => {},
+      error: () => {},
+    };
+    const handler = new UnifiedBatteryHandler(device);
+
+    handler._handleTuyaBatteryDP(15, 86);
+
+    assert.strictEqual(values.measure_battery, 86);
+    assert.strictEqual(store.last_battery_estimated, false);
+    assert.strictEqual(store.last_battery_source, 'tuya-dp-15');
+  });
+});

--- a/test/critical/wifi-local-battery-normalization.test.js
+++ b/test/critical/wifi-local-battery-normalization.test.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('assert');
+
+const Module = require('module');
+const originalLoad = Module._load;
+Module._load = function patchedHomeyLoad(request, parent, isMain) {
+  if (request === 'homey') {
+    return { Device: class {} };
+  }
+  if (request === './TuyaLocalClient') {
+    return class TuyaLocalClientMock {};
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+const TuyaLocalDevice = require('../../lib/tuya-local/TuyaLocalDevice');
+Module._load = originalLoad;
+
+function createLocalDevice() {
+  const values = {};
+  const store = {};
+  const device = Object.create(TuyaLocalDevice.prototype);
+
+  device.dpMappings = {
+    4: { capability: 'measure_battery' },
+    6: { capability: 'measure_battery' },
+    15: { capability: 'measure_battery' },
+    33: { capability: 'measure_battery' },
+    20: { capability: 'measure_power', divisor: 10 },
+  };
+  device.values = values;
+  device.store = store;
+  device.log = () => {};
+  device.error = () => {};
+  device.getSettings = () => ({});
+  device.getStore = () => store;
+  device.getData = () => ({ modelId: 'wifi-test' });
+  device.hasCapability = cap => ['measure_battery', 'measure_power'].includes(cap);
+  device.getCapabilityValue = cap => values[cap] ?? null;
+  device.setCapabilityValue = async (cap, value) => {
+    values[cap] = value;
+  };
+  device.setStoreValue = async (key, value) => {
+    store[key] = value;
+  };
+
+  return device;
+}
+
+describe('Wi-Fi local battery normalization', function() {
+  it('uses the unified battery cascade for local-first Wi-Fi DP batteries', function() {
+    const device = createLocalDevice();
+
+    assert.strictEqual(device._fromDeviceValue('measure_battery', 4, { capability: 'measure_battery' }, 200), 100);
+    assert.strictEqual(device._fromDeviceValue('measure_battery', 4, { capability: 'measure_battery' }, 255), null);
+
+    const voltagePercent = device._fromDeviceValue('measure_battery', 33, { capability: 'measure_battery' }, 3000);
+    assert(voltagePercent >= 90 && voltagePercent <= 100, `3000mV should normalize near full, got ${voltagePercent}`);
+  });
+
+  it('stores real Wi-Fi battery sources and leaves non-battery transforms unchanged', async function() {
+    const device = createLocalDevice();
+
+    await device._onData({ dps: { 4: 200, 20: 123 } });
+
+    assert.strictEqual(device.values.measure_battery, 100);
+    assert.strictEqual(device.values.measure_power, 12.3);
+    assert.strictEqual(device.store.last_battery_percentage, 100);
+    assert.strictEqual(device.store.last_battery_source, 'wifi-dp-4');
+    assert.strictEqual(device.store.last_battery_estimated, false);
+  });
+
+  it('does not overwrite an existing battery value with invalid Wi-Fi sentinels', async function() {
+    const device = createLocalDevice();
+    device.values.measure_battery = 74;
+
+    await device._onData({ dps: { 4: 255 } });
+
+    assert.strictEqual(device.values.measure_battery, 74);
+    assert.strictEqual(device.store.last_battery_percentage, undefined);
+  });
+});


### PR DESCRIPTION
## Summary
- restores the historic unified battery cascade on current master: Tuya DP percent/state/voltage, ZCL 0-200, legacy store keys, and source/estimated metadata
- routes Wi-Fi local `measure_battery` through the same cascade while preserving SmartDivisor energy parsing and safe capability updates
- adds regression tests for legacy battery restore, invalid sentinels, Wi-Fi DP battery normalization, and real DP values replacing estimates

## Validation
- `npx mocha test\critical\unified-battery-cascade.test.js test\critical\wifi-local-battery-normalization.test.js --timeout 10000`
- `npm run check:button-flows`
- `npm run precommit`
- pre-push gate passed