### PR TITLE
Fix TS0201 temperature/humidity sensor routing

### DIFF
--- a/drivers/air_purifier/driver.compose.json
+++ b/drivers/air_purifier/driver.compose.json
@@ -62,7 +62,6 @@
     },
     "manufacturerName": [
       "_TZ3000_6uzkisv2",
-      "_TZ3000_fllyghyj",
       "_TZ3000_saiqcn0y",
       "_TZ3000_utwgoauk",
       "_TZ3000_xr3htd96",

--- a/drivers/climate_sensor/driver.compose.json
+++ b/drivers/climate_sensor/driver.compose.json
@@ -66,6 +66,7 @@
       "_TZ3000_EIT6L5",
       "_TZ3000_ESYNMMOX",
       "_TZ3000_EXC99DVW",
+      "_TZ3000_fllyghyj",
       "_TZ3000_FKXMYICS",
       "_TZ3000_GEYH5RFS",
       "_TZ3000_HGM6K8KU",


### PR DESCRIPTION
Fixes #506.

The supplied interview identifies `_TZ3000_fllyghyj / TS0201` as a battery temperature/humidity sensor with clusters 0x0402 and 0x0405. It was incorrectly assigned to `air_purifier` in `master`.

This change removes the fingerprint from the air-purifier driver and assigns it to `climate_sensor`. Local Homey `app validate --level publish` passes after the change.