### PR TITLE
[codex] Enrich secondary battery paths from version audit

### DIFF
--- a/docs/RULES_PHYSICAL_BUTTONS.md
+++ b/docs/RULES_PHYSICAL_BUTTONS.md
@@ -10,8 +10,10 @@
     *   If `isAppCommand(gang)` is `false`, the report is a physical event.
     *   **Action**: Use `_triggerPhysicalFlow(gang, value)` and then `_safeSetCapability(gangId, value)`.
 *   **Rule 1.3: Physical Execution (Zero Defect)**
-    *   Flow Action cards MUST use `triggerCapabilityListener()` instead of `setCapabilityValue()` to ensure actual physical relay switching.
-    *   **Action**: Implement fallback in `HybridSwitchBase` to route flow commands through listeners.
+    *   Flow Action cards MUST NOT write `setCapabilityValue()` directly when the device is expected to actuate physically.
+    *   Commands MUST enter a protocol-aware path that first calls `markAppCommand(gang, value)` and then sends the actual ZCL/Tuya-DP command.
+    *   `triggerCapabilityListener()` is only a fallback for devices without a direct protocol router. Since v9.0.103, button and switch mixins prefer direct ZCL/Tuya-DP dispatch to avoid echo loops and missing-listener crashes.
+    *   **Action**: Keep physical execution centralized in `VirtualButtonMixin`, `PhysicalButtonMixin`, `UnifiedSwitchBase`, or equivalent base routers.
 
 ## 2. Hardening (Anti-Burst & SDK 3 Safety)
 *   **Rule 2.1: ZCL Burst Debounce**

--- a/docs/VERSION_HISTORY_BATTERY_BUTTON_AUDIT_2026-07-05.md
+++ b/docs/VERSION_HISTORY_BATTERY_BUTTON_AUDIT_2026-07-05.md
@@ -1,0 +1,58 @@
+# Battery, Energy, and Button Version Audit - 2026-07-05
+
+This reference captures the version-by-version findings used for the July 5 battery/button enrichment pass.
+
+## Scope
+
+- Runtime paths: `UnifiedBatteryHandler`, `SmartBatteryManager`, `BatteryRouter`, `TuyaLocalDevice`, `PhysicalButtonMixin`, `VirtualButtonMixin`, and button flow routing tests.
+- Main risk: different historical code paths had different battery DP lists, default values, voltage parsing, and button dispatch rules.
+- Result of this pass: the secondary managers now reuse the same unified battery cascade and the button rules documentation matches the current direct protocol dispatch architecture.
+
+## Version Findings
+
+| Date | Version / Commit | Finding | Current Action |
+| --- | --- | --- | --- |
+| 2026-01-31 | v5.7.14 `201b41bf96` | Introduced bidirectional virtual/physical button deduplication. | Preserved through `markAppCommand`, `isAppCommand`, and `getLastVirtualButtonEvent`. |
+| 2026-02-01 | v5.7.16 `1cd54e210f` | Virtual button UI needed explicit handling for Homey interaction. | Current rule keeps UI commands routed through protocol-aware mixins, not raw capability writes. |
+| 2026-02-01 | v5.7.19 `2b1f514484` | Scene mode moved into `ButtonDevice` for TS004x and related remotes. | Kept in button runtime tests and routing guards. |
+| 2026-02-01 | v5.7.24 `2c6c9bc58c` | Multi-endpoint buttons needed shared state to stop ghost presses. | Preserved by broad multi-endpoint routing checks. |
+| 2026-02-01 | v5.7.38 `38c7c1046c` | BSEED 4-gang virtual buttons needed direct ZCL first plus retry. | Preserved in `VirtualButtonMixin`; docs updated to allow direct ZCL/Tuya-DP dispatch. |
+| 2026-02-08 | v5.8.67 `67d7f1620c` | Non-linear battery curves and the divide-by-two bug were fixed. | Reused through `UnifiedBatteryHandler.calculateFromVoltage()` and normalized DP/ZCL parsing. |
+| 2026-02-08 | v5.8.69 `f33d82e427` | `?` battery display required store restore, DP fallback, and invalid-value filtering. | Extended to `SmartBatteryManager` and `BatteryRouter` in this pass. |
+| 2026-02-08 | v5.8.69 `13c35f8342` | Sleeping device battery values must persist to store. | Secondary paths now store `last_battery_percentage`, `last_battery_time`, `last_battery_source`, and `last_battery_estimated`. |
+| 2026-02-11 | v5.8.92 `94b70bc36c` | Button wake-up was a useful time to read battery. | Kept in button battery routing tests and unified cascade behavior. |
+| 2026-06-23 | v9.0.76 `53550844cb` | Linear battery formulas and battery halving had reappeared in generated drivers. | Secondary managers now call unified non-linear voltage and sentinel-aware parsing. |
+| 2026-06-24 | v9.0.88 `c43ea8f377` | ZCL voltage fallback and anti-broadcast dedup were needed for dynamic devices. | ZCL voltage is normalized before percent conversion in all battery paths. |
+| 2026-06-24 | v9.0.89 `4c2f0fc640` | Z2M quirks, 0-50 scale and anomaly alerts were added. | Preserved in `UnifiedBatteryHandler`; secondary paths defer to it. |
+| 2026-06-24 | v9.0.90 `14406267af` | Multi-endpoint battery support was added to the universal engine. | `SmartBatteryManager` and `BatteryRouter` now scan all endpoints, not only endpoint 1. |
+| 2026-06-24 | v9.0.92 `5751e98a1a` | Sentinel filtering and duplicate-listener prevention were required. | Secondary tests now verify `255` does not overwrite existing battery. |
+| 2026-06-25 | v9.0.103 | `triggerCapabilityListener()` echo loops were replaced by direct protocol routing. | `RULES_PHYSICAL_BUTTONS.md` updated to match this architecture. |
+| 2026-07-05 | PR #501 `6b9312acc2` | Unified cascade restored on main and Wi-Fi local battery was normalized. | This pass extends the same logic to `SmartBatteryManager` and `BatteryRouter`. |
+
+## Gaps Fixed In This Pass
+
+| Gap | Risk | Fix |
+| --- | --- | --- |
+| `SmartBatteryManager` used a private DP list missing DP3/DP121 and profile-only DPs. | Battery reports could be ignored outside the main handler. | It now calls `UnifiedBatteryHandler.getTuyaBatteryDPs({ includeProfileOnly: true })`. |
+| `BatteryRouter` used `[4, 10, 14, 15, 101, 105]` only. | Extended batteries and state DPs were missed. | It now shares the unified DP matrix and voltage DP list. |
+| Secondary paths wrote default `100%`. | A false full battery hid unknown/sleeping-device states. | Default is now marked `50%` estimate and replaced by real values. |
+| ZCL report parser used `value / 2` directly. | `255` could become a fake valid percentage. | Parser now uses `normalizeZigbeeValue()`. |
+| Tuya DP listeners clamped raw values. | Sentinels and voltage-looking values could overwrite true battery. | Listeners now use `normalizeTuyaBatteryValue()` and ignore invalid values. |
+| Battery detection assumed endpoint 1. | Multi-endpoint remotes/buttons could lose battery. | Managers now scan all endpoints for power and IAS clusters. |
+| Button docs still mandated `triggerCapabilityListener()`. | Future automation could reintroduce echo loops. | Rule now requires protocol-aware dispatch with `markAppCommand`, using listeners only as fallback. |
+
+## Regression Tests
+
+- `test/critical/unified-battery-cascade.test.js`
+- `test/critical/wifi-local-battery-normalization.test.js`
+- `test/critical/battery-secondary-paths.test.js`
+- `test/button-flow-runtime-routing.test.js`
+
+## Rules Going Forward
+
+1. Battery DP lists must come from `UnifiedBatteryHandler`.
+2. Unknown/sentinel values must never overwrite a previous real battery value.
+3. Estimates must be explicitly marked in store.
+4. Voltage must be normalized before curve conversion.
+5. Battery and IAS clusters must be discovered across all endpoints.
+6. Button UI/Flow commands must enter a protocol-aware router with `markAppCommand` before physical dispatch.

--- a/lib/battery/UnifiedBatteryHandler.js
+++ b/lib/battery/UnifiedBatteryHandler.js
@@ -1118,10 +1118,10 @@ class UnifiedBatteryHandler {
     const bindManager = () => {
       const ef00Manager = this.device.tuyaEF00Manager;
       if (ef00Manager) {
-        BATTERY_DPS.forEach(dp => {
+        UnifiedBatteryHandler.getTuyaBatteryDPs({ profile: this._profile, includeProfileOnly: true }).forEach(dp => {
           ef00Manager.on(`dp-${dp}`, (value) => this._handleTuyaBatteryDP(dp, value));
         });
-        VOLTAGE_DPS.forEach(dp => {
+        UnifiedBatteryHandler.getTuyaVoltageDPs().forEach(dp => {
           ef00Manager.on(`dp-${dp}`, (value) => this._handleTuyaVoltageDP(dp, value));
         });
         this.device.log('[BATTERY-UNIFIED] ✅ Tuya DP listeners registered');

--- a/lib/helpers/BatteryRouter.js
+++ b/lib/helpers/BatteryRouter.js
@@ -15,9 +15,20 @@
  */
 
 const { CLUSTER } = require('zigbee-clusters');
+let UnifiedBatteryHandler;
+try {
+  UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
+} catch (_e) {
+  UnifiedBatteryHandler = null;
+}
 
 // Battery-related DPs from Tuya devices
-const TUYA_BATTERY_DPS = [4, 10, 14, 15, 101, 105];
+const TUYA_BATTERY_DPS = UnifiedBatteryHandler
+  ? UnifiedBatteryHandler.getTuyaBatteryDPs({ includeProfileOnly: true })
+  : [3, 4, 10, 14, 15, 21, 100, 101, 102, 104, 105, 121];
+const TUYA_VOLTAGE_DPS = UnifiedBatteryHandler
+  ? UnifiedBatteryHandler.getTuyaVoltageDPs()
+  : [33, 35, 247];
 const TUYA_VOLTAGE_DP = 247;
 
 /**
@@ -42,6 +53,7 @@ async function resolveBatterySource(device) {
     source: BatterySource.UNKNOWN,
     method: 'none',
     dps: [],
+    endpointId: 1,
     hasCapability: device.hasCapability('measure_battery')
   };
 
@@ -58,17 +70,12 @@ async function resolveBatterySource(device) {
   }
 
   // Check for standard ZCL genPowerCfg cluster
-  const endpoint = zclNode.endpoints?.[1];
-  const hasPowerCfg = !!(endpoint?.clusters?.genPowerCfg || endpoint?.clusters?.powerConfiguration);
+  const powerEndpoint = _findEndpointByCluster(zclNode, ['genPowerCfg', 'powerConfiguration', 0x0001, '0x0001']);
+  const tuyaEndpoint = _findEndpointByCluster(zclNode, ['tuya', 'tuyaSpecific', 'manuSpecificTuya', 61184, 0xEF00, '0xEF00']);
+  const hasPowerCfg = !!powerEndpoint?.cluster;
 
   // Check for Tuya EF00 cluster
-  const hasTuyaCluster = !!(
-    endpoint?.clusters?.tuya ||
-    endpoint?.clusters?.tuyaSpecific ||
-    endpoint?.clusters?.manuSpecificTuya ||
-    endpoint?.clusters?.[61184] ||
-    endpoint?.clusters?.[0xEF00]
-  );
+  const hasTuyaCluster = !!tuyaEndpoint?.cluster;
 
   // Get device info
   const settings = device.getSettings?.() || {};
@@ -93,12 +100,14 @@ async function resolveBatterySource(device) {
     // Standard ZCL device with genPowerCfg
     result.source = BatterySource.ZCL;
     result.method = 'zcl_attribute_reporting';
+    result.endpointId = powerEndpoint?.endpointId || 1;
     device.log('[BATTERY-ROUTER] ✅ Selected: ZCL genPowerCfg cluster');
   } else if (hasTuyaCluster) {
     // Has Tuya cluster but not TS0601 - try both
     result.source = BatterySource.TUYA_DP;
     result.method = 'tuya_dp_listener';
     result.dps = TUYA_BATTERY_DPS;
+    result.endpointId = tuyaEndpoint?.endpointId || 1;
     device.log('[BATTERY-ROUTER] ✅ Selected: Tuya cluster (hybrid)');
   } else {
     // No known battery source - might be mains powered
@@ -110,6 +119,7 @@ async function resolveBatterySource(device) {
   // Always check for voltage capability (USB devices)
   if (device.hasCapability('measure_voltage')) {
     result.voltageDP = TUYA_VOLTAGE_DP;
+    result.voltageDPs = TUYA_VOLTAGE_DPS;
     device.log('[BATTERY-ROUTER] ⚡ Voltage capability present (DP 247)');
   }
 
@@ -125,16 +135,17 @@ async function resolveBatterySource(device) {
 async function configureBatteryReporting(device, batteryInfo) {
   device.log(`[BATTERY-ROUTER] Configuring ${batteryInfo.source} reporting...`);
 
-  // Set default value immediately to avoid null KPI
+  // Set a marked estimate only for devices with a plausible battery source.
+  // Old versions wrote 100%, which hid real "unknown" battery bugs for sleepy devices.
   const currentBattery = device.getCapabilityValue?.('measure_battery');
-  if (currentBattery === null || currentBattery === undefined) {
-    await device.safeSetCapabilityValue('measure_battery', 100).catch(() => { });
-    device.log('[BATTERY-ROUTER] 📊 Set default battery = 100% (pending first report)');
+  if (batteryInfo.source !== BatterySource.NONE && (currentBattery === null || currentBattery === undefined)) {
+    await _setBatteryValue(device, 50, 'battery-router-estimated-default', true);
+    device.log('[BATTERY-ROUTER] 📊 Set default battery = 50% estimate (pending first report)');
   }
 
   switch (batteryInfo.source) {
   case BatterySource.ZCL:
-    await _configureZCLBattery(device);
+    await _configureZCLBattery(device, batteryInfo.endpointId || 1);
     break;
 
   case BatterySource.TUYA_DP:
@@ -158,13 +169,13 @@ async function configureBatteryReporting(device, batteryInfo) {
 /**
  * Configure standard ZCL battery reporting
  */
-async function _configureZCLBattery(device) {
+async function _configureZCLBattery(device, endpointId = 1) {
   device.log('[BATTERY-ROUTER] Configuring ZCL battery reporting...');
 
   try {
     // Try to configure attribute reporting
     await device.configureAttributeReporting([{
-      endpointId: 1,
+      endpointId,
       cluster: 'genPowerCfg',
       attributeName: 'batteryPercentageRemaining',
       minInterval: 600,      // 10 minutes minimum
@@ -188,14 +199,31 @@ async function _configureZCLBattery(device) {
       },
       report: 'batteryPercentageRemaining',
       reportParser: (value) => {
-        // ZCL reports 0-200 (half percentage), convert to 0-100
-        return Math.round(value / 2);
+        const percent = UnifiedBatteryHandler
+          ? UnifiedBatteryHandler.normalizeZigbeeValue(value)
+          : _normalizeBatteryValue(value > 100 ? value / 2 : value);
+        return percent ?? device.getCapabilityValue?.('measure_battery') ?? 50;
       }
     });
     device.log('[BATTERY-ROUTER] ✅ ZCL battery capability registered');
   } catch (err) {
     device.log('[BATTERY-ROUTER] ℹ️ registerCapability error:', err.message);
   }
+}
+
+function _findEndpointByCluster(zclNode, clusterKeys) {
+  const keys = Array.isArray(clusterKeys) ? clusterKeys : [clusterKeys];
+  const endpoints = zclNode?.endpoints || {};
+  for (const [endpointId, endpoint] of Object.entries(endpoints)) {
+    const clusters = endpoint?.clusters || {};
+    for (const key of keys) {
+      const cluster = clusters[key] || clusters[Number(key)] || clusters[String(key)];
+      if (cluster) {
+        return { endpointId: Number(endpointId), endpoint, cluster };
+      }
+    }
+  }
+  return null;
 }
 
 /**
@@ -208,9 +236,13 @@ async function _configureTuyaDPBattery(device, dps) {
   if (device.tuyaEF00Manager) {
     for (const dp of dps) {
       device.tuyaEF00Manager.on(`dp-${dp}`, async (value) => {
-        const batteryValue = Math.min(100, Math.max(0, Number(value) || 0));
+        const batteryValue = _normalizeTuyaBatteryValue(device, dp, value);
+        if (batteryValue === null) {
+          device.log(`[BATTERY-ROUTER] Ignored invalid Tuya DP${dp} battery value: ${value}`);
+          return;
+        }
         device.log(`[BATTERY-ROUTER] 🔋 Tuya DP${dp} battery: ${batteryValue}%`);
-        await device.safeSetCapabilityValue('measure_battery', parseFloat(batteryValue)).catch(() => { });
+        await _setBatteryValue(device, batteryValue, `battery-router-tuya-dp-${dp}`, false);
       });
     }
     device.log('[BATTERY-ROUTER] ✅ Tuya DP battery listeners registered');
@@ -218,9 +250,10 @@ async function _configureTuyaDPBattery(device, dps) {
 
   // Also listen for generic dpReport event
   device.on('tuya_dp_battery', async (value) => {
-    const batteryValue = Math.min(100, Math.max(0, Number(value) || 0));
+    const batteryValue = _normalizeBatteryValue(value);
+    if (batteryValue === null) {return;}
     device.log(`[BATTERY-ROUTER] 🔋 tuya_dp_battery event: ${batteryValue}%`);
-    await device.safeSetCapabilityValue('measure_battery', parseFloat(batteryValue)).catch(() => { });
+    await _setBatteryValue(device, batteryValue, 'battery-router-tuya-dp-event', false);
   });
 }
 
@@ -230,18 +263,77 @@ async function _configureTuyaDPBattery(device, dps) {
 async function _configureVoltageBattery(device) {
   device.log('[BATTERY-ROUTER] Configuring voltage-based battery...');
 
-  // Listen for DP 247 voltage reports
+  // Listen for voltage reports
   if (device.tuyaEF00Manager) {
-    device.tuyaEF00Manager.on(`dp-${TUYA_VOLTAGE_DP}`, async (value) => {
-      // Convert mV to V
-      const voltage = Number(value) / 1000;
-      device.log(`[BATTERY-ROUTER] ⚡ Voltage DP247: ${voltage}V`);
+    for (const dp of TUYA_VOLTAGE_DPS) {
+      device.tuyaEF00Manager.on(`dp-${dp}`, async (value) => {
+        const voltage = UnifiedBatteryHandler ? UnifiedBatteryHandler.normalizeVoltage(value) : Number(value) / 1000;
+        if (voltage === null || !Number.isFinite(voltage)) {return;}
+        device.log(`[BATTERY-ROUTER] ⚡ Voltage DP${dp}: ${voltage}V`);
 
-      if (device.hasCapability('measure_voltage')) {
-        await device.safeSetCapabilityValue('measure_voltage', parseFloat(voltage)).catch(() => { });
-      }
-    });
+        if (device.hasCapability('measure_voltage')) {
+          await device.safeSetCapabilityValue('measure_voltage', parseFloat(voltage)).catch(() => { });
+        }
+
+        if (device.hasCapability('measure_battery') && UnifiedBatteryHandler) {
+          const batteryValue = UnifiedBatteryHandler.calculateFromVoltage(voltage, getRecommendedBatteryType(device));
+          await _setBatteryValue(device, batteryValue, `battery-router-voltage-dp-${dp}`, false);
+        }
+      });
+    }
   }
+}
+
+async function _setBatteryValue(device, value, source, estimated) {
+  const batteryValue = _normalizeBatteryValue(value);
+  if (batteryValue === null) {return;}
+  const setter = typeof device.safeSetCapabilityValue === 'function'
+    ? device.safeSetCapabilityValue.bind(device)
+    : device.setCapabilityValue?.bind(device);
+  await setter?.('measure_battery', parseFloat(batteryValue)).catch(() => { });
+  await device.setStoreValue?.('last_battery_percentage', Math.round(batteryValue)).catch(() => { });
+  await device.setStoreValue?.('last_battery_time', Date.now()).catch(() => { });
+  await device.setStoreValue?.('last_battery_source', source).catch(() => { });
+  await device.setStoreValue?.('last_battery_estimated', estimated === true).catch(() => { });
+}
+
+function _normalizeBatteryValue(value) {
+  if (UnifiedBatteryHandler) {
+    return UnifiedBatteryHandler.normalizeStoredBattery(value);
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric === 255 || numeric === 0xFFFF || numeric < 0 || numeric > 200) {
+    return null;
+  }
+  return numeric > 100 ? Math.round(numeric / 2) : Math.round(numeric);
+}
+
+function _normalizeTuyaBatteryValue(device, dp, value) {
+  if (!UnifiedBatteryHandler) {
+    return _normalizeBatteryValue(value);
+  }
+  const settings = device.getSettings?.() || {};
+  const store = device.getStore?.() || {};
+  const profile = UnifiedBatteryHandler.lookupBatteryProfile?.(
+    settings.zb_manufacturer_name || settings.zb_manufacturerName || store.manufacturerName || '',
+    settings.zb_model_id || settings.zb_modelId || store.modelId || ''
+  );
+  const normalized = UnifiedBatteryHandler.normalizeTuyaBatteryValue(dp, value, {
+    profile,
+    profileMatch: profile && (Number(profile.dpId) === Number(dp) || Number(profile.dpIdState) === Number(dp)),
+    batteryType: profile?.chemistry || getRecommendedBatteryType(device),
+    lastValue: device.getCapabilityValue?.('measure_battery'),
+    temperature: device.getCapabilityValue?.('measure_temperature'),
+  });
+  if (normalized !== null) return normalized;
+
+  const raw = UnifiedBatteryHandler.coerceNumericValue(value);
+  const voltage = UnifiedBatteryHandler.normalizeVoltage(value);
+  if (Number.isFinite(raw) && raw >= 800 && voltage !== null) {
+    return UnifiedBatteryHandler.calculateFromVoltage(voltage, profile?.chemistry || getRecommendedBatteryType(device));
+  }
+
+  return null;
 }
 
 /**
@@ -276,5 +368,6 @@ module.exports = {
   configureBatteryReporting,
   getRecommendedBatteryType,
   TUYA_BATTERY_DPS,
-  TUYA_VOLTAGE_DP
+  TUYA_VOLTAGE_DP,
+  TUYA_VOLTAGE_DPS
 };

--- a/lib/managers/SmartBatteryManager.js
+++ b/lib/managers/SmartBatteryManager.js
@@ -1,6 +1,11 @@
 'use strict';
 
-const { safeMultiply, safeParse } = require('../utils/tuyaUtils.js');
+let UnifiedBatteryHandler;
+try {
+  UnifiedBatteryHandler = require('../battery/UnifiedBatteryHandler');
+} catch (_e) {
+  UnifiedBatteryHandler = null;
+}
 
 /**
  * SmartBatteryManager v5.12.0 (Enriched Hardened Edition)
@@ -14,7 +19,17 @@ const { safeMultiply, safeParse } = require('../utils/tuyaUtils.js');
  * 5. Improved Bidirectional Synthesis between alarm_battery and measure_battery.
  */
 
-const BATTERY_DPS = [4, 10, 14, 15, 21, 100, 101, 102, 104, 105];
+const FALLBACK_BATTERY_DPS = [3, 4, 10, 14, 15, 21, 100, 101, 102, 104, 105, 121];
+const FALLBACK_VOLTAGE_DPS = [33, 35, 247];
+const STORED_BATTERY_KEYS = [
+  'last_battery_percentage',
+  'last_battery_percent',
+  'lastBatteryPercentage',
+  'battery_percentage',
+  'batteryPercent',
+  'batteryLevel',
+  'battery',
+];
 
 class SmartBatteryManager {
   constructor(device) {
@@ -86,22 +101,43 @@ class SmartBatteryManager {
   }
 
   _hasZclBatteryCluster(zclNode) {
-    const pc = zclNode?.endpoints?.[1]?.clusters?.powerConfiguration;
-    return !!pc?.on;
+    return !!this._findEndpointByCluster(['powerConfiguration', 'genPowerCfg', 0x0001, '0x0001'], zclNode)?.cluster?.on;
   }
 
   _hasIasZoneCluster(zclNode) {
-    const ias = zclNode?.endpoints?.[1]?.clusters?.iasZone || zclNode?.endpoints?.[1]?.clusters?.ssIasZone;
-    return !!ias;
+    return !!this._findEndpointByCluster(['iasZone', 'ssIasZone', 0x0500, '0x0500'], zclNode)?.cluster;
+  }
+
+  _findEndpointByCluster(clusterKeys, zclNode = this.device.zclNode) {
+    const keys = Array.isArray(clusterKeys) ? clusterKeys : [clusterKeys];
+    const endpoints = zclNode?.endpoints || {};
+    for (const [endpointId, endpoint] of Object.entries(endpoints)) {
+      const clusters = endpoint?.clusters || {};
+      for (const key of keys) {
+        const cluster = clusters[key] || clusters[Number(key)] || clusters[String(key)];
+        if (cluster) {
+          return { endpointId: Number(endpointId), endpoint, cluster };
+        }
+      }
+    }
+    return null;
   }
 
   async _setupZCLListener() {
     try {
-      const pc = this.device.zclNode?.endpoints?.[1]?.clusters?.powerConfiguration;
+      const pc = this._findEndpointByCluster(['powerConfiguration', 'genPowerCfg', 0x0001, '0x0001'])?.cluster;
       if (!pc?.on) {return;}
 
-      pc.on('attr.batteryPercentageRemaining', (v) => this.setBattery(safeParse(v, 2)));
-      pc.on('attr.batteryVoltage', (v) => this.setBattery(this._voltageToPercent(v)));
+      pc.on('attr.batteryPercentageRemaining', (v) => {
+        const percent = UnifiedBatteryHandler
+          ? UnifiedBatteryHandler.normalizeZigbeeValue(v, { batteryType: this._getBatteryType() })
+          : this._normalizeStoredBattery(v);
+        this.setBattery(percent, { source: 'smart-zcl-report', estimated: false });
+      });
+      pc.on('attr.batteryVoltage', (v) => this.setBattery(this._voltageToPercent(v), {
+        source: 'smart-zcl-voltage',
+        estimated: false,
+      }));
 
       // Some devices report alarm state in Power cluster
       pc.on('attr.batteryAlarmState', (v) => this.setAlarmBattery(!!v));
@@ -112,7 +148,7 @@ class SmartBatteryManager {
 
   async _setupIASListener(zclNode) {
     try {
-      const ias = zclNode?.endpoints?.[1]?.clusters?.iasZone || zclNode?.endpoints?.[1]?.clusters?.ssIasZone;
+      const ias = this._findEndpointByCluster(['iasZone', 'ssIasZone', 0x0500, '0x0500'], zclNode)?.cluster;
       if (!ias) {return;}
 
       // Bit 3 of ZoneStatus is battery-low
@@ -134,8 +170,13 @@ class SmartBatteryManager {
   }
 
   _restoreFromStore() {
-    const stored = this.device.getStoreValue('last_battery_percentage');
-    if (stored !== null && typeof stored === 'number') {
+    let stored = null;
+    for (const key of STORED_BATTERY_KEYS) {
+      stored = this._normalizeStoredBattery(this.device.getStoreValue?.(key));
+      if (stored !== null) break;
+    }
+
+    if (stored !== null) {
       this.device.log(`[BATTERY] Restored last known value: ${stored}%`);
       this._lastValue = stored;
       // We don't setCapabilityValue here to avoid flow triggers on app restart,
@@ -144,7 +185,14 @@ class SmartBatteryManager {
   }
 
   async handleDP(dpId, value) {
-    if (!BATTERY_DPS.includes(dpId)) {return false;}
+    const batteryDps = UnifiedBatteryHandler
+      ? UnifiedBatteryHandler.getTuyaBatteryDPs({ includeProfileOnly: true })
+      : FALLBACK_BATTERY_DPS;
+    const voltageDps = UnifiedBatteryHandler
+      ? UnifiedBatteryHandler.getTuyaVoltageDPs()
+      : FALLBACK_VOLTAGE_DPS;
+    const numericDp = Number(dpId);
+    if (!batteryDps.includes(numericDp) && !voltageDps.includes(numericDp)) {return false;}
     
     // v5.12.1: Ignore battery DPs for mains-powered and kinetic devices to prevent phantom capabilities
     if (this.device.mainsPowered === true || this._isKineticDevice()) {
@@ -153,23 +201,36 @@ class SmartBatteryManager {
 
     this.device.log(`[BATTERY] Received DP ${dpId} with raw value: ${value}`);
 
-    if (typeof value === 'boolean') {
+    if (typeof value === 'boolean' && !batteryDps.includes(numericDp)) {
       await this.setAlarmBattery(value);
       return true;
     }
 
-    let percent = value;
-    if (dpId === 101 || dpId === 104 || dpId === 105) {
+    let percent = UnifiedBatteryHandler
+      ? UnifiedBatteryHandler.normalizeTuyaBatteryValue(numericDp, value, {
+        batteryType: this._getBatteryType(),
+        lastValue: this._lastValue,
+        temperature: this.device.getCapabilityValue?.('measure_temperature'),
+      })
+      : this._normalizeStoredBattery(value);
+
+    if (percent === null && voltageDps.includes(numericDp)) {
       percent = this._voltageToPercent(value);
     }
+    if (percent === null && typeof value === 'boolean') {
+      await this.setAlarmBattery(value);
+      return true;
+    }
     
-    await this.setBattery(percent);
+    await this.setBattery(percent, { source: `smart-tuya-dp-${numericDp}`, estimated: false });
     return true;
   }
 
-  async setBattery(percent) {
+  async setBattery(percent, meta = {}) {
     if (percent === null || percent === undefined) {return;}
-    percent = Math.max(0, Math.min(100, Math.round(percent)));
+    const normalizedPercent = this._normalizeStoredBattery(percent);
+    if (normalizedPercent === null) {return;}
+    percent = normalizedPercent;
     
     if (!this.device.hasCapability('measure_battery') && !this.device.hasCapability('alarm_battery')) {
       await this.device.addCapability('measure_battery').catch(() => {});
@@ -186,6 +247,13 @@ class SmartBatteryManager {
       await this.device.setCapabilityValue('measure_battery', percent).catch(() => {});
     }
     await this.device.setStoreValue('last_battery_percentage', percent).catch(() => {});
+    await this.device.setStoreValue('last_battery_time', Date.now()).catch(() => {});
+    if (meta.source) {
+      await this.device.setStoreValue('last_battery_source', meta.source).catch(() => {});
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, 'estimated')) {
+      await this.device.setStoreValue('last_battery_estimated', meta.estimated === true).catch(() => {});
+    }
     
     this._lastValue = percent;
     this._lastUpdateTime = now;
@@ -212,15 +280,22 @@ class SmartBatteryManager {
     // Bidirectional synthesis
     const currentPercent = this.device.getCapabilityValue('measure_battery');
     if (alarmVal && (currentPercent === null || currentPercent > 15)) {
-      await this.setBatteryDirect(10);
+      await this.setBatteryDirect(10, { source: 'smart-alarm-low-estimate', estimated: true });
     } else if (!alarmVal && (currentPercent === null || currentPercent <= 15)) {
-      await this.setBatteryDirect(100);
+      await this.setBatteryDirect(100, { source: 'smart-alarm-ok-estimate', estimated: true });
     }
   }
 
-  async setBatteryDirect(percent) {
+  async setBatteryDirect(percent, meta = {}) {
     if (this.device.hasCapability('measure_battery')) {
       await this.device.setCapabilityValue('measure_battery', percent).catch(() => {});
+      await this.device.setStoreValue?.('last_battery_percentage', Math.round(percent)).catch(() => {});
+      if (meta.source) {
+        await this.device.setStoreValue?.('last_battery_source', meta.source).catch(() => {});
+      }
+      if (Object.prototype.hasOwnProperty.call(meta, 'estimated')) {
+        await this.device.setStoreValue?.('last_battery_estimated', meta.estimated === true).catch(() => {});
+      }
       this._lastValue = percent;
       this._lastUpdateTime = Date.now();
       this.device.log(`[BATTERY] Synthesized virtual percentage: ${percent}%`);
@@ -239,10 +314,36 @@ class SmartBatteryManager {
 
   _voltageToPercent(mV) {
     if (mV === null || mV === undefined) {return null;}
+    if (UnifiedBatteryHandler) {
+      const voltage = UnifiedBatteryHandler.normalizeVoltage(mV);
+      return voltage === null
+        ? null
+        : UnifiedBatteryHandler.calculateFromVoltage(voltage, this._getBatteryType(), this.device.getCapabilityValue?.('measure_temperature'));
+    }
     if (mV < 10) {mV = mV * 1000;}
     else if (mV < 100) {mV = mV * 100;}
     const curve = this._selectCurve(mV);
     return this._interpolateCurve(mV, curve);
+  }
+
+  _normalizeStoredBattery(value) {
+    if (UnifiedBatteryHandler) {
+      return UnifiedBatteryHandler.normalizeStoredBattery(value);
+    }
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric === 255 || numeric === 0xFFFF || numeric < 0 || numeric > 200) {
+      return null;
+    }
+    return numeric > 100 ? Math.round(numeric / 2) : Math.round(numeric);
+  }
+
+  _getBatteryType() {
+    const settings = this.device.getSettings?.() || {};
+    const configuredType = this.device.getSetting?.('battery_type') || settings.battery_type;
+    if (UnifiedBatteryHandler) {
+      return UnifiedBatteryHandler.normalizeBatteryType(configuredType);
+    }
+    return configuredType || 'CR2032';
   }
 
   _selectCurve(mV) {

--- a/lib/tuya-local/TuyaLocalDevice.js
+++ b/lib/tuya-local/TuyaLocalDevice.js
@@ -359,26 +359,38 @@ class TuyaLocalDevice extends Homey.Device {
       data.modelId ||
       '';
     const lookedUpProfile = UnifiedBatteryHandler.lookupBatteryProfile?.(manufacturer, modelId);
-    const profile = cfg.batteryProfile || lookedUpProfile || {
-      dpId: Number(dp),
-      algorithm: cfg.batteryAlgorithm || cfg.algorithm || 'direct',
-      chemistry: cfg.batteryType || cfg.chemistry || 'CR2032',
-    };
+    const hasExplicitProfile = Boolean(
+      cfg.batteryProfile ||
+      lookedUpProfile ||
+      cfg.batteryAlgorithm ||
+      cfg.algorithm
+    );
+    const profile = hasExplicitProfile
+      ? (cfg.batteryProfile || lookedUpProfile || {
+        dpId: Number(dp),
+        algorithm: cfg.batteryAlgorithm || cfg.algorithm || 'direct',
+        chemistry: cfg.batteryType || cfg.chemistry || 'CR2032',
+      })
+      : null;
 
     const normalized = UnifiedBatteryHandler.normalizeTuyaBatteryValue(Number(dp), transformed, {
       profile,
-      profileMatch: true,
-      batteryType: cfg.batteryType || profile.chemistry || 'CR2032',
+      profileMatch: hasExplicitProfile,
+      batteryType: cfg.batteryType || profile?.chemistry || 'CR2032',
       lastValue: this.getCapabilityValue?.('measure_battery'),
       temperature: this.getCapabilityValue?.('measure_temperature') || settings.temperature,
       stateMode: cfg.stateMode,
     });
 
-    if (normalized === null) {
-      return UnifiedBatteryHandler.normalizeStoredBattery(transformed);
+    if (normalized !== null) return normalized;
+
+    const raw = UnifiedBatteryHandler.coerceNumericValue(transformed);
+    const voltage = UnifiedBatteryHandler.normalizeVoltage(transformed);
+    if (Number.isFinite(raw) && raw >= 800 && voltage !== null) {
+      return UnifiedBatteryHandler.calculateFromVoltage(voltage, cfg.batteryType || profile?.chemistry || 'CR2032');
     }
 
-    return normalized;
+    return null;
   }
 
   async _setLocalCapabilityValue(capability, value) {

--- a/test/critical/battery-secondary-paths.test.js
+++ b/test/critical/battery-secondary-paths.test.js
@@ -1,0 +1,124 @@
+'use strict';
+
+const assert = require('assert');
+const EventEmitter = require('events');
+const Module = require('module');
+
+const originalLoad = Module._load;
+Module._load = function patchedLoad(request, parent, isMain) {
+  if (request === 'zigbee-clusters') {
+    return { CLUSTER: { POWER_CONFIGURATION: 'powerConfiguration' } };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const BatteryRouter = require('../../lib/helpers/BatteryRouter');
+const SmartBatteryManager = require('../../lib/managers/SmartBatteryManager');
+
+Module._load = originalLoad;
+
+function createDevice() {
+  const values = {};
+  const store = {};
+  const capabilities = new Set(['measure_battery']);
+  const manager = new EventEmitter();
+
+  return {
+    values,
+    store,
+    tuyaEF00Manager: manager,
+    on: manager.on.bind(manager),
+    emit: manager.emit.bind(manager),
+    log: () => {},
+    driver: { id: 'button_wireless_2' },
+    zclNode: { endpoints: {} },
+    getSettings: () => ({}),
+    getStore: () => store,
+    getStoreValue: key => store[key],
+    setStoreValue: async (key, value) => {
+      store[key] = value;
+    },
+    hasCapability: cap => capabilities.has(cap),
+    addCapability: async cap => capabilities.add(cap),
+    removeCapability: async cap => capabilities.delete(cap),
+    getCapabilityValue: cap => values[cap] ?? null,
+    setCapabilityValue: async (cap, value) => {
+      values[cap] = value;
+    },
+    safeSetCapabilityValue: async (cap, value) => {
+      values[cap] = value;
+    },
+  };
+}
+
+describe('secondary battery paths', function() {
+  it('shares the extended Tuya battery and voltage DP matrix', function() {
+    assert(BatteryRouter.TUYA_BATTERY_DPS.includes(3), 'DP3 state battery must be routed');
+    assert(BatteryRouter.TUYA_BATTERY_DPS.includes(121), 'DP121 extended battery must be routed');
+    assert.deepStrictEqual(BatteryRouter.TUYA_VOLTAGE_DPS, [33, 35, 247]);
+  });
+
+  it('uses marked 50% estimates and replaces them with real router DP values', async function() {
+    const device = createDevice();
+
+    await BatteryRouter.configureBatteryReporting(device, {
+      source: BatteryRouter.BatterySource.TUYA_DP,
+      method: 'tuya_dp_listener',
+      dps: [121],
+    });
+
+    assert.strictEqual(device.values.measure_battery, 50);
+    assert.strictEqual(device.store.last_battery_estimated, true);
+    assert.strictEqual(device.store.last_battery_source, 'battery-router-estimated-default');
+
+    device.tuyaEF00Manager.emit('dp-121', 88);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(device.values.measure_battery, 88);
+    assert.strictEqual(device.store.last_battery_estimated, false);
+    assert.strictEqual(device.store.last_battery_source, 'battery-router-tuya-dp-121');
+  });
+
+  it('does not let router sentinels overwrite existing battery values', async function() {
+    const device = createDevice();
+    device.values.measure_battery = 74;
+
+    await BatteryRouter.configureBatteryReporting(device, {
+      source: BatteryRouter.BatterySource.TUYA_DP,
+      method: 'tuya_dp_listener',
+      dps: [4],
+    });
+
+    device.tuyaEF00Manager.emit('dp-4', 255);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(device.values.measure_battery, 74);
+    assert.strictEqual(device.store.last_battery_source, undefined);
+
+    await BatteryRouter.configureBatteryReporting(device, {
+      source: BatteryRouter.BatterySource.TUYA_DP,
+      method: 'tuya_dp_listener',
+      dps: [102],
+    });
+
+    device.tuyaEF00Manager.emit('dp-102', 1);
+    await new Promise(resolve => setImmediate(resolve));
+
+    assert.strictEqual(device.values.measure_battery, 74);
+  });
+
+  it('routes SmartBatteryManager extended DPs through the unified cascade', async function() {
+    const device = createDevice();
+    const manager = new SmartBatteryManager(device);
+
+    assert.strictEqual(await manager.handleDP(121, 91), true);
+    assert.strictEqual(device.values.measure_battery, 91);
+    assert.strictEqual(device.store.last_battery_source, 'smart-tuya-dp-121');
+
+    assert.strictEqual(await manager.handleDP(4, 255), true);
+    assert.strictEqual(device.values.measure_battery, 91);
+
+    assert.strictEqual(await manager.handleDP(102, 1), true);
+    assert.strictEqual(device.values.measure_battery, 91);
+  });
+});

--- a/test/critical/wifi-local-battery-normalization.test.js
+++ b/test/critical/wifi-local-battery-normalization.test.js
@@ -26,6 +26,7 @@ function createLocalDevice() {
     6: { capability: 'measure_battery' },
     15: { capability: 'measure_battery' },
     33: { capability: 'measure_battery' },
+    102: { capability: 'measure_battery' },
     20: { capability: 'measure_power', divisor: 10 },
   };
   device.values = values;
@@ -78,5 +79,9 @@ describe('Wi-Fi local battery normalization', function() {
 
     assert.strictEqual(device.values.measure_battery, 74);
     assert.strictEqual(device.store.last_battery_percentage, undefined);
+
+    await device._onData({ dps: { 102: 1 } });
+
+    assert.strictEqual(device.values.measure_battery, 74);
   });
 });


### PR DESCRIPTION
## Summary

This PR applies the July 5 version-history audit for battery, energy, and button regressions.

- Added a dated reference document that maps the relevant historical battery/button versions and the runtime gaps found during the audit.
- Extended secondary battery paths (`SmartBatteryManager` and `BatteryRouter`) so they reuse the unified Tuya DP matrix, voltage DPs, sentinel filtering, store metadata, and multi-endpoint discovery.
- Hardened local Wi-Fi battery normalization so ambiguous extended/state DP values do not overwrite a real battery percentage.
- Updated the physical button rules to match the current direct ZCL/Tuya-DP dispatch architecture introduced after the historical `triggerCapabilityListener()` echo-loop fixes.
- Added critical tests for secondary router/manager battery behavior and extended the Wi-Fi local battery test.

## Root Cause

The main unified battery cascade had been repaired in PR #501, but older secondary managers still carried stale private DP lists, endpoint-1 assumptions, raw ZCL `/2` parsing, and default `100%` fallbacks. Those paths could still show `?`, overwrite a real value with sentinels, or miss DP121/profile-only battery reports.

## Validation

- `node --check` on changed runtime/test files
- `npx mocha test\critical\unified-battery-cascade.test.js test\critical\wifi-local-battery-normalization.test.js test\critical\battery-secondary-paths.test.js test\button-flow-runtime-routing.test.js --timeout 10000` — 22 passing
- `npm run precommit` — passed
- Git pre-commit hook — passed all 9 layers
- Git pre-push Homey gate — passed

Known repo warnings unchanged: app.json `api` field review warning, synthetic manufacturer identifiers to be pruned by prepare-publish, and existing fingerprint catalog warnings.