### PR TITLE
Fix routing of myd45weu soil sensor variants

### DIFF
--- a/data/fingerprints.json
+++ b/data/fingerprints.json
@@ -39,7 +39,7 @@
     ]
   },
   "_TZE200_myd45weu": {
-    "driverId": "soilsensor_2",
+    "driverId": "soil_sensor",
     "type": "soil_sensor",
     "powerSource": "battery",
     "modelIds": [
@@ -79,7 +79,7 @@
     }
   },
   "_TZE284_myd45weu": {
-    "driverId": "soilsensor_2",
+    "driverId": "soil_sensor",
     "type": "soil_sensor",
     "powerSource": "battery",
     "modelIds": [
@@ -556,7 +556,7 @@
     "notes": "Normalized TZE28C1000000 prefix sibling for Homey forum 26439 #5484 Zemismart boiler switch."
   },
   "_TZE204_myd45weu": {
-    "driverId": "soilsensor_2",
+    "driverId": "soil_sensor",
     "type": "soil_sensor",
     "powerSource": "battery",
     "modelIds": [


### PR DESCRIPTION
The fingerprint catalog assigned three `myd45weu` variants to disabled `soilsensor_2`, while the active `soil_sensor` driver already contains the corresponding manufacturer identifiers.

This aligns the catalog with the live driver and restores integrity validation (`verify_fingerprints_integrity.js`: 0 errors).