### PR TITLE
fix(runtime): SOS catch abort (BOTH reliability → stable)

### DIFF
--- a/drivers/button_emergency_sos/device.js
+++ b/drivers/button_emergency_sos/device.js
@@ -47,7 +47,9 @@ class SosEmergencyButtonDevice extends TuyaZigbeeDevice {
    * _registerButtonListener is the single button.1 listener — a second one
    * would double-trigger the alarm.
    */
-  _registerButtonCapabilityListeners() { /* intentionally empty — see _registerButtonListener */ }
+  // Must stay async: TuyaZigbeeDevice.onNodeInit awaits Promise.resolve(this._registerButtonCapabilityListeners()).catch(...)
+  // Sync empty override → "reading 'catch'" aborts IAS/battery (Peter #2134). BOTH reliability — not AlarmPolarity.
+  async _registerButtonCapabilityListeners() { /* intentionally empty — see _registerButtonListener */ }
 
   async onNodeInit({ zclNode }) {
     await this._safeInvoke(async () => {

--- a/lib/tuya/TuyaZigbeeDevice.js
+++ b/lib/tuya/TuyaZigbeeDevice.js
@@ -234,7 +234,8 @@ class TuyaZigbeeDevice extends PhysicalButtonMixin(VirtualButtonMixin(ZigBeeDevi
     // but only 2 bases ever registered listeners — every UI press logged
     // "Missing Capability Listener: Button N" and did nothing. Register them
     // centrally: press → toggle the matching gang when possible, else log.
-    await this._registerButtonCapabilityListeners().catch(err => this.log(`[BUTTON-INIT] ⚠️ UI listeners error: ${err.message}`));
+    // Promise.resolve: sync overrides must not throw "reading 'catch'" (BOTH reliability backport).
+    await Promise.resolve(this._registerButtonCapabilityListeners()).catch(err => this.log(`[BUTTON-INIT] ⚠️ UI listeners error: ${err.message}`));
 
     // 🛡️ v5.13.0: UNIVERSAL TX/RX FALLBACK HANDLER
     this._setupRawFrameFallback();


### PR DESCRIPTION
## Summary
- Surgical BOTH-track backport: async SOS `_registerButtonCapabilityListeners` + `Promise.resolve(...).catch` in `TuyaZigbeeDevice`.
- Fixes Peter #2134 abort (`reading catch`) on stable without copying MASTER_ONLY features (AlarmPolarity, free-scrape, CapabilityCommandRouter).

## Dual-app
- Tag: **BOTH** (crash only)
- Does **not** change App ID / version identity beyond this patch
- Do **not** promote this branch to Test if it would overwrite master 9.x Test on the shared App ID

## Test plan
- [ ] Install stable build after merge
- [ ] Pair/repair SOS — no onNodeInit abort
- [ ] Confirm master Test still on 9.0.x soak