### PR TITLE
[codex] Add probabilistic local device detection

### DIFF
--- a/docs/PROBABILISTIC_LOCAL_DEVICE_DETECTION.md
+++ b/docs/PROBABILISTIC_LOCAL_DEVICE_DETECTION.md
@@ -1,0 +1,41 @@
+# Probabilistic Local Device Detection - 2026-07-05
+
+This reference defines the local heuristic detection layer used for unknown devices and migration recommendations.
+
+## Goal
+
+Device routing must not rely on a single broad identifier such as `TS0601`. The detector should cross-check local databases, fingerprints, clusters, DP behavior, and learning reports, then return ranked candidates with confidence and reasons.
+
+## Evidence Sources
+
+- Compound fingerprint database: exact `manufacturerName|productId` routes.
+- Runtime fingerprint catalog: broad manufacturer/model catalog from `data/fingerprints.json`.
+- Driver mapping database: `mfr_index`, `pid_index`, and driver capability metadata.
+- MFS/community databases: harvested source aggregation and enriched forum/GitHub rows.
+- Zigbee cluster behavior: endpoints, standard clusters, Tuya EF00, battery and energy clusters.
+- Tuya DP behavior: observed DP IDs and `data/dp_database.json` capability hints.
+- 15 minute DP learning report: `dp_auto_discovery_report` profile, capabilities, and dynamic DP map.
+
+## Rules
+
+1. Exact compound fingerprints are strong evidence, but behavior can still add contradictions.
+2. Broad product IDs such as `TS0601` are weak priors only.
+3. Observed DP and cluster behavior may lift an unknown variant into a specific family.
+4. Generic fallback drivers receive a penalty when a more specific driver has supporting evidence.
+5. Contradictions must reduce confidence, not be hidden.
+6. The output must keep ranked alternatives for manual review.
+7. Migration can use the probabilistic result only when confidence is at least 70%.
+8. A confidence below 70% is a learning/reporting signal, not an auto-route.
+
+## Output Fields
+
+- `suggestedDriver`: best ranked driver.
+- `confidence`: bounded 0-99 confidence score.
+- `probability`: relative probability of the best candidate among ranked candidates.
+- `candidates`: ranked alternatives with sources, evidence, contradictions, capabilities, and probability.
+- `evidenceBadges`: compact debug labels such as `multi_source_agreement`, `dp_behavior_seen`, or `close_race_manual_review`.
+- `observed`: normalized manufacturer/model, endpoint count, clusters, DP IDs, capabilities, and inferred device types.
+
+## Safety
+
+The detector is local-first and lazy-loaded. Databases are read only when detection is requested, not at app startup. Every optional source is guarded so a bad cache or missing file cannot crash pairing, unknown-device reporting, or migration analysis.

--- a/lib/helpers/ProbabilisticDeviceDetector.js
+++ b/lib/helpers/ProbabilisticDeviceDetector.js
@@ -1,0 +1,875 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DP_DATABASE_PATH = path.join(ROOT, 'data', 'dp_database.json');
+const DRIVER_MAPPING_PATH = path.join(ROOT, 'driver-mapping-database.json');
+const MFS_DATABASE_PATH = path.join(ROOT, 'data', 'mfs_db.json');
+const COMMUNITY_ENRICHED_PATH = path.join(ROOT, 'data', 'community-sync', 'all-enriched.json');
+
+const CLUSTER_IDS = {
+  basic: 0x0000,
+  powerConfiguration: 0x0001,
+  genPowerCfg: 0x0001,
+  onOff: 0x0006,
+  genOnOff: 0x0006,
+  levelControl: 0x0008,
+  genLevelCtrl: 0x0008,
+  doorLock: 0x0101,
+  windowCovering: 0x0102,
+  thermostat: 0x0201,
+  fanControl: 0x0202,
+  colorControl: 0x0300,
+  msIlluminanceMeasurement: 0x0400,
+  illuminanceMeasurement: 0x0400,
+  msTemperatureMeasurement: 0x0402,
+  temperatureMeasurement: 0x0402,
+  msRelativeHumidity: 0x0405,
+  relativeHumidity: 0x0405,
+  msOccupancySensing: 0x0406,
+  occupancySensing: 0x0406,
+  ssIasZone: 0x0500,
+  iasZone: 0x0500,
+  ssIasWd: 0x0502,
+  iasWd: 0x0502,
+  seMetering: 0x0702,
+  metering: 0x0702,
+  haElectricalMeasurement: 0x0B04,
+  electricalMeasurement: 0x0B04,
+  tuya: 0xEF00,
+  tuyaSpecific: 0xEF00,
+  manuSpecificTuya: 0xEF00,
+};
+
+const CLUSTER_CAPABILITY_RULES = [
+  { ids: [0x0001], capability: 'measure_battery', deviceTypes: ['button', 'sensor'] },
+  { ids: [0x0006], capability: 'onoff', deviceTypes: ['switch', 'plug', 'light'] },
+  { ids: [0x0008], capability: 'dim', deviceTypes: ['dimmer', 'light'] },
+  { ids: [0x0101], capability: 'locked', deviceTypes: ['lock'] },
+  { ids: [0x0102], capability: 'windowcoverings_set', deviceTypes: ['cover', 'curtain'] },
+  { ids: [0x0201], capability: 'target_temperature', deviceTypes: ['thermostat', 'radiator_valve'] },
+  { ids: [0x0202], capability: 'fan_speed', deviceTypes: ['fan'] },
+  { ids: [0x0300], capability: 'light_hue', extraCapabilities: ['light_saturation'], deviceTypes: ['light'] },
+  { ids: [0x0400], capability: 'measure_luminance', deviceTypes: ['illuminance', 'presence', 'motion'] },
+  { ids: [0x0402], capability: 'measure_temperature', deviceTypes: ['climate', 'thermostat', 'soil'] },
+  { ids: [0x0405], capability: 'measure_humidity', deviceTypes: ['climate', 'soil'] },
+  { ids: [0x0406], capability: 'alarm_motion', deviceTypes: ['motion', 'presence'] },
+  { ids: [0x0500], capability: 'alarm_contact', deviceTypes: ['contact', 'water', 'motion'] },
+  { ids: [0x0502], capability: 'alarm_generic', deviceTypes: ['siren'] },
+  { ids: [0x0702], capability: 'meter_power', extraCapabilities: ['measure_power'], deviceTypes: ['plug', 'meter'] },
+  { ids: [0x0B04], capability: 'measure_power', extraCapabilities: ['measure_voltage', 'measure_current'], deviceTypes: ['plug', 'meter'] },
+  { ids: [0xEF00], capability: 'tuya_dp', deviceTypes: ['tuya_dp'] },
+];
+
+const DEVICE_TYPE_TO_DRIVER = {
+  air_quality: 'air_quality_comprehensive',
+  button: 'button_wireless_1',
+  climate: 'climate_sensor',
+  contact: 'contact_sensor',
+  cover: 'curtain_motor',
+  curtain: 'curtain_motor',
+  dimmer: 'dimmer_wall_1gang',
+  fan: 'fan_controller',
+  gas: 'gas_detector',
+  illuminance: 'light_sensor_outdoor',
+  light: 'bulb_rgbw',
+  lock: 'lock_smart',
+  meter: 'power_meter',
+  motion: 'motion_sensor',
+  plug: 'plug_energy_monitor',
+  presence: 'presence_sensor_radar',
+  radiator_valve: 'radiator_valve',
+  sensor: 'climate_sensor',
+  siren: 'siren',
+  smoke: 'smoke_detector_advanced',
+  soil: 'soil_sensor',
+  switch: 'switch_1gang',
+  thermostat: 'radiator_valve',
+  tuya_dp: 'device_generic_tuya_universal',
+  valve: 'valve_irrigation',
+  water: 'water_leak_sensor',
+};
+
+const PROFILE_TO_DRIVER = {
+  button_wireless: 'button_wireless_1',
+  button_wireless_1: 'button_wireless_1',
+  button_wireless_2: 'button_wireless_2',
+  button_wireless_3: 'button_wireless_3',
+  button_wireless_4: 'button_wireless_4',
+  button_wireless_5: 'switch_wall_5gang',
+  button_wireless_6: 'button_wireless_6',
+  climate_sensor: 'climate_sensor',
+  contact_sensor: 'contact_sensor',
+  generic_tuya: 'device_generic_tuya_universal',
+  power_plug: 'plug_energy_monitor',
+  presence_sensor_radar: 'presence_sensor_radar',
+  sensor_climate_presence: 'sensor_climate_presence',
+  sensor_illuminance_presence: 'sensor_illuminance_presence',
+  switch: 'switch_1gang',
+};
+
+const GENERIC_DRIVER_PENALTY = new Set([
+  'device_generic_tuya_universal',
+  'generic_tuya',
+  'universal_fallback',
+  'universal_zigbee',
+  'zigbee_universal',
+]);
+
+let _jsonCache = new Map();
+let _compoundDb = undefined;
+let _runtimeFingerprintDb = undefined;
+let _tuyaProfiles = undefined;
+let _enrichedDpMappings = undefined;
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function round(value, decimals = 2) {
+  const factor = Math.pow(10, decimals);
+  return Math.round(value * factor) / factor;
+}
+
+function normalizeText(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function normalizeDriverId(value) {
+  return String(value || '').trim();
+}
+
+function safeRequire(request) {
+  try {
+    return require(request);
+  } catch (_err) {
+    return null;
+  }
+}
+
+function readJson(filePath, fallback) {
+  if (_jsonCache.has(filePath)) return _jsonCache.get(filePath);
+  try {
+    if (!fs.existsSync(filePath)) {
+      _jsonCache.set(filePath, fallback);
+      return fallback;
+    }
+    const data = JSON.parse(fs.readFileSync(filePath));
+    _jsonCache.set(filePath, data);
+    return data;
+  } catch (_err) {
+    _jsonCache.set(filePath, fallback);
+    return fallback;
+  }
+}
+
+function getCompoundDb() {
+  if (_compoundDb !== undefined) return _compoundDb;
+  _compoundDb = safeRequire('../DeviceFingerprintDB') || null;
+  return _compoundDb;
+}
+
+function getRuntimeFingerprintDb() {
+  if (_runtimeFingerprintDb !== undefined) return _runtimeFingerprintDb;
+  _runtimeFingerprintDb = safeRequire('../tuya/DeviceFingerprintDB') || null;
+  return _runtimeFingerprintDb;
+}
+
+function getTuyaProfiles() {
+  if (_tuyaProfiles !== undefined) return _tuyaProfiles;
+  _tuyaProfiles = safeRequire('../tuya/TuyaProfiles') || null;
+  return _tuyaProfiles;
+}
+
+function getEnrichedDpMappings() {
+  if (_enrichedDpMappings !== undefined) return _enrichedDpMappings;
+  _enrichedDpMappings = safeRequire('../tuya/EnrichedDPMappings') || null;
+  return _enrichedDpMappings;
+}
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null) return [];
+  return [value];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(value => value !== undefined && value !== null && value !== ''))];
+}
+
+function parseNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^0x/i.test(trimmed)) return parseInt(trimmed, 16);
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}
+
+function clusterIdFromKey(key, cluster) {
+  const direct = parseNumber(key);
+  if (direct !== null) return direct;
+  if (CLUSTER_IDS[key] !== undefined) return CLUSTER_IDS[key];
+  if (CLUSTER_IDS[String(key).replace(/^gen/, '')] !== undefined) return CLUSTER_IDS[String(key).replace(/^gen/, '')];
+  const fromCluster = cluster?.ID ?? cluster?.id ?? cluster?.clusterId;
+  const parsed = parseNumber(fromCluster);
+  return parsed !== null ? parsed : null;
+}
+
+function normalizeDiscoveryData(data = {}) {
+  const settings = data.settings || data.getSettings?.() || {};
+  const store = data.store || data.getStore?.() || {};
+  const modelId = data.modelId || data.productId || data.model || data.product ||
+    settings.zb_model_id || settings.zb_modelId || store.modelId || data.node?.modelId || '';
+  const manufacturerName = data.manufacturerName || data.manufacturer || data.mfr ||
+    settings.zb_manufacturer_name || settings.zb_manufacturerName || store.manufacturerName || '';
+
+  return {
+    ...data,
+    modelId,
+    productId: data.productId || modelId,
+    manufacturerName,
+    endpoints: data.endpoints || data.zclNode?.endpoints || {},
+    capabilities: unique([
+      ...asArray(data.capabilities),
+      ...asArray(data.detectedCapabilities),
+      ...asArray(data.clusterAnalysis?.features),
+    ]),
+    dpAutoDiscoveryReport: data.dpAutoDiscoveryReport || data.autoDiscoveryReport || data.dpReport ||
+      data.getStoreValue?.('dp_auto_discovery_report') || null,
+    observedDps: data.observedDps || data.dps || data.dpMappings || data.dpMap || {},
+  };
+}
+
+function extractClusterSummary(endpoints = {}) {
+  const clusters = new Set();
+  const names = new Set();
+  const endpointIds = [];
+
+  const entries = Array.isArray(endpoints)
+    ? endpoints.map((endpoint, index) => [String(endpoint.endpointId || endpoint.id || index + 1), endpoint])
+    : Object.entries(endpoints || {});
+
+  for (const [endpointId, endpoint] of entries) {
+    endpointIds.push(Number(endpointId) || endpointId);
+    const rawClusters = endpoint?.clusters || endpoint?.inputClusters || endpoint?.serverClusters || [];
+
+    if (Array.isArray(rawClusters)) {
+      for (const cluster of rawClusters) {
+        const id = clusterIdFromKey(cluster, null);
+        if (id !== null) clusters.add(id);
+        if (typeof cluster === 'string') names.add(cluster);
+      }
+    } else if (rawClusters && typeof rawClusters === 'object') {
+      for (const [key, cluster] of Object.entries(rawClusters)) {
+        const id = clusterIdFromKey(key, cluster);
+        if (id !== null) clusters.add(id);
+        names.add(String(key));
+      }
+    }
+  }
+
+  const capabilities = new Set();
+  const deviceTypes = new Set();
+  for (const rule of CLUSTER_CAPABILITY_RULES) {
+    if (!rule.ids.some(id => clusters.has(id))) continue;
+    capabilities.add(rule.capability);
+    for (const extra of rule.extraCapabilities || []) capabilities.add(extra);
+    for (const type of rule.deviceTypes || []) deviceTypes.add(type);
+  }
+
+  return {
+    clusters: [...clusters].sort((a, b) => a - b),
+    clusterNames: [...names].sort(),
+    endpointIds: unique(endpointIds),
+    endpointCount: unique(endpointIds).length,
+    capabilities: [...capabilities].sort(),
+    deviceTypes: [...deviceTypes].sort(),
+    hasTuya: clusters.has(0xEF00),
+    hasEnergy: clusters.has(0x0702) || clusters.has(0x0B04),
+    hasBattery: clusters.has(0x0001),
+  };
+}
+
+function extractDpIds(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return unique(value.map(entry => Number(entry?.dpId ?? entry?.dp ?? entry)).filter(Number.isFinite));
+  }
+  if (value instanceof Map) {
+    return unique([...value.keys()].map(Number).filter(Number.isFinite));
+  }
+  if (typeof value === 'object') {
+    return unique(Object.keys(value).map(Number).filter(Number.isFinite));
+  }
+  return [];
+}
+
+function extractCapabilitiesFromDpReport(report) {
+  const capabilities = [];
+  const types = [];
+  const dpIds = [];
+  const recommendation = report?.profileRecommendation || null;
+
+  for (const cap of asArray(recommendation?.observedCapabilities)) capabilities.push(cap);
+  for (const type of asArray(recommendation?.observedTypes)) types.push(type);
+
+  const dynamicMap = report?.dynamicDPMap || {};
+  for (const [dp, mapping] of Object.entries(dynamicMap)) {
+    dpIds.push(Number(dp));
+    if (mapping?.capability) capabilities.push(mapping.capability);
+    if (mapping?.type) types.push(mapping.type);
+  }
+
+  const dps = report?.dps || {};
+  for (const [dp, info] of Object.entries(dps)) {
+    dpIds.push(Number(dp));
+    if (info?.capability) capabilities.push(info.capability);
+    if (info?.type) types.push(info.type);
+  }
+
+  return {
+    capabilities: unique(capabilities),
+    types: unique(types),
+    dpIds: unique(dpIds.filter(Number.isFinite)),
+    recommendation,
+  };
+}
+
+function driverFromProfile(profileId) {
+  if (!profileId) return null;
+  if (PROFILE_TO_DRIVER[profileId]) return PROFILE_TO_DRIVER[profileId];
+  const match = /^button_wireless_(\d+)$/.exec(profileId);
+  if (match) return Number(match[1]) <= 4 ? `button_wireless_${match[1]}` : `switch_wall_${match[1]}gang`;
+  return DEVICE_TYPE_TO_DRIVER[profileId] || null;
+}
+
+function driverFromDeviceType(type, context = {}) {
+  if (!type) return null;
+  const normalized = normalizeText(type).replace(/-/g, '_');
+  if (normalized === 'switch' && context.gangCount > 1) {
+    return context.gangCount <= 4 ? `switch_${context.gangCount}gang` : `switch_wall_${context.gangCount}gang`;
+  }
+  if (normalized === 'button' && context.gangCount > 1) {
+    return context.gangCount <= 4 ? `button_wireless_${context.gangCount}` : `switch_wall_${context.gangCount}gang`;
+  }
+  return DEVICE_TYPE_TO_DRIVER[normalized] || null;
+}
+
+class ProbabilisticDeviceDetector {
+  constructor(data = {}, options = {}) {
+    this.data = normalizeDiscoveryData(data);
+    this.options = options;
+    this.clusterSummary = extractClusterSummary(this.data.endpoints);
+    this.dpReportSummary = extractCapabilitiesFromDpReport(this.data.dpAutoDiscoveryReport);
+    this.dpIds = unique([
+      ...extractDpIds(this.data.observedDps),
+      ...this.dpReportSummary.dpIds,
+    ]);
+    this.observedCapabilities = unique([
+      ...this.data.capabilities,
+      ...this.clusterSummary.capabilities,
+      ...this.dpReportSummary.capabilities,
+    ]);
+    this.observedDeviceTypes = unique([
+      ...this.clusterSummary.deviceTypes,
+      ...this.dpReportSummary.types.map(type => this._deviceTypeFromInferredType(type)).filter(Boolean),
+    ]);
+    this.candidates = new Map();
+    this.sourceSummary = [];
+  }
+
+  static detect(data = {}, options = {}) {
+    return new ProbabilisticDeviceDetector(data, options).detect();
+  }
+
+  static resetCaches() {
+    _jsonCache = new Map();
+    _compoundDb = undefined;
+    _runtimeFingerprintDb = undefined;
+    _tuyaProfiles = undefined;
+    _enrichedDpMappings = undefined;
+  }
+
+  detect() {
+    this._addCompoundFingerprintEvidence();
+    this._addRuntimeFingerprintEvidence();
+    this._addTuyaProfileEvidence();
+    this._addEnrichedMappingEvidence();
+    this._addDriverMappingEvidence();
+    this._addMfsEvidence();
+    this._addCommunityEvidence();
+    this._addClusterBehaviorEvidence();
+    this._addDpBehaviorEvidence();
+    this._addLearningRecommendationEvidence();
+    this._addCapabilityOverlapEvidence();
+    return this._buildResult();
+  }
+
+  _candidate(driverId) {
+    const normalized = normalizeDriverId(driverId);
+    if (!normalized) return null;
+    if (!this.candidates.has(normalized)) {
+      this.candidates.set(normalized, {
+        driver: normalized,
+        rawScore: 0,
+        evidence: [],
+        contradictions: [],
+        sources: new Set(),
+        capabilities: new Set(),
+        deviceTypes: new Set(),
+        sourceWeights: {},
+      });
+    }
+    return this.candidates.get(normalized);
+  }
+
+  _vote(driverId, score, source, reason, meta = {}) {
+    const candidate = this._candidate(driverId);
+    if (!candidate || !Number.isFinite(score) || score <= 0) return;
+
+    const boundedScore = clamp(score, 0, 95);
+    candidate.rawScore += boundedScore;
+    candidate.sources.add(source);
+    candidate.sourceWeights[source] = (candidate.sourceWeights[source] || 0) + boundedScore;
+    if (reason) candidate.evidence.push(`${source}:${reason}`);
+    for (const cap of asArray(meta.capabilities)) candidate.capabilities.add(cap);
+    for (const type of asArray(meta.deviceTypes)) candidate.deviceTypes.add(type);
+    for (const contradiction of asArray(meta.contradictions)) candidate.contradictions.push(contradiction);
+  }
+
+  _addSourceSummary(source, status, details = {}) {
+    this.sourceSummary.push({ source, status, ...details });
+  }
+
+  _addCompoundFingerprintEvidence() {
+    const db = getCompoundDb();
+    if (!db?.lookup) {
+      this._addSourceSummary('compound_fingerprint_db', 'unavailable');
+      return;
+    }
+
+    const profile = db.lookup(this.data.manufacturerName, this.data.modelId);
+    if (!profile) {
+      this._addSourceSummary('compound_fingerprint_db', 'miss');
+      return;
+    }
+
+    const score = profile.matchType === 'exact' || profile.matchType === 'exact_ci' ? 92 : 36;
+    const driver = profile.driver || driverFromDeviceType(profile.type, { gangCount: profile.gangCount || this.clusterSummary.endpointCount });
+    this._vote(driver, score, 'compound_fingerprint_db', profile.matchType || 'match', {
+      capabilities: Object.values(profile.dp || {}).map(value => String(value).split(/[/*]/)[0]),
+      deviceTypes: [profile.type, profile.driver],
+    });
+    this._addSourceSummary('compound_fingerprint_db', 'hit', {
+      driver,
+      matchType: profile.matchType,
+      key: profile.key,
+    });
+  }
+
+  _addRuntimeFingerprintEvidence() {
+    const db = getRuntimeFingerprintDb();
+    if (!db?.getFingerprint) {
+      this._addSourceSummary('runtime_fingerprint_db', 'unavailable');
+      return;
+    }
+
+    const fp = db.getFingerprint(this.data.manufacturerName, this.data.modelId);
+    if (!fp?.driverId) {
+      this._addSourceSummary('runtime_fingerprint_db', 'miss');
+      return;
+    }
+
+    const modelLower = normalizeText(this.data.modelId);
+    const modelMatches = !modelLower || !Array.isArray(fp.modelIds) ||
+      fp.modelIds.some(model => normalizeText(model) === modelLower);
+    const score = fp.matchType === 'exact' || fp.matchType === 'exact_ci' ? 88 : modelMatches ? 64 : 46;
+    this._vote(fp.driverId, score, 'runtime_fingerprint_db', modelMatches ? 'manufacturer_model' : 'manufacturer_only', {
+      capabilities: fp.capabilities,
+      deviceTypes: [fp.type, fp.driverId],
+    });
+    this._addSourceSummary('runtime_fingerprint_db', 'hit', {
+      driver: fp.driverId,
+      matchType: fp.matchType || (modelMatches ? 'model_supported' : 'manufacturer_only'),
+    });
+  }
+
+  _addTuyaProfileEvidence() {
+    const profiles = getTuyaProfiles();
+    const profile = profiles?.getTuyaProfile?.(this.data.modelId, this.data.manufacturerName);
+    if (!profile) {
+      this._addSourceSummary('tuya_profiles', 'miss');
+      return;
+    }
+
+    const driver = profile.driver || driverFromProfile(profile.profileId) || driverFromDeviceType(profile.type);
+    this._vote(driver, profile.driver ? 72 : 50, 'tuya_profiles', profile.name || profile.key || 'profile_match', {
+      capabilities: profiles.getProfileCapabilities?.(profile),
+      deviceTypes: [profile.type, driver],
+    });
+    this._addSourceSummary('tuya_profiles', 'hit', { driver, key: profile.key });
+  }
+
+  _addEnrichedMappingEvidence() {
+    const mappings = getEnrichedDpMappings();
+    const profile = mappings?.getProfile?.(this.data.manufacturerName);
+    if (!profile) {
+      this._addSourceSummary('enriched_dp_mappings', 'miss');
+      return;
+    }
+
+    const type = profile.type || mappings.getDeviceType?.(this.data.manufacturerName);
+    const driver = profile.driver || driverFromDeviceType(type);
+    this._vote(driver, 42, 'enriched_dp_mappings', type || 'manufacturer_profile', {
+      capabilities: Object.values(profile.profile || {}).map(value => value?.capability).filter(Boolean),
+      deviceTypes: [type],
+    });
+    this._addSourceSummary('enriched_dp_mappings', 'hit', { driver, type });
+  }
+
+  _addDriverMappingEvidence() {
+    const db = readJson(DRIVER_MAPPING_PATH, {});
+    const mfrDrivers = this._lookupCaseInsensitive(db.mfr_index, this.data.manufacturerName);
+    const pidDrivers = this._lookupCaseInsensitive(db.pid_index, this.data.modelId);
+    const driverSpecs = db.drivers || {};
+
+    if (Array.isArray(mfrDrivers)) {
+      const spread = Math.max(1, Math.min(mfrDrivers.length, 12));
+      for (const driver of mfrDrivers.slice(0, 40)) {
+        this._vote(driver, 34 / Math.sqrt(spread), 'driver_mapping_mfr_index', 'manufacturer_index', {
+          capabilities: driverSpecs[driver]?.capabilities,
+          deviceTypes: [driverSpecs[driver]?.class],
+        });
+      }
+    }
+
+    if (Array.isArray(pidDrivers)) {
+      const isBroadTuya = normalizeText(this.data.modelId) === 'ts0601';
+      const spread = Math.max(1, Math.min(pidDrivers.length, isBroadTuya ? 80 : 20));
+      const base = isBroadTuya ? 10 : 24;
+      for (const driver of pidDrivers.slice(0, isBroadTuya ? 120 : 50)) {
+        this._vote(driver, base / Math.sqrt(spread), 'driver_mapping_pid_index', isBroadTuya ? 'broad_ts0601_index' : 'product_index', {
+          capabilities: driverSpecs[driver]?.capabilities,
+          deviceTypes: [driverSpecs[driver]?.class],
+        });
+      }
+    }
+
+    this._addSourceSummary('driver_mapping_database', (mfrDrivers || pidDrivers) ? 'hit' : 'miss', {
+      manufacturerCandidates: Array.isArray(mfrDrivers) ? mfrDrivers.length : 0,
+      productCandidates: Array.isArray(pidDrivers) ? pidDrivers.length : 0,
+    });
+  }
+
+  _addMfsEvidence() {
+    const db = readJson(MFS_DATABASE_PATH, {});
+    const key = normalizeText(this.data.manufacturerName);
+    const entry = this._lookupCaseInsensitive(db.devices, key) || this._lookupCaseInsensitive(db, this.data.manufacturerName);
+    if (!entry?.driverId && !entry?.driver) {
+      this._addSourceSummary('mfs_db', 'miss');
+      return;
+    }
+
+    const sourceCount = asArray(entry.source || entry.sources).length || 1;
+    const driver = entry.driverId || entry.driver;
+    this._vote(driver, 28 + Math.min(12, sourceCount * 3), 'mfs_db', `sources:${sourceCount}`, {
+      capabilities: entry.capabilities,
+      deviceTypes: [entry.deviceType, entry.type],
+    });
+    this._addSourceSummary('mfs_db', 'hit', { driver, sourceCount });
+  }
+
+  _addCommunityEvidence() {
+    const rows = readJson(COMMUNITY_ENRICHED_PATH, []);
+    const mfrLower = normalizeText(this.data.manufacturerName);
+    const modelLower = normalizeText(this.data.modelId);
+    let hits = 0;
+
+    for (const row of Array.isArray(rows) ? rows : []) {
+      if (normalizeText(row.mfr || row.manufacturerName) !== mfrLower) continue;
+      const productIds = asArray(row.productId || row.productIds || row.modelId);
+      const modelMatches = !modelLower || !productIds.length || productIds.some(productId => normalizeText(productId) === modelLower);
+      if (!modelMatches) continue;
+      hits += 1;
+      this._vote(row.driver, row.source ? 42 : 34, 'community_enriched', row.source || 'community_match', {
+        capabilities: row.capabilities,
+        deviceTypes: [row.deviceType],
+        contradictions: row.hasBattery === false && this.observedCapabilities.includes('measure_battery')
+          ? ['community:no_battery_but_battery_observed']
+          : [],
+      });
+      if (hits >= 8) break;
+    }
+
+    this._addSourceSummary('community_enriched', hits ? 'hit' : 'miss', { hits });
+  }
+
+  _addClusterBehaviorEvidence() {
+    const context = { gangCount: this.clusterSummary.endpointCount };
+    for (const type of this.clusterSummary.deviceTypes) {
+      const driver = driverFromDeviceType(type, context);
+      const score = type === 'tuya_dp' ? 18 : 30;
+      this._vote(driver, score, 'cluster_behavior', `type:${type}`, {
+        capabilities: this.clusterSummary.capabilities,
+        deviceTypes: [type],
+      });
+    }
+
+    if (this.clusterSummary.hasEnergy) {
+      this._vote('plug_energy_monitor', 24, 'cluster_behavior', 'energy_clusters_present', {
+        capabilities: ['measure_power', 'meter_power'],
+        deviceTypes: ['plug', 'meter'],
+      });
+    }
+
+    if (this.clusterSummary.hasBattery && this.clusterSummary.endpointCount >= 2 && !this.clusterSummary.hasEnergy) {
+      const buttonDriver = this.clusterSummary.endpointCount <= 4
+        ? `button_wireless_${this.clusterSummary.endpointCount}`
+        : 'button_wireless';
+      this._vote(buttonDriver, 20, 'cluster_behavior', `battery_multi_endpoint:${this.clusterSummary.endpointCount}`, {
+        capabilities: ['measure_battery'],
+        deviceTypes: ['button'],
+      });
+    }
+
+    this._addSourceSummary('cluster_behavior', this.clusterSummary.clusters.length ? 'hit' : 'miss', {
+      clusters: this.clusterSummary.clusters,
+      endpointCount: this.clusterSummary.endpointCount,
+    });
+  }
+
+  _addDpBehaviorEvidence() {
+    const dpDb = readJson(DP_DATABASE_PATH, {});
+    const dpCapabilities = new Set();
+    const dpDeviceTypes = new Set();
+
+    for (const dpId of this.dpIds) {
+      const info = dpDb[String(dpId)];
+      if (!info) continue;
+      for (const cap of asArray(info.capabilities)) dpCapabilities.add(cap);
+      for (const type of asArray(info.deviceTypes)) dpDeviceTypes.add(type);
+    }
+
+    for (const type of dpDeviceTypes) {
+      const driver = driverFromDeviceType(type, { gangCount: this.clusterSummary.endpointCount });
+      this._vote(driver, 14 + Math.min(20, this.dpIds.length * 2), 'dp_database_behavior', `dp_type:${type}`, {
+        capabilities: [...dpCapabilities],
+        deviceTypes: [type],
+      });
+    }
+
+    this._addSourceSummary('dp_database_behavior', dpCapabilities.size || dpDeviceTypes.size ? 'hit' : 'miss', {
+      dpCount: this.dpIds.length,
+      capabilities: [...dpCapabilities].sort(),
+      deviceTypes: [...dpDeviceTypes].sort(),
+    });
+  }
+
+  _addLearningRecommendationEvidence() {
+    const recommendation = this.dpReportSummary.recommendation;
+    if (!recommendation?.profileId) {
+      this._addSourceSummary('dp_learning_report', 'miss');
+      return;
+    }
+
+    const driver = driverFromProfile(recommendation.profileId);
+    const confidence = clamp(Number(recommendation.confidence) || 0, 0, 99);
+    this._vote(driver, Math.max(18, confidence * 0.62), 'dp_learning_report', recommendation.profileId, {
+      capabilities: recommendation.observedCapabilities,
+      deviceTypes: [recommendation.profileId],
+    });
+    this._addSourceSummary('dp_learning_report', 'hit', {
+      profileId: recommendation.profileId,
+      confidence,
+      driver,
+    });
+  }
+
+  _addCapabilityOverlapEvidence() {
+    if (!this.observedCapabilities.length) {
+      this._addSourceSummary('capability_overlap', 'miss');
+      return;
+    }
+
+    const mapping = readJson(DRIVER_MAPPING_PATH, {});
+    const drivers = mapping.drivers || {};
+    const observed = new Set(this.observedCapabilities.map(String));
+    let matched = 0;
+
+    for (const [driverId, spec] of Object.entries(drivers)) {
+      const caps = asArray(spec.capabilities).map(String);
+      if (!caps.length) continue;
+      const overlap = caps.filter(cap => observed.has(cap)).length;
+      if (!overlap) continue;
+      const ratio = overlap / Math.max(observed.size, caps.length, 1);
+      if (ratio < 0.18 && overlap < 2) continue;
+      matched += 1;
+      this._vote(driverId, Math.min(28, overlap * 6 + ratio * 18), 'capability_overlap', `overlap:${overlap}`, {
+        capabilities: caps,
+        deviceTypes: [spec.class],
+      });
+    }
+
+    this._addSourceSummary('capability_overlap', matched ? 'hit' : 'miss', { matched });
+  }
+
+  _lookupCaseInsensitive(object, key) {
+    if (!object || !key) return null;
+    if (object[key] !== undefined) return object[key];
+    const lowered = normalizeText(key);
+    for (const [candidateKey, value] of Object.entries(object)) {
+      if (normalizeText(candidateKey) === lowered) return value;
+    }
+    return null;
+  }
+
+  _deviceTypeFromInferredType(type) {
+    const normalized = normalizeText(type);
+    if (!normalized) return null;
+    if (normalized.includes('button')) return 'button';
+    if (normalized.includes('presence')) return 'presence';
+    if (normalized.includes('contact')) return 'contact';
+    if (normalized.includes('battery')) return 'sensor';
+    if (normalized.includes('temperature') || normalized.includes('humidity')) return 'climate';
+    if (normalized.includes('power') || normalized.includes('energy') || normalized.includes('voltage') || normalized.includes('current')) return 'plug';
+    if (normalized.includes('lux')) return 'illuminance';
+    if (normalized.includes('onoff')) return 'switch';
+    return null;
+  }
+
+  _applyCandidateBonuses(candidate) {
+    let score = candidate.rawScore;
+    const sources = [...candidate.sources];
+    const capabilities = [...candidate.capabilities];
+    const deviceTypes = [...candidate.deviceTypes].map(normalizeText);
+    const driverLower = normalizeText(candidate.driver);
+    const evidence = [...candidate.evidence];
+    const contradictions = [...candidate.contradictions];
+
+    const diversityBonus = Math.min(18, Math.max(0, sources.length - 1) * 5);
+    if (diversityBonus) {
+      score += diversityBonus;
+      evidence.push(`bonus:source_diversity:${sources.length}`);
+    }
+
+    const observedCaps = new Set(this.observedCapabilities.map(String));
+    const overlap = capabilities.filter(cap => observedCaps.has(cap)).length;
+    if (overlap) {
+      const bonus = Math.min(20, overlap * 4);
+      score += bonus;
+      evidence.push(`bonus:capability_agreement:${overlap}`);
+    }
+
+    const observedTypes = new Set(this.observedDeviceTypes.map(normalizeText));
+    const typeOverlap = deviceTypes.filter(type => observedTypes.has(type) || driverLower.includes(type)).length;
+    if (typeOverlap) {
+      score += Math.min(14, typeOverlap * 5);
+      evidence.push(`bonus:type_agreement:${typeOverlap}`);
+    }
+
+    if (GENERIC_DRIVER_PENALTY.has(candidate.driver)) {
+      score -= 18;
+      contradictions.push('generic_driver_penalty');
+    }
+
+    if (this.clusterSummary.hasEnergy && /battery|button|contact|motion|climate/.test(driverLower) && !/plug|meter|energy|air_quality/.test(driverLower)) {
+      score -= 12;
+      contradictions.push('energy_cluster_vs_battery_driver');
+    }
+
+    if (this.clusterSummary.hasBattery && /plug|meter|mains|air_quality/.test(driverLower) && !this.clusterSummary.hasEnergy) {
+      score -= 8;
+      contradictions.push('battery_cluster_vs_mains_driver');
+    }
+
+    if (normalizeText(this.data.modelId) === 'ts004f' && !/button|knob|scene/.test(driverLower)) {
+      score -= 24;
+      contradictions.push('ts004f_not_button_or_knob');
+    }
+
+    if (this.observedCapabilities.includes('windowcoverings_set') && !/curtain|cover|blind|shutter/.test(driverLower)) {
+      score -= 14;
+      contradictions.push('cover_capability_driver_mismatch');
+    }
+
+    if ((this.observedCapabilities.includes('alarm_motion') || this.observedCapabilities.includes('alarm_presence')) &&
+        (this.observedCapabilities.includes('measure_luminance') || this.observedCapabilities.includes('target_distance')) &&
+        !/presence|motion|radar/.test(driverLower)) {
+      score -= 10;
+      contradictions.push('presence_behavior_driver_mismatch');
+    }
+
+    return {
+      ...candidate,
+      rankScore: round(score, 2),
+      score: clamp(round(score, 2), 0, 99),
+      sources,
+      capabilities: unique(capabilities),
+      deviceTypes: unique(deviceTypes.filter(Boolean)),
+      evidence: unique(evidence).slice(0, 20),
+      contradictions: unique(contradictions).slice(0, 12),
+    };
+  }
+
+  _buildResult() {
+    const candidates = [...this.candidates.values()]
+      .map(candidate => this._applyCandidateBonuses(candidate))
+      .filter(candidate => candidate.score > 0)
+      .sort((a, b) => b.rankScore - a.rankScore || b.score - a.score || a.driver.localeCompare(b.driver))
+      .slice(0, 12);
+
+    const weights = candidates.map(candidate => Math.pow(Math.max(candidate.rankScore, candidate.score), 1.18));
+    const totalWeight = weights.reduce((sum, weight) => sum + weight, 0) || 1;
+    candidates.forEach((candidate, index) => {
+      candidate.probability = round((weights[index] / totalWeight) * 100, 2);
+      candidate.confidence = clamp(Math.round(candidate.score * 0.78 + candidate.probability * 0.22), 0, 99);
+      candidate.sources = candidate.sources.sort();
+    });
+
+    const best = candidates[0] || null;
+    const second = candidates[1] || null;
+    const margin = best && second ? best.rankScore - second.rankScore : best ? best.rankScore : 0;
+    const confidence = best
+      ? clamp(Math.round(best.score * 0.72 + best.probability * 0.18 + Math.min(10, margin * 0.4)), 0, 99)
+      : 0;
+
+    const badges = [];
+    if (best?.sources?.length >= 3) badges.push('multi_source_agreement');
+    if (this.clusterSummary.clusters.length) badges.push('cluster_behavior_seen');
+    if (this.dpIds.length) badges.push('dp_behavior_seen');
+    if (this.dpReportSummary.recommendation) badges.push('learning_report_seen');
+    if (margin < 8 && candidates.length > 1) badges.push('close_race_manual_review');
+    if (confidence >= 85) badges.push('high_confidence_route');
+
+    return {
+      suggestedDriver: best?.driver || null,
+      deviceType: best?.deviceTypes?.[0] || this.observedDeviceTypes[0] || 'unknown',
+      confidence,
+      probability: best?.probability || 0,
+      confidenceClass: confidence >= 85 ? 'high' : confidence >= 65 ? 'medium' : confidence >= 45 ? 'low' : 'unknown',
+      candidates,
+      evidenceBadges: badges,
+      observed: {
+        manufacturerName: this.data.manufacturerName || null,
+        modelId: this.data.modelId || null,
+        endpointCount: this.clusterSummary.endpointCount,
+        clusters: this.clusterSummary.clusters,
+        hasTuya: this.clusterSummary.hasTuya,
+        dpIds: this.dpIds,
+        capabilities: unique(this.observedCapabilities).sort(),
+        deviceTypes: unique(this.observedDeviceTypes).sort(),
+      },
+      sources: this.sourceSummary,
+      generatedAt: new Date().toISOString(),
+      action: confidence >= 90 ? 'safe_recommendation' : confidence >= 70 ? 'recommendation_with_review' : 'learn_more',
+    };
+  }
+}
+
+module.exports = ProbabilisticDeviceDetector;

--- a/lib/helpers/UnknownDeviceHandler.js
+++ b/lib/helpers/UnknownDeviceHandler.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const ProbabilisticDeviceDetector = require('./ProbabilisticDeviceDetector');
+
 /**
  * UNKNOWN DEVICE HANDLER
  * 
@@ -109,7 +111,9 @@ class UnknownDeviceHandler {
       capabilities: [],
       gangCount: 1,
       powerSource: 'unknown',
-      matchedPatterns: []
+      matchedPatterns: [],
+      probabilistic: null,
+      alternatives: []
     };
     
     const { modelId, manufacturerName, endpoints } = data;
@@ -184,9 +188,47 @@ class UnknownDeviceHandler {
         analysis.matchedPatterns.push(`endpoints:${epCount}_gang`);
       }
     }
+
+    // 5. Probabilistic local cross-source detection
+    try {
+      const probabilistic = ProbabilisticDeviceDetector.detect({
+        ...data,
+        capabilities: analysis.capabilities,
+        observedDps: data.observedDps || data.dps || data.dpMappings,
+        dpAutoDiscoveryReport: data.dpAutoDiscoveryReport || data.autoDiscoveryReport
+      });
+
+      analysis.probabilistic = probabilistic;
+      analysis.alternatives = probabilistic.candidates.slice(1, 5).map(candidate => ({
+        driver: candidate.driver,
+        confidence: candidate.confidence,
+        probability: candidate.probability,
+        sources: candidate.sources,
+        evidence: candidate.evidence.slice(0, 5)
+      }));
+
+      if (probabilistic.observed?.capabilities?.length) {
+        analysis.capabilities = [...new Set([
+          ...analysis.capabilities,
+          ...probabilistic.observed.capabilities.filter(cap => cap !== 'tuya_dp')
+        ])];
+      }
+
+      if (probabilistic.suggestedDriver && probabilistic.confidence >= 55) {
+        analysis.suggestedDriver = probabilistic.suggestedDriver;
+        analysis.confidence = Math.max(analysis.confidence, probabilistic.confidence);
+        analysis.matchedPatterns.push(`probabilistic:${probabilistic.suggestedDriver}:${probabilistic.confidence}%`);
+        if (analysis.deviceType === 'unknown' || probabilistic.confidence >= analysis.confidence) {
+          analysis.deviceType = probabilistic.deviceType || analysis.deviceType;
+        }
+      }
+    } catch (err) {
+      analysis.matchedPatterns.push(`probabilistic_error:${err.message}`);
+    }
     
-    // 5. Suggest Driver
-    analysis.suggestedDriver = this.suggestDriver(analysis);
+    // 6. Suggest Driver
+    analysis.suggestedDriver = analysis.suggestedDriver || this.suggestDriver(analysis);
+    analysis.confidence = Math.max(0, Math.min(99, Math.round(analysis.confidence)));
     
     return analysis;
   }
@@ -198,12 +240,52 @@ class UnknownDeviceHandler {
     const clusters = new Set();
     
     for (const ep of Object.values(endpoints)) {
-      if (ep.clusters) {
-        ep.clusters.forEach(c => clusters.add(c));
+      if (Array.isArray(ep.clusters)) {
+        ep.clusters.forEach(c => {
+          const id = this.clusterIdFromAny(c, null);
+          clusters.add(id === null ? c : id);
+        });
+      } else if (ep.clusters && typeof ep.clusters === 'object') {
+        Object.entries(ep.clusters).forEach(([key, cluster]) => {
+          const id = this.clusterIdFromAny(key, cluster);
+          clusters.add(id === null ? key : id);
+        });
       }
     }
     
     return Array.from(clusters);
+  }
+
+  clusterIdFromAny(key, cluster) {
+    const clusterNames = {
+      powerConfiguration: 0x0001,
+      genPowerCfg: 0x0001,
+      onOff: 0x0006,
+      genOnOff: 0x0006,
+      levelControl: 0x0008,
+      genLevelCtrl: 0x0008,
+      windowCovering: 0x0102,
+      thermostat: 0x0201,
+      colorControl: 0x0300,
+      illuminanceMeasurement: 0x0400,
+      temperatureMeasurement: 0x0402,
+      relativeHumidity: 0x0405,
+      occupancySensing: 0x0406,
+      iasZone: 0x0500,
+      ssIasZone: 0x0500,
+      metering: 0x0702,
+      electricalMeasurement: 0x0B04,
+      tuya: 0xEF00,
+      tuyaSpecific: 0xEF00,
+      manuSpecificTuya: 0xEF00
+    };
+
+    if (clusterNames[key] !== undefined) return clusterNames[key];
+    const numericKey = typeof key === 'string' && /^0x/i.test(key) ? parseInt(key, 16) : Number(key);
+    if (Number.isFinite(numericKey)) return numericKey;
+    const rawId = cluster?.ID ?? cluster?.id ?? cluster?.clusterId;
+    const numericId = typeof rawId === 'string' && /^0x/i.test(rawId) ? parseInt(rawId, 16) : Number(rawId);
+    return Number.isFinite(numericId) ? numericId : null;
   }
   
   /**
@@ -307,6 +389,11 @@ class UnknownDeviceHandler {
     this.homey.log('💡 RECOMMENDATION:');
     this.homey.log(`   Suggested Driver: ${analysis.suggestedDriver}`);
     this.homey.log(`   Matched Patterns: ${analysis.matchedPatterns.join(', ')}`);
+    if (analysis.probabilistic) {
+      this.homey.log(`   Probability: ${analysis.probabilistic.probability}% (${analysis.probabilistic.confidenceClass})`);
+      this.homey.log(`   Evidence Badges: ${analysis.probabilistic.evidenceBadges.join(', ') || 'None'}`);
+      this.homey.log(`   Top Candidates: ${analysis.probabilistic.candidates.slice(0, 3).map(c => `${c.driver}:${c.confidence}%`).join(', ')}`);
+    }
     this.homey.log('');
     this.homey.log('📝 NEXT STEPS:');
     this.homey.log('   1. Remove device from Homey');

--- a/lib/managers/DriverMigrationManager.js
+++ b/lib/managers/DriverMigrationManager.js
@@ -1,5 +1,12 @@
 'use strict';
 const { normalize: normalizeCI, containsCI } = require('../utils/CaseInsensitiveMatcher');
+const ProbabilisticDeviceDetector = require('../helpers/ProbabilisticDeviceDetector');
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null) return [];
+  return [value];
+}
 
 /**
  * DriverMigrationManager - Gestion de migration automatique vers le bon driver
@@ -28,6 +35,7 @@ class DriverMigrationManager {
       confidence: 0,
       reason: []
     };
+    const probabilisticBest = this._determineProbabilisticBestDriver(deviceInfo, clusterAnalysis);
 
     const deviceType = clusterAnalysis.deviceType;
     const powerSource = clusterAnalysis.powerSource;
@@ -216,10 +224,61 @@ class DriverMigrationManager {
       bestDriver.reason.push('Window covering cluster detected');
     }
 
+    const probabilisticHasExactSource = probabilisticBest?.probabilistic?.candidates?.[0]?.sources?.some(source =>
+      source === 'compound_fingerprint_db' || source === 'runtime_fingerprint_db'
+    );
+    if (probabilisticBest && (
+      probabilisticBest.confidence > bestDriver.confidence ||
+      (probabilisticBest.confidence >= 0.85 && probabilisticHasExactSource)
+    )) {
+      bestDriver.driverId = probabilisticBest.driverId;
+      bestDriver.confidence = probabilisticBest.confidence;
+      bestDriver.reason = probabilisticBest.reason;
+      bestDriver.probabilistic = probabilisticBest.probabilistic;
+    }
+
     this.log(`   ✅ Best driver: ${bestDriver.driverId || 'unknown'} (confidence: ${bestDriver.confidence})`);
     this.log(`      Reasons: ${bestDriver.reason.join(', ')}`);
 
     return bestDriver;
+  }
+
+  _determineProbabilisticBestDriver(deviceInfo = {}, clusterAnalysis = {}) {
+    try {
+      const result = ProbabilisticDeviceDetector.detect({
+        manufacturerName: deviceInfo.manufacturerName || deviceInfo.manufacturer,
+        modelId: deviceInfo.modelId || deviceInfo.productId || deviceInfo.model,
+        endpoints: deviceInfo.endpoints,
+        capabilities: [
+          ...asArray(deviceInfo.capabilities),
+          ...asArray(clusterAnalysis.features),
+          ...asArray(clusterAnalysis.capabilities)
+        ],
+        observedDps: deviceInfo.observedDps || deviceInfo.dps || deviceInfo.dpMappings,
+        dpAutoDiscoveryReport: deviceInfo.dpAutoDiscoveryReport || deviceInfo.autoDiscoveryReport
+      });
+
+      if (!result.suggestedDriver || result.confidence < 70) return null;
+      return {
+        driverId: result.suggestedDriver,
+        confidence: result.confidence / 100,
+        reason: [
+          `probabilistic local detection: ${result.confidence}%`,
+          `probability: ${result.probability}%`,
+          ...result.evidenceBadges.slice(0, 4),
+          ...((result.candidates[0]?.evidence || []).slice(0, 5))
+        ],
+        probabilistic: {
+          confidence: result.confidence,
+          probability: result.probability,
+          candidates: result.candidates.slice(0, 5),
+          sources: result.sources
+        }
+      };
+    } catch (err) {
+      this.log(`[MIGRATION] Probabilistic detector skipped: ${err.message}`);
+      return null;
+    }
   }
 
   /**

--- a/test/critical/probabilistic-device-detection.test.js
+++ b/test/critical/probabilistic-device-detection.test.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const assert = require('assert');
+
+const ProbabilisticDeviceDetector = require('../../lib/helpers/ProbabilisticDeviceDetector');
+const UnknownDeviceHandler = require('../../lib/helpers/UnknownDeviceHandler');
+const DriverMigrationManager = require('../../lib/managers/DriverMigrationManager');
+
+function createHomeyLog() {
+  return {
+    messages: [],
+    log(...args) {
+      this.messages.push(args.join(' '));
+    },
+    error(...args) {
+      this.messages.push(args.join(' '));
+    }
+  };
+}
+
+describe('probabilistic local device detection', function() {
+  it('keeps exact compound fingerprints stronger than broad TS0601 product matches', function() {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZE284_0ints6wl',
+      modelId: 'TS0601',
+      endpoints: {
+        1: { clusters: { tuya: { clusterId: 0xEF00 }, powerConfiguration: { clusterId: 0x0001 } } }
+      },
+      observedDps: { 3: 42, 5: 214, 15: 91 }
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'soil_sensor');
+    assert(result.confidence >= 85, `expected high confidence, got ${result.confidence}`);
+    assert(result.candidates[0].sources.includes('compound_fingerprint_db'));
+    assert(result.observed.dpIds.includes(15));
+  });
+
+  it('uses learned DP behavior to route unknown TS0601 variants toward the right family', function() {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZE200_probably_new',
+      modelId: 'TS0601',
+      endpoints: {
+        1: { clusters: { tuya: { clusterId: 0xEF00 } } }
+      },
+      dpAutoDiscoveryReport: {
+        profileRecommendation: {
+          profileId: 'presence_sensor_radar',
+          confidence: 88,
+          observedCapabilities: ['alarm_motion', 'measure_luminance', 'target_distance'],
+          observedTypes: ['presence_bool', 'lux_direct', 'distance']
+        },
+        dynamicDPMap: {
+          1: { capability: 'alarm_motion', type: 'presence_bool', confidence: 82 },
+          103: { capability: 'measure_luminance', type: 'lux_direct', confidence: 77 },
+          9: { capability: 'target_distance', type: 'distance', confidence: 72 }
+        }
+      }
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'presence_sensor_radar');
+    assert(result.confidence >= 65, `expected useful confidence, got ${result.confidence}`);
+    assert(result.evidenceBadges.includes('learning_report_seen'));
+    assert(result.observed.capabilities.includes('target_distance'));
+  });
+
+  it('enriches UnknownDeviceHandler recommendations with ranked candidates', async function() {
+    const homey = createHomeyLog();
+    const handler = new UnknownDeviceHandler(homey);
+
+    const analysis = await handler.analyzeDevice({
+      manufacturerName: '_TZ3000_u3nv1jwk',
+      modelId: 'TS004F',
+      endpoints: {
+        1: { clusters: { powerConfiguration: {}, onOff: {} } },
+        2: { clusters: { onOff: {} } },
+        3: { clusters: { onOff: {} } },
+        4: { clusters: { onOff: {} } }
+      }
+    });
+
+    assert.strictEqual(analysis.suggestedDriver, 'button_wireless_4');
+    assert(analysis.probabilistic);
+    assert(analysis.alternatives.length > 0);
+    assert(analysis.matchedPatterns.some(pattern => pattern.startsWith('probabilistic:button_wireless_4')));
+  });
+
+  it('lets migration manager prefer a stronger probabilistic route', function() {
+    const manager = new DriverMigrationManager(createHomeyLog());
+
+    const best = manager.determineBestDriver({
+      manufacturerName: '_TZE284_0ints6wl',
+      modelId: 'TS0601',
+      endpoints: {
+        1: { clusters: { tuya: { clusterId: 0xEF00 }, powerConfiguration: { clusterId: 0x0001 } } }
+      },
+      observedDps: { 3: 60, 5: 210, 15: 90 }
+    }, {
+      deviceType: 'sensor',
+      powerSource: 'battery',
+      features: ['measure_temperature', 'measure_humidity', 'measure_battery']
+    });
+
+    assert.strictEqual(best.driverId, 'soil_sensor');
+    assert(best.confidence >= 0.85);
+    assert(best.reason.some(reason => reason.includes('probabilistic local detection')));
+  });
+});


### PR DESCRIPTION
## Summary

Adds a local-first probabilistic device detection layer for unknown devices and migration recommendations.

- New `ProbabilisticDeviceDetector` crosses compound fingerprints, runtime fingerprints, driver mapping DB, MFS/community databases, Zigbee clusters, observed Tuya DP IDs, and the 15-minute DP learning report.
- Unknown device analysis now includes ranked candidates, probability/confidence, evidence badges, and cross-source alternatives.
- Driver migration recommendations can use the probabilistic result when confidence is strong enough, including exact fingerprint overrides for generic legacy routes.
- Adds a reference doc for local probabilistic detection rules and safety thresholds.
- Adds critical regression coverage for exact TS0601 soil routing, learned radar/presence behavior, UnknownDeviceHandler enrichment, and migration override behavior.

## Safety

The detector is lazy-loaded and guarded per source. Missing or corrupt local databases degrade to lower confidence instead of crashing pairing, unknown-device reporting, or migration analysis. Broad product IDs such as `TS0601` are weak priors only; exact fingerprints and observed behavior carry more weight.

## Validation

- `node --check` on changed JS files and test
- `npx mocha test\critical\probabilistic-device-detection.test.js test\dynamic-dp-auto-discovery.test.js test\button-flow-runtime-routing.test.js --timeout 10000` — 24 passing
- `npm run precommit` — passed
- Git pre-commit hook — passed all 9 layers
- Git pre-push Homey gate — passed

Known repo warnings unchanged: app.json `api` field review warning, synthetic manufacturer identifiers to be pruned by prepare-publish, and existing fingerprint catalog warnings.