### PR TITLE
Add manufacturer device quirk detection

### DIFF
--- a/docs/MANUFACTURER_DEVICE_QUIRKS.md
+++ b/docs/MANUFACTURER_DEVICE_QUIRKS.md
@@ -1,0 +1,60 @@
+# Manufacturer Device Quirks
+
+Updated: 2026-07-05
+
+This reference documents the manufacturer/model behavior rules used by
+`lib/helpers/ManufacturerDeviceQuirkRegistry.js`.
+
+## Why This Exists
+
+Tuya manufacturers often reuse the same `modelId` for different physical
+products. The detector must therefore combine:
+
+- exact `manufacturerName + modelId` fingerprints,
+- endpoint count and functional endpoint shape,
+- input/output clusters,
+- private Tuya clusters `0xE000`, `0xE001`, `0xEF00`,
+- DP learning reports and observed DP count,
+- forum/GitHub evidence.
+
+The result is intentionally explainable: every quirk adds evidence, preferred
+drivers, penalized drivers, and source references to the probabilistic detector.
+
+## Active Rules
+
+| Quirk | Functional meaning | Preferred driver | Guardrail |
+| --- | --- | --- | --- |
+| `moes_ts0014_4gang_actuator_false_battery` | `_TZ3000_mrduubod / TS0014` is a 4-gang wall switch with real loads. Some Basic reports say battery. | `wall_switch_4gang_1way` | Ignore false Basic `powerSource=battery`; penalize wireless button and knob drivers. |
+| `ts00xx_4gang_actuator_signature` | Unknown TS000x/TS001x devices with multiple OnOff endpoints are actuators, not scene-only remotes. | `wall_switch_4gang_1way` when `0xE000/0xE001` are present, otherwise the matching `switch_Ngang`. | Prevent routing to battery/button/climate fallbacks. |
+| `ts004f_four_endpoint_scene_remote_signature` | TS004F with four functional OnOff endpoints is a 4-button scene remote. | `button_wireless_4` | Penalize smart knob and wall switch routes. |
+| `ts004f_single_endpoint_rotary_or_smart_button_signature` | TS004F with one functional endpoint and output LevelControl/ColorControl is a rotary/smart knob. | `smart_knob_rotary` | Penalize 4-button routes. |
+| `ts004f_known_one_button_variant` | Certain manufacturers use TS004F for one-button variants. | `button_wireless_1` / `smart_knob` | Penalize 4-button routes. |
+| `ef00_full_state_map_or_flood_signature` | EF00 devices may publish full state maps repeatedly. | none | Diagnostics mark exact-payload dedupe only; changed DP values must still be processed. |
+
+## Source Cross-Checks
+
+- Zigbee2MQTT `TS004F`: documents 4-button wireless switch behavior, battery,
+  command/event modes, and non-standard/event-vs-standard command differences.
+- Zigbee2MQTT `TS0014`: documents 4-gang wall switch state endpoints and
+  `state_action` behavior.
+- Koenkk/zigbee2mqtt #15339: `_TZ3000_mrduubod / TS0014` interview shows four
+  OnOff endpoints plus `0xE000/0xE001`; converter forces mains because the device
+  can report battery incorrectly.
+- JohanBendz/com.tuya.zigbee #1413 and Homey forum #2099: same Moes TS0014
+  variant and Homey interview context.
+- zigpy/zha-device-handlers #3604 and #4301 plus Koenkk/zigbee2mqtt #27239:
+  TS004F can be a rotary knob with one endpoint and LevelControl/ColorControl
+  action outputs, not a four-button remote.
+- Koenkk/zigbee2mqtt #27119: `_TZ3000_xabckq1v / TS004F` variants can lack some
+  operation-mode reads/actions, so route by endpoint/transport shape as well as
+  exact manufacturer.
+
+## Implementation Notes
+
+- Endpoint `242` and profile `0xA1E0` are GreenPower metadata and are excluded
+  from gang counts.
+- Manufacturer quirks vote in the probabilistic detector and also apply candidate
+  penalties. This keeps exact fingerprints strong while allowing unknown sibling
+  devices to inherit safe behavior.
+- The quirk registry does not suppress EF00 frames. Raw/DP flood handling remains
+  in `RawFrameDeduplicator`, `TuyaEF00Manager`, and `IntelligentFrameAnalyzer`.

--- a/lib/helpers/ManufacturerDeviceQuirkRegistry.js
+++ b/lib/helpers/ManufacturerDeviceQuirkRegistry.js
@@ -1,0 +1,430 @@
+'use strict';
+
+const PRIVATE_E000 = 0xE000;
+const PRIVATE_E001 = 0xE001;
+const TUYA_EF00 = 0xEF00;
+const GREEN_POWER_ENDPOINT = 242;
+const GREEN_POWER_PROFILE = 0xA1E0;
+
+const CLUSTER_NAME_IDS = {
+  basic: 0x0000,
+  powerconfiguration: 0x0001,
+  genpowercfg: 0x0001,
+  onoff: 0x0006,
+  genonoff: 0x0006,
+  levelcontrol: 0x0008,
+  genlevelctrl: 0x0008,
+  colorcontrol: 0x0300,
+  manuspecifictuya_3: TUYA_EF00,
+  manuspecifictuya: TUYA_EF00,
+  tuya: TUYA_EF00,
+  tuyaspecific: TUYA_EF00,
+};
+
+const TS004F_4_BUTTON_MANUFACTURERS = [
+  '_TZ3000_u3nv1jwk',
+  '_TZ3000_kfu8zapd',
+  '_TZ3000_xabckq1v',
+  '_TZ3000_czuyt8lz',
+  '_TZ3000_b3mgfu0d',
+  '_TZ3000_rco1yzb1',
+  '_TZ3000_abrsvsou',
+  '_TZ3000_4fjiwweb',
+];
+
+const TS004F_ROTARY_MANUFACTURERS = [
+  '_TZ3000_402vrq2i',
+  '_TZ3000_qja6nq5z',
+  '_TZ3000_gwkzibhs',
+  '_TZ3000_ugi8ky6u',
+];
+
+const TS004F_ONE_BUTTON_MANUFACTURERS = [
+  '_TZ3000_kaflzta4',
+  '_TZ3000_ja5osu5g',
+  '_TZ3000_an5rjiwd',
+];
+
+const KNOWN_QUIRKS = [
+  {
+    id: 'moes_ts0014_4gang_actuator_false_battery',
+    manufacturers: ['_TZ3000_mrduubod'],
+    modelIds: ['TS0014'],
+    preferredDrivers: ['wall_switch_4gang_1way', 'switch_4gang'],
+    penalizedDrivers: ['button_wireless_4', 'button_wireless_3', 'button_wireless_2', 'button_wireless_1', 'smart_knob', 'smart_knob_rotary', 'climate_sensor', 'device_generic_tuya_universal'],
+    boost: 76,
+    candidateBoost: 30,
+    penalty: 48,
+    capabilities: ['onoff', 'button.1', 'button.2', 'button.3', 'button.4'],
+    deviceTypes: ['switch', 'actuator', 'wall_switch'],
+    powerSourceOverride: 'mains',
+    evidence: ['exact_moes_ts0014', 'four_onoff_endpoints', 'private_e000_e001', 'ignore_basic_power_source_battery'],
+    sourceRefs: ['homey_forum_2099', 'johan_1413', 'z2m_15339', 'z2m_ts0014'],
+  },
+  {
+    id: 'ts004f_known_4button_scene_remote',
+    manufacturers: TS004F_4_BUTTON_MANUFACTURERS,
+    modelIds: ['TS004F', 'TS0044'],
+    preferredDrivers: ['button_wireless_4'],
+    penalizedDrivers: ['smart_knob_rotary', 'switch_4gang', 'wall_switch_4gang_1way', 'climate_sensor', 'device_generic_tuya_universal'],
+    boost: 68,
+    candidateBoost: 26,
+    penalty: 42,
+    capabilities: ['measure_battery', 'button.1', 'button.2', 'button.3', 'button.4'],
+    deviceTypes: ['button', 'scene_remote'],
+    evidence: ['known_ts004f_4button_manufacturer', 'operation_mode_command_event', 'zcl_e000_levelcontrol_paths'],
+    sourceRefs: ['z2m_ts004f', 'johan_270', 'z2m_27119'],
+  },
+  {
+    id: 'ts004f_known_rotary_knob',
+    manufacturers: TS004F_ROTARY_MANUFACTURERS,
+    modelIds: ['TS004F'],
+    preferredDrivers: ['smart_knob_rotary', 'smart_knob'],
+    penalizedDrivers: ['button_wireless_4', 'switch_4gang', 'wall_switch_4gang_1way', 'climate_sensor', 'device_generic_tuya_universal'],
+    boost: 74,
+    candidateBoost: 30,
+    penalty: 48,
+    capabilities: ['measure_battery', 'button.1', 'dim'],
+    deviceTypes: ['rotary', 'button', 'scene_remote'],
+    evidence: ['known_ts004f_rotary_manufacturer', 'single_endpoint_rotary_signature', 'levelcontrol_rotation_actions'],
+    sourceRefs: ['zha_3604', 'zha_4301', 'z2m_27239'],
+  },
+  {
+    id: 'ts004f_known_one_button_variant',
+    manufacturers: TS004F_ONE_BUTTON_MANUFACTURERS,
+    modelIds: ['TS004F'],
+    preferredDrivers: ['button_wireless_1', 'smart_knob'],
+    penalizedDrivers: ['button_wireless_4', 'switch_4gang', 'wall_switch_4gang_1way', 'climate_sensor'],
+    boost: 62,
+    candidateBoost: 24,
+    penalty: 40,
+    capabilities: ['measure_battery', 'button.1'],
+    deviceTypes: ['button', 'scene_remote'],
+    evidence: ['known_ts004f_not_4gang', 'single_button_variant'],
+    sourceRefs: ['local_variation_audit', 'z2m_8951'],
+  },
+];
+
+function asArray(value) {
+  if (Array.isArray(value)) return value;
+  if (value === undefined || value === null) return [];
+  return [value];
+}
+
+function unique(values) {
+  return [...new Set(values.filter(value => value !== undefined && value !== null && value !== ''))];
+}
+
+function normalizeText(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function parseNumber(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    if (/^0x/i.test(trimmed)) return parseInt(trimmed, 16);
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}
+
+function clusterIdFromValue(value) {
+  const direct = parseNumber(value);
+  if (direct !== null) return direct;
+  const named = CLUSTER_NAME_IDS[normalizeText(value)];
+  if (named !== undefined) return named;
+  if (value && typeof value === 'object') {
+    return parseNumber(value.ID ?? value.id ?? value.clusterId ?? value.cluster);
+  }
+  return null;
+}
+
+function collectClusters(endpoint, keys) {
+  const clusters = new Set();
+  for (const key of keys) {
+    const raw = endpoint?.[key];
+    if (!raw) continue;
+    if (Array.isArray(raw)) {
+      for (const item of raw) {
+        const id = clusterIdFromValue(item);
+        if (id !== null) clusters.add(id);
+      }
+      continue;
+    }
+    if (typeof raw === 'object') {
+      for (const [clusterKey, clusterValue] of Object.entries(raw)) {
+        const id = clusterIdFromValue(clusterKey) ?? clusterIdFromValue(clusterValue);
+        if (id !== null) clusters.add(id);
+      }
+    }
+  }
+  return [...clusters].sort((a, b) => a - b);
+}
+
+function endpointIdFromEntry(entryId, endpoint) {
+  return parseNumber(endpoint?.endpointId ?? endpoint?.epId ?? endpoint?.id ?? entryId);
+}
+
+function normalizeEndpointEntries(endpoints = {}) {
+  if (!endpoints) return [];
+  if (Array.isArray(endpoints)) {
+    return endpoints.map((endpoint, index) => [endpointIdFromEntry(index + 1, endpoint), endpoint]);
+  }
+  if (Array.isArray(endpoints.endpointDescriptors)) {
+    return endpoints.endpointDescriptors.map((endpoint, index) => [endpointIdFromEntry(index + 1, endpoint), endpoint]);
+  }
+  if (endpoints.endpoints && endpoints.endpoints !== endpoints) {
+    return normalizeEndpointEntries(endpoints.endpoints);
+  }
+  if (endpoints.extendedEndpointDescriptors && typeof endpoints.extendedEndpointDescriptors === 'object') {
+    return Object.entries(endpoints.extendedEndpointDescriptors).map(([endpointId, endpoint]) => [endpointIdFromEntry(endpointId, endpoint), endpoint]);
+  }
+  return Object.entries(endpoints).map(([endpointId, endpoint]) => [endpointIdFromEntry(endpointId, endpoint), endpoint]);
+}
+
+function normalizeEndpointSummary(endpoints = {}) {
+  const records = [];
+  for (const [entryId, endpoint] of normalizeEndpointEntries(endpoints)) {
+    if (!endpoint || typeof endpoint !== 'object') continue;
+    const endpointId = endpointIdFromEntry(entryId, endpoint);
+    if (endpointId === null) continue;
+    const profileId = parseNumber(endpoint.applicationProfileId ?? endpoint.profileId ?? endpoint.profId);
+    const deviceId = parseNumber(endpoint.applicationDeviceId ?? endpoint.deviceType ?? endpoint.devId);
+    const inputClusters = collectClusters(endpoint, ['clusters', 'inputClusters', 'serverClusters', 'inClusterList', 'inputClusterList']);
+    const outputClusters = collectClusters(endpoint, ['outputClusters', 'clientClusters', 'outClusterList', 'outputClusterList']);
+    const allClusters = unique([...inputClusters, ...outputClusters]).sort((a, b) => a - b);
+    const greenPower = Number(endpointId) === GREEN_POWER_ENDPOINT || profileId === GREEN_POWER_PROFILE;
+    records.push({ endpointId, profileId, deviceId, inputClusters, outputClusters, allClusters, greenPower });
+  }
+  return records;
+}
+
+function hasCluster(record, clusterId, direction = 'all') {
+  if (direction === 'input') return record.inputClusters.includes(clusterId);
+  if (direction === 'output') return record.outputClusters.includes(clusterId);
+  return record.allClusters.includes(clusterId);
+}
+
+function countWhere(records, predicate) {
+  return records.filter(record => !record.greenPower && predicate(record)).length;
+}
+
+function collectPowerSourceHints(value, hints = [], depth = 0) {
+  if (!value || depth > 6) return hints;
+  if (Array.isArray(value)) {
+    for (const item of value) collectPowerSourceHints(item, hints, depth + 1);
+    return hints;
+  }
+  if (typeof value !== 'object') return hints;
+
+  const namedPowerSource = normalizeText(value.name) === 'powersource' || normalizeText(value.name) === 'power_source';
+  if (namedPowerSource && value.value !== undefined) {
+    hints.push(String(value.value));
+  }
+  for (const [key, nested] of Object.entries(value)) {
+    if (normalizeText(key) === 'powersource' || normalizeText(key) === 'power_source') {
+      hints.push(String(nested));
+      continue;
+    }
+    collectPowerSourceHints(nested, hints, depth + 1);
+  }
+  return hints;
+}
+
+function addQuirk(quirks, quirk, extra = {}) {
+  quirks.push({
+    ...quirk,
+    ...extra,
+    evidence: unique([...(quirk.evidence || []), ...(extra.evidence || [])]),
+    sourceRefs: unique([...(quirk.sourceRefs || []), ...(extra.sourceRefs || [])]),
+  });
+}
+
+function matchesFingerprint(quirk, manufacturerName, modelId) {
+  const mfr = normalizeText(manufacturerName);
+  const model = normalizeText(modelId);
+  const manufacturerMatches = !quirk.manufacturers?.length ||
+    quirk.manufacturers.some(value => normalizeText(value) === mfr);
+  const modelMatches = !quirk.modelIds?.length ||
+    quirk.modelIds.some(value => normalizeText(value) === model);
+  return manufacturerMatches && modelMatches;
+}
+
+function hasDriverMatch(driverId, matchers = []) {
+  const driver = normalizeText(driverId);
+  return asArray(matchers).some(matcher => {
+    const normalized = normalizeText(matcher);
+    if (!normalized) return false;
+    if (normalized.endsWith('*')) return driver.startsWith(normalized.slice(0, -1));
+    return driver === normalized;
+  });
+}
+
+class ManufacturerDeviceQuirkRegistry {
+  static analyze(context = {}) {
+    const data = context.data || context;
+    const manufacturerName = data.manufacturerName || data.manufacturer || data.mfr || '';
+    const modelId = data.modelId || data.productId || data.model || '';
+    const model = normalizeText(modelId);
+    const endpoints = normalizeEndpointSummary(data.endpoints || data.zclNode?.endpoints || {});
+    const functional = endpoints.filter(record => !record.greenPower);
+    const powerSourceHints = unique(collectPowerSourceHints(data).map(normalizeText));
+    const dpIds = unique(asArray(context.dpIds).map(Number).filter(Number.isFinite));
+
+    const stats = {
+      functionalEndpointCount: functional.length,
+      inputOnOffEndpointCount: countWhere(endpoints, record => hasCluster(record, 0x0006, 'input')),
+      outputOnOffEndpointCount: countWhere(endpoints, record => hasCluster(record, 0x0006, 'output')),
+      inputPowerCfgEndpointCount: countWhere(endpoints, record => hasCluster(record, 0x0001, 'input')),
+      privateE000EndpointCount: countWhere(endpoints, record => hasCluster(record, PRIVATE_E000, 'input')),
+      privateE001EndpointCount: countWhere(endpoints, record => hasCluster(record, PRIVATE_E001, 'input')),
+      outputLevelEndpointCount: countWhere(endpoints, record => hasCluster(record, 0x0008, 'output')),
+      outputColorEndpointCount: countWhere(endpoints, record => hasCluster(record, 0x0300, 'output')),
+      tuyaEndpointCount: countWhere(endpoints, record => hasCluster(record, TUYA_EF00)),
+      powerSourceHints,
+      hasFalseBatteryHint: powerSourceHints.includes('battery') && countWhere(endpoints, record => hasCluster(record, 0x0006, 'input')) >= 2,
+      dpCount: dpIds.length,
+    };
+
+    const quirks = [];
+    for (const quirk of KNOWN_QUIRKS) {
+      if (matchesFingerprint(quirk, manufacturerName, modelId)) {
+        addQuirk(quirks, quirk);
+      }
+    }
+
+    if (/^ts00[01][1-4]$/.test(model) && stats.inputOnOffEndpointCount >= 2) {
+      const gangCount = Math.min(4, Math.max(1, stats.inputOnOffEndpointCount));
+      const hasPrivateSwitchClusters = Boolean(stats.privateE000EndpointCount || stats.privateE001EndpointCount);
+      const preferredDrivers = gangCount === 4
+        ? [hasPrivateSwitchClusters ? 'wall_switch_4gang_1way' : 'switch_4gang']
+        : [`switch_${gangCount}gang`, `wall_switch_${gangCount}gang_1way`];
+      addQuirk(quirks, {
+        id: `ts00xx_${gangCount}gang_actuator_signature`,
+        preferredDrivers,
+        penalizedDrivers: ['button_wireless_4', 'button_wireless_3', 'button_wireless_2', 'button_wireless_1', 'smart_knob', 'smart_knob_rotary', 'climate_sensor', 'device_generic_tuya_universal'],
+        boost: 58 + gangCount * 4,
+        candidateBoost: 20 + gangCount * 2,
+        penalty: 36,
+        capabilities: ['onoff', ...Array.from({ length: gangCount }, (_, index) => `button.${index + 1}`)],
+        deviceTypes: ['switch', 'actuator', 'wall_switch'],
+        powerSourceOverride: 'mains',
+        evidence: unique([
+          `model_family:${modelId}`,
+          `onoff_endpoints:${stats.inputOnOffEndpointCount}`,
+          stats.privateE000EndpointCount ? 'private_e000_present' : null,
+          stats.privateE001EndpointCount ? 'private_e001_present' : null,
+          stats.hasFalseBatteryHint ? 'ignore_basic_power_source_battery' : null,
+        ]),
+        sourceRefs: ['z2m_ts0014', 'z2m_15339', 'homey_forum_2099'],
+      });
+    }
+
+    if (model === 'ts004f' && stats.functionalEndpointCount >= 4 && stats.inputOnOffEndpointCount >= 3) {
+      addQuirk(quirks, {
+        id: 'ts004f_four_endpoint_scene_remote_signature',
+        preferredDrivers: ['button_wireless_4'],
+        penalizedDrivers: ['smart_knob_rotary', 'switch_4gang', 'wall_switch_4gang_1way', 'climate_sensor', 'device_generic_tuya_universal'],
+        boost: 66,
+        candidateBoost: 24,
+        penalty: 40,
+        capabilities: ['measure_battery', 'button.1', 'button.2', 'button.3', 'button.4'],
+        deviceTypes: ['button', 'scene_remote'],
+        evidence: unique([
+          'model_family:TS004F',
+          `functional_endpoints:${stats.functionalEndpointCount}`,
+          `onoff_endpoints:${stats.inputOnOffEndpointCount}`,
+          stats.inputPowerCfgEndpointCount ? 'battery_power_cfg_present' : null,
+          stats.privateE000EndpointCount ? 'private_e000_present' : null,
+          stats.outputLevelEndpointCount ? 'levelcontrol_actions_present' : null,
+        ]),
+        sourceRefs: ['z2m_ts004f', 'johan_270', 'z2m_27119'],
+      });
+    }
+
+    if (model === 'ts004f' && stats.functionalEndpointCount <= 1 &&
+        (stats.outputLevelEndpointCount || stats.outputColorEndpointCount || stats.outputOnOffEndpointCount)) {
+      addQuirk(quirks, {
+        id: 'ts004f_single_endpoint_rotary_or_smart_button_signature',
+        preferredDrivers: stats.outputLevelEndpointCount || stats.outputColorEndpointCount
+          ? ['smart_knob_rotary']
+          : ['smart_knob', 'button_wireless_1'],
+        penalizedDrivers: ['button_wireless_4', 'switch_4gang', 'wall_switch_4gang_1way', 'climate_sensor', 'device_generic_tuya_universal'],
+        boost: stats.outputLevelEndpointCount || stats.outputColorEndpointCount ? 70 : 56,
+        candidateBoost: 26,
+        penalty: 42,
+        capabilities: unique(['measure_battery', 'button.1', stats.outputLevelEndpointCount ? 'dim' : null]),
+        deviceTypes: ['rotary', 'button', 'scene_remote'],
+        evidence: unique([
+          'model_family:TS004F',
+          `functional_endpoints:${stats.functionalEndpointCount}`,
+          stats.outputLevelEndpointCount ? 'levelcontrol_output_rotation' : null,
+          stats.outputColorEndpointCount ? 'colorcontrol_output_rotation' : null,
+          stats.outputOnOffEndpointCount ? 'onoff_output_actions' : null,
+        ]),
+        sourceRefs: ['zha_3604', 'zha_4301', 'z2m_27239'],
+      });
+    }
+
+    if (stats.tuyaEndpointCount && (dpIds.length >= 4 || context.dpReportSummary?.dpIds?.length >= 4)) {
+      addQuirk(quirks, {
+        id: 'ef00_full_state_map_or_flood_signature',
+        preferredDrivers: [],
+        penalizedDrivers: [],
+        boost: 0,
+        candidateBoost: 0,
+        penalty: 0,
+        capabilities: ['tuya_dp'],
+        deviceTypes: ['tuya_dp'],
+        evidence: [`tuya_dp_count:${Math.max(dpIds.length, context.dpReportSummary?.dpIds?.length || 0)}`, 'dedupe_exact_payload_only'],
+        sourceRefs: ['raw_advertisement_state_tests'],
+      });
+    }
+
+    const deduped = [];
+    const seen = new Set();
+    for (const quirk of quirks) {
+      if (seen.has(quirk.id)) continue;
+      seen.add(quirk.id);
+      deduped.push(quirk);
+    }
+
+    return {
+      fingerprintKey: `${manufacturerName || '*'}|${modelId || '*'}`,
+      quirks: deduped,
+      stats,
+      endpointSummary: endpoints,
+      preferredDrivers: unique(deduped.flatMap(quirk => quirk.preferredDrivers || [])),
+      penalizedDrivers: unique(deduped.flatMap(quirk => quirk.penalizedDrivers || [])),
+      evidenceBadges: unique(deduped.flatMap(quirk => quirk.evidence || [])),
+      powerSourceOverride: deduped.find(quirk => quirk.powerSourceOverride)?.powerSourceOverride || null,
+    };
+  }
+
+  static driverEffect(analysis, driverId) {
+    let boost = 0;
+    let penalty = 0;
+    const evidence = [];
+    const contradictions = [];
+
+    for (const quirk of analysis?.quirks || []) {
+      if (hasDriverMatch(driverId, quirk.preferredDrivers)) {
+        const amount = Number.isFinite(quirk.candidateBoost) ? quirk.candidateBoost : Math.round((quirk.boost || 0) * 0.35);
+        boost += amount;
+        evidence.push(`manufacturer_quirk_preferred:${quirk.id}`);
+      }
+      if (hasDriverMatch(driverId, quirk.penalizedDrivers)) {
+        const amount = Number.isFinite(quirk.penalty) ? quirk.penalty : 30;
+        penalty += amount;
+        contradictions.push(`manufacturer_quirk_penalty:${quirk.id}`);
+      }
+    }
+
+    return { boost, penalty, evidence: unique(evidence), contradictions: unique(contradictions) };
+  }
+}
+
+module.exports = ManufacturerDeviceQuirkRegistry;

--- a/lib/helpers/ProbabilisticDeviceDetector.js
+++ b/lib/helpers/ProbabilisticDeviceDetector.js
@@ -2,6 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
+const ManufacturerDeviceQuirkRegistry = require('./ManufacturerDeviceQuirkRegistry');
 
 const ROOT = path.join(__dirname, '..', '..');
 const DP_DATABASE_PATH = path.join(ROOT, 'data', 'dp_database.json');
@@ -251,25 +252,49 @@ function extractClusterSummary(endpoints = {}) {
   const names = new Set();
   const endpointIds = [];
 
-  const entries = Array.isArray(endpoints)
-    ? endpoints.map((endpoint, index) => [String(endpoint.endpointId || endpoint.id || index + 1), endpoint])
-    : Object.entries(endpoints || {});
+  const entries = (() => {
+    if (Array.isArray(endpoints)) {
+      return endpoints.map((endpoint, index) => [String(endpoint.endpointId || endpoint.epId || endpoint.id || index + 1), endpoint]);
+    }
+    if (Array.isArray(endpoints?.endpointDescriptors)) {
+      return endpoints.endpointDescriptors.map((endpoint, index) => [String(endpoint.endpointId || endpoint.epId || endpoint.id || index + 1), endpoint]);
+    }
+    if (endpoints?.endpoints && endpoints.endpoints !== endpoints) {
+      return Object.entries(endpoints.endpoints || {});
+    }
+    if (endpoints?.extendedEndpointDescriptors && typeof endpoints.extendedEndpointDescriptors === 'object') {
+      return Object.entries(endpoints.extendedEndpointDescriptors);
+    }
+    return Object.entries(endpoints || {});
+  })();
 
   for (const [endpointId, endpoint] of entries) {
-    endpointIds.push(Number(endpointId) || endpointId);
-    const rawClusters = endpoint?.clusters || endpoint?.inputClusters || endpoint?.serverClusters || [];
+    const normalizedEndpointId = Number(endpoint?.endpointId || endpoint?.epId || endpoint?.id || endpointId) || endpointId;
+    const profileId = parseNumber(endpoint?.applicationProfileId ?? endpoint?.profileId ?? endpoint?.profId);
+    if (Number(normalizedEndpointId) === 242 || profileId === 0xA1E0) continue;
+    endpointIds.push(normalizedEndpointId);
 
-    if (Array.isArray(rawClusters)) {
-      for (const cluster of rawClusters) {
-        const id = clusterIdFromKey(cluster, null);
-        if (id !== null) clusters.add(id);
-        if (typeof cluster === 'string') names.add(cluster);
-      }
-    } else if (rawClusters && typeof rawClusters === 'object') {
-      for (const [key, cluster] of Object.entries(rawClusters)) {
-        const id = clusterIdFromKey(key, cluster);
-        if (id !== null) clusters.add(id);
-        names.add(String(key));
+    const rawClusterSets = [
+      endpoint?.clusters,
+      endpoint?.inputClusters,
+      endpoint?.serverClusters,
+      endpoint?.inClusterList,
+      endpoint?.inputClusterList,
+    ];
+    for (const rawClusters of rawClusterSets) {
+      if (!rawClusters) continue;
+      if (Array.isArray(rawClusters)) {
+        for (const cluster of rawClusters) {
+          const id = clusterIdFromKey(cluster, null);
+          if (id !== null) clusters.add(id);
+          if (typeof cluster === 'string') names.add(cluster);
+        }
+      } else if (rawClusters && typeof rawClusters === 'object') {
+        for (const [key, cluster] of Object.entries(rawClusters)) {
+          const id = clusterIdFromKey(key, cluster);
+          if (id !== null) clusters.add(id);
+          names.add(String(key));
+        }
       }
     }
   }
@@ -382,6 +407,14 @@ class ProbabilisticDeviceDetector {
     ]);
     this.candidates = new Map();
     this.sourceSummary = [];
+    this.quirkAnalysis = ManufacturerDeviceQuirkRegistry.analyze({
+      data: this.data,
+      clusterSummary: this.clusterSummary,
+      dpIds: this.dpIds,
+      dpReportSummary: this.dpReportSummary,
+      observedCapabilities: this.observedCapabilities,
+      observedDeviceTypes: this.observedDeviceTypes,
+    });
   }
 
   static detect(data = {}, options = {}) {
@@ -404,6 +437,7 @@ class ProbabilisticDeviceDetector {
     this._addDriverMappingEvidence();
     this._addMfsEvidence();
     this._addCommunityEvidence();
+    this._addManufacturerQuirkEvidence();
     this._addClusterBehaviorEvidence();
     this._addDpBehaviorEvidence();
     this._addLearningRecommendationEvidence();
@@ -610,6 +644,32 @@ class ProbabilisticDeviceDetector {
     this._addSourceSummary('community_enriched', hits ? 'hit' : 'miss', { hits });
   }
 
+  _addManufacturerQuirkEvidence() {
+    const quirks = this.quirkAnalysis?.quirks || [];
+    if (!quirks.length) {
+      this._addSourceSummary('manufacturer_quirks', 'miss');
+      return;
+    }
+
+    for (const quirk of quirks) {
+      const preferredDrivers = asArray(quirk.preferredDrivers);
+      if (!preferredDrivers.length || !quirk.boost) continue;
+      const score = Math.max(16, Number(quirk.boost) / Math.sqrt(preferredDrivers.length));
+      for (const driver of preferredDrivers) {
+        this._vote(driver, score, 'manufacturer_quirks', quirk.id, {
+          capabilities: quirk.capabilities,
+          deviceTypes: quirk.deviceTypes,
+        });
+      }
+    }
+
+    this._addSourceSummary('manufacturer_quirks', 'hit', {
+      fingerprintKey: this.quirkAnalysis.fingerprintKey,
+      quirks: quirks.map(quirk => quirk.id),
+      powerSourceOverride: this.quirkAnalysis.powerSourceOverride,
+    });
+  }
+
   _addClusterBehaviorEvidence() {
     const context = { gangCount: this.clusterSummary.endpointCount };
     for (const type of this.clusterSummary.deviceTypes) {
@@ -778,6 +838,16 @@ class ProbabilisticDeviceDetector {
       contradictions.push('generic_driver_penalty');
     }
 
+    const quirkEffect = ManufacturerDeviceQuirkRegistry.driverEffect(this.quirkAnalysis, candidate.driver);
+    if (quirkEffect.boost) {
+      score += quirkEffect.boost;
+      evidence.push(...quirkEffect.evidence);
+    }
+    if (quirkEffect.penalty) {
+      score -= quirkEffect.penalty;
+      contradictions.push(...quirkEffect.contradictions);
+    }
+
     if (this.clusterSummary.hasEnergy && /battery|button|contact|motion|climate/.test(driverLower) && !/plug|meter|energy|air_quality/.test(driverLower)) {
       score -= 12;
       contradictions.push('energy_cluster_vs_battery_driver');
@@ -844,6 +914,8 @@ class ProbabilisticDeviceDetector {
     if (this.clusterSummary.clusters.length) badges.push('cluster_behavior_seen');
     if (this.dpIds.length) badges.push('dp_behavior_seen');
     if (this.dpReportSummary.recommendation) badges.push('learning_report_seen');
+    if (this.quirkAnalysis?.quirks?.length) badges.push('manufacturer_quirk_seen');
+    if (this.quirkAnalysis?.powerSourceOverride) badges.push('power_source_quirk_seen');
     if (margin < 8 && candidates.length > 1) badges.push('close_race_manual_review');
     if (confidence >= 85) badges.push('high_confidence_route');
 
@@ -864,8 +936,23 @@ class ProbabilisticDeviceDetector {
         dpIds: this.dpIds,
         capabilities: unique(this.observedCapabilities).sort(),
         deviceTypes: unique(this.observedDeviceTypes).sort(),
+        manufacturerQuirks: (this.quirkAnalysis?.quirks || []).map(quirk => ({
+          id: quirk.id,
+          preferredDrivers: quirk.preferredDrivers || [],
+          penalizedDrivers: quirk.penalizedDrivers || [],
+          powerSourceOverride: quirk.powerSourceOverride || null,
+          evidence: quirk.evidence || [],
+          sourceRefs: quirk.sourceRefs || [],
+        })),
       },
       sources: this.sourceSummary,
+      manufacturerQuirks: {
+        fingerprintKey: this.quirkAnalysis?.fingerprintKey,
+        stats: this.quirkAnalysis?.stats,
+        preferredDrivers: this.quirkAnalysis?.preferredDrivers || [],
+        penalizedDrivers: this.quirkAnalysis?.penalizedDrivers || [],
+        powerSourceOverride: this.quirkAnalysis?.powerSourceOverride || null,
+      },
       generatedAt: new Date().toISOString(),
       action: confidence >= 90 ? 'safe_recommendation' : confidence >= 70 ? 'recommendation_with_review' : 'learn_more',
     };

--- a/test/critical/manufacturer-device-quirks.test.js
+++ b/test/critical/manufacturer-device-quirks.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+const assert = require('assert');
+
+const ManufacturerDeviceQuirkRegistry = require('../../lib/helpers/ManufacturerDeviceQuirkRegistry');
+const ProbabilisticDeviceDetector = require('../../lib/helpers/ProbabilisticDeviceDetector');
+
+const testApi = global.describe && global.it ? global : require('node:test');
+const { describe, it } = testApi;
+
+function ts0014Endpoints() {
+  return {
+    endpointDescriptors: [
+      { endpointId: 1, applicationProfileId: 260, applicationDeviceId: 256, inputClusters: [0, 3, 4, 5, 6, 57344, 57345], outputClusters: [25, 10] },
+      { endpointId: 2, applicationProfileId: 260, applicationDeviceId: 256, inputClusters: [3, 4, 5, 6, 57344, 57345], outputClusters: [] },
+      { endpointId: 3, applicationProfileId: 260, applicationDeviceId: 256, inputClusters: [3, 4, 5, 6, 57344, 57345], outputClusters: [] },
+      { endpointId: 4, applicationProfileId: 260, applicationDeviceId: 256, inputClusters: [3, 4, 5, 6, 57344, 57345], outputClusters: [] },
+      { endpointId: 242, applicationProfileId: 41440, applicationDeviceId: 97, inputClusters: [], outputClusters: [33] },
+    ],
+    extendedEndpointDescriptors: {
+      1: {
+        clusters: {
+          basic: {
+            attributes: [
+              { name: 'manufacturerName', value: '_TZ3000_mrduubod' },
+              { name: 'modelId', value: 'TS0014' },
+              { name: 'powerSource', value: 'battery' },
+            ],
+          },
+        },
+      },
+    },
+  };
+}
+
+function ts004fFourButtonEndpoints() {
+  return {
+    1: { clusters: { powerConfiguration: {}, onOff: {}, levelControl: {}, tuyaE000: { clusterId: 57344 } } },
+    2: { clusters: { onOff: {}, levelControl: {}, tuyaE000: { clusterId: 57344 } } },
+    3: { clusters: { onOff: {}, levelControl: {}, tuyaE000: { clusterId: 57344 } } },
+    4: { clusters: { onOff: {}, levelControl: {}, tuyaE000: { clusterId: 57344 } } },
+  };
+}
+
+function ts004fRotaryEndpoint() {
+  return {
+    endpointDescriptors: [
+      {
+        endpointId: 1,
+        applicationProfileId: 260,
+        applicationDeviceId: 2080,
+        inputClusters: [0, 1, 3, 4, 6, 4096],
+        outputClusters: [3, 4, 5, 6, 8, 10, 25, 768, 4096],
+      },
+    ],
+  };
+}
+
+describe('manufacturer device quirk registry', () => {
+  it('routes Moes TS0014 4-gang actuators to wall switch handling despite false battery hints', () => {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZ3000_mrduubod',
+      modelId: 'TS0014',
+      endpoints: ts0014Endpoints(),
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'wall_switch_4gang_1way');
+    assert.strictEqual(result.observed.endpointCount, 4);
+    assert(result.evidenceBadges.includes('manufacturer_quirk_seen'));
+    assert(result.evidenceBadges.includes('power_source_quirk_seen'));
+    assert(result.observed.manufacturerQuirks.some(quirk => quirk.id === 'moes_ts0014_4gang_actuator_false_battery'));
+    assert.strictEqual(result.manufacturerQuirks.powerSourceOverride, 'mains');
+
+    const buttonCandidate = result.candidates.find(candidate => candidate.driver === 'button_wireless_4');
+    assert(!buttonCandidate || buttonCandidate.contradictions.some(item => item.includes('manufacturer_quirk_penalty')));
+  });
+
+  it('uses the TS001x multi-endpoint OnOff signature for unknown manufacturer siblings', () => {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZ3000_new_moes_like',
+      modelId: 'TS0014',
+      endpoints: ts0014Endpoints(),
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'wall_switch_4gang_1way');
+    assert(result.confidence >= 75, `expected confident wall-switch route, got ${result.confidence}`);
+    assert(result.observed.manufacturerQuirks.some(quirk => quirk.id === 'ts00xx_4gang_actuator_signature'));
+  });
+
+  it('keeps TS004F four-endpoint scene remotes on button_wireless_4 even without an exact manufacturer row', () => {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZ3000_new_4button_remote',
+      modelId: 'TS004F',
+      endpoints: ts004fFourButtonEndpoints(),
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'button_wireless_4');
+    assert(result.observed.manufacturerQuirks.some(quirk => quirk.id === 'ts004f_four_endpoint_scene_remote_signature'));
+    assert(!result.candidates[0].contradictions.some(item => item.includes('manufacturer_quirk_penalty')));
+  });
+
+  it('routes one-endpoint TS004F rotary signatures away from 4-button remotes', () => {
+    const result = ProbabilisticDeviceDetector.detect({
+      manufacturerName: '_TZ3000_new_rotary_knob',
+      modelId: 'TS004F',
+      endpoints: ts004fRotaryEndpoint(),
+    });
+
+    assert.strictEqual(result.suggestedDriver, 'smart_knob_rotary');
+    assert(result.observed.manufacturerQuirks.some(quirk => quirk.id === 'ts004f_single_endpoint_rotary_or_smart_button_signature'));
+
+    const fourButtonCandidate = result.candidates.find(candidate => candidate.driver === 'button_wireless_4');
+    assert(!fourButtonCandidate || fourButtonCandidate.contradictions.some(item => item.includes('manufacturer_quirk_penalty')));
+  });
+
+  it('keeps known TS004F one-button variants out of the 4-button driver', () => {
+    const analysis = ManufacturerDeviceQuirkRegistry.analyze({
+      manufacturerName: '_TZ3000_ja5osu5g',
+      modelId: 'TS004F',
+      endpoints: {
+        1: { clusters: { powerConfiguration: {}, onOff: {}, tuyaE000: { clusterId: 57344 } } },
+      },
+    });
+
+    assert(analysis.quirks.some(quirk => quirk.id === 'ts004f_known_one_button_variant'));
+    const effect = ManufacturerDeviceQuirkRegistry.driverEffect(analysis, 'button_wireless_4');
+    assert(effect.penalty >= 40);
+  });
+});


### PR DESCRIPTION
## Summary
- add a manufacturer/device quirk registry for buggy Tuya variants where modelId alone is unsafe
- feed quirk votes and penalties into probabilistic detection, including TS0014 actuator false-battery handling and TS004F button/rotary split
- improve endpoint parsing for Homey endpointDescriptors and ignore GreenPower endpoint 242 in functional gang counts
- document the source-backed quirk rules and add critical regression tests

## Sources crossed
- Homey forum #2099 and JohanBendz/com.tuya.zigbee #1413 for _TZ3000_mrduubod / TS0014
- Zigbee2MQTT TS0014 / TS004F docs and Koenkk issues/discussions #15339, #27119, #27239
- ZHA device-handlers TS004F issues #3604 and #4301
- local prior TS004F button/battery audit and raw EF00 state-map tests

## Validation
- node --check lib/helpers/ManufacturerDeviceQuirkRegistry.js lib/helpers/ProbabilisticDeviceDetector.js test/critical/manufacturer-device-quirks.test.js
- npx mocha test/critical/manufacturer-device-quirks.test.js test/critical/probabilistic-device-detection.test.js test/critical/forum-routing-regressions.test.js test/critical/raw-advertisement-state.test.js test/button-flow-runtime-routing.test.js --timeout 15000
- npm run precommit
- git pre-push gate