### PR TITLE
fix(runtime): contact/water safe timers BOTH → stable 5.12.77

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,6 +1,13 @@
 {
   "changelog": [
     {
+      "version": "5.12.77",
+      "date": "2026-08-15",
+      "channel": "stable",
+      "en": "Reliability BOTH: contact/water debounce timers use safeSetTimeout (Peter crash class).",
+      "fr": "Fiabilite BOTH: timers debounce contact/eau via safeSetTimeout."
+    },
+    {
       "version": "5.12.76",
       "date": "2026-08-15",
       "channel": "stable",

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.76",
+  "version": "5.12.77",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Generated from .homeycompose/app.json. STABLE channel — only bug fixes applied.",
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.76",
+  "version": "5.12.77",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/drivers/contact_sensor/device.js
+++ b/drivers/contact_sensor/device.js
@@ -1,6 +1,7 @@
 'use strict';
 const { safeMultiply, safeParse } = require('../../lib/utils/tuyaUtils.js');
 const { includesCI } = require('../../lib/utils/CaseInsensitiveMatcher');
+const { safeSetTimeout, safeClearTimeout } = require('../../lib/utils/safe-timers');
 
 
 const { UnifiedSensorBase } = require('../../lib/devices/UnifiedSensorBase');
@@ -315,11 +316,11 @@ class ContactSensorDevice extends UnifiedSensorBase {
 
         // Clear existing timer
         if (state.timer) {
-          this.homey.clearTimeout(state.timer);
+          safeClearTimeout(this, state.timer);
         }
 
         // Set timer to apply after debounce window
-        state.timer = this.homey.setTimeout(async () => {
+        state.timer = safeSetTimeout(this, async () => {
           if (this._destroyed) return;
           this.log(`[CONTACT]  Debounce complete - applying: ${finalValue}`);
           state.lastValue = finalValue;
@@ -349,11 +350,11 @@ class ContactSensorDevice extends UnifiedSensorBase {
           this.log('[CONTACT]  Problematic sensor: openclosed change - applying extended debounce');
 
           if (state.timer) {
-            this.homey.clearTimeout(state.timer);
+            safeClearTimeout(this, state.timer);
           }
 
           // Double debounce for problematic openclosed transitions
-          state.timer = this.homey.setTimeout(async () => {
+          state.timer = safeSetTimeout(this, async () => {
             if (this._destroyed) return;
             this.log(`[CONTACT]  Extended debounce complete - applying: ${finalValue}`);
             state.lastValue = finalValue;
@@ -376,7 +377,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
 
       // Clear any pending timer
       if (state.timer) {
-        this.homey.clearTimeout(state.timer);
+        safeClearTimeout(this, state.timer);
         state.timer = null;
       }
 
@@ -411,7 +412,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
   async onUninit() {
     this.log('[CONTACT] onUninit - cleaning up...');
     if (this._contactState?.timer) {
-      this.homey.clearTimeout(this._contactState.timer);
+      safeClearTimeout(this, this._contactState.timer);
       this._contactState.timer = null;
     }
     if (super.onUninit) {
@@ -427,7 +428,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
     if (this._destroyed) return;
     this._destroyed = true;
     if (this._contactState?.timer) {
-      this.homey.clearTimeout(this._contactState.timer );
+      safeClearTimeout(this, this._contactState.timer);
       this._contactState.timer = null;
     }
     await super.onDeleted?.();

--- a/drivers/sensor_contact_water/device.js
+++ b/drivers/sensor_contact_water/device.js
@@ -1,6 +1,7 @@
 'use strict';
 const { safeMultiply, safeParse } = require('../../lib/utils/tuyaUtils.js');
 const { includesCI } = require('../../lib/utils/CaseInsensitiveMatcher');
+const { safeSetTimeout, safeClearTimeout } = require('../../lib/utils/safe-timers');
 
 
 const { UnifiedSensorBase } = require('../../lib/devices/UnifiedSensorBase');
@@ -315,11 +316,11 @@ class ContactSensorDevice extends UnifiedSensorBase {
 
         // Clear existing timer
         if (state.timer) {
-          this.homey.clearTimeout(state.timer);
+          safeClearTimeout(this, state.timer);
         }
 
         // Set timer to apply after debounce window
-        state.timer = this.homey.setTimeout(async () => {
+        state.timer = safeSetTimeout(this, async () => {
           if (this._destroyed) return;
           this.log(`[CONTACT]  Debounce complete - applying: ${finalValue}`);
           state.lastValue = finalValue;
@@ -349,11 +350,11 @@ class ContactSensorDevice extends UnifiedSensorBase {
           this.log('[CONTACT]  Problematic sensor: openclosed change - applying extended debounce');
 
           if (state.timer) {
-            this.homey.clearTimeout(state.timer);
+            safeClearTimeout(this, state.timer);
           }
 
           // Double debounce for problematic openclosed transitions
-          state.timer = this.homey.setTimeout(async () => {
+          state.timer = safeSetTimeout(this, async () => {
             if (this._destroyed) return;
             this.log(`[CONTACT]  Extended debounce complete - applying: ${finalValue}`);
             state.lastValue = finalValue;
@@ -376,7 +377,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
 
       // Clear any pending timer
       if (state.timer) {
-        this.homey.clearTimeout(state.timer);
+        safeClearTimeout(this, state.timer);
         state.timer = null;
       }
 
@@ -411,7 +412,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
   async onUninit() {
     this.log('[CONTACT] onUninit - cleaning up...');
     if (this._contactState?.timer) {
-      this.homey.clearTimeout(this._contactState.timer);
+      safeClearTimeout(this, this._contactState.timer);
       this._contactState.timer = null;
     }
     if (super.onUninit) {
@@ -427,7 +428,7 @@ class ContactSensorDevice extends UnifiedSensorBase {
     if (this._destroyed) return;
     this._destroyed = true;
     if (this._contactState?.timer) {
-      this.homey.clearTimeout(this._contactState.timer );
+      safeClearTimeout(this, this._contactState.timer);
       this._contactState.timer = null;
     }
     await super.onDeleted?.();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.76",
+  "version": "5.12.77",
   "description": "Tuya Unified Zigbee - Local-first control with AI automation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Replace bare \homey.setTimeout/clearTimeout\ in contact + water contact debounce
- **No** AlarmPolarity (MASTER_ONLY)
- Version **5.12.77**

## Classification
\BOTH\

## Resume
See \eports/SESSION_HANDOFF_2026-08-15.md\ on master.


Made with [Cursor](https://cursor.com)