### PR TITLE
fix(stable): changelog Athom keys + ZT08 timers (5.12.78)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,6 +1,13 @@
 {
   "changelog": [
     {
+      "version": "5.12.78",
+      "date": "2026-08-15",
+      "channel": "stable",
+      "en": "Reliability BOTH: ZT08 safe time-sync timers; Athom changelog keys so Test publish works (5.12.75-77 crash class).",
+      "fr": "Fiabilite BOTH: timers ZT08 safe; cles changelog Athom pour publier Test (classe crash 5.12.75-77)."
+    },
+    {
       "version": "5.12.77",
       "date": "2026-08-15",
       "channel": "stable",
@@ -1243,5 +1250,21 @@
   },
   "5.12.70": {
     "en": "Stop publish reinject from stripping TS004F remotes off button_wireless_4."
+  },
+  "5.12.78": {
+    "en": "Reliability BOTH: ZT08 safe time-sync timers; Athom changelog keys so Test publish works (5.12.75-77 crash class).",
+    "fr": "Fiabilite BOTH: timers ZT08 safe; cles changelog Athom pour publier Test (classe crash 5.12.75-77)."
+  },
+  "5.12.77": {
+    "en": "Reliability BOTH: contact/water debounce timers use safeSetTimeout (Peter crash class).",
+    "fr": "Fiabilite BOTH: timers debounce contact/eau via safeSetTimeout."
+  },
+  "5.12.76": {
+    "en": "Reliability BOTH: SOS zoneId 10 + CIE zero-guard + safe timers + battery wake; water_leak_sensor_tuya IAS path.",
+    "fr": "Fiabilite BOTH: SOS zoneId 10 + garde CIE + timers safe; chemin IAS water_leak."
+  },
+  "5.12.75": {
+    "en": "Reliability: guard DCM auditCapabilities + safe IAS timers; stop TS0041 matching door/window sensors.",
+    "fr": "Fiabilite: garde auditCapabilities DCM + timers IAS; TS0041 hors door/window."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.77",
+  "version": "5.12.78",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Generated from .homeycompose/app.json. STABLE channel — only bug fixes applied.",
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.77",
+  "version": "5.12.78",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/drivers/climate_sensor_zt08/device.js
+++ b/drivers/climate_sensor_zt08/device.js
@@ -4,6 +4,7 @@ const UnifiedSensorBase = require('../../lib/devices/UnifiedSensorBase');
 const GlobalTimeSyncEngine = require('../../lib/tuya/GlobalTimeSyncEngine');
 const UnifiedBatteryHandler = require('../../lib/battery/UnifiedBatteryHandler');
 const { ClimateInference, BatteryInference } = require('../../lib/IntelligentSensorInference');
+const { safeSetTimeout, safeClearTimeout } = require('../../lib/utils/safe-timers');
 
 /**
  * P133 / GH #513 — Dedicated thin driver for ZT08 LCD climate
@@ -43,7 +44,7 @@ class ClimateSensorZt08Device extends UnifiedSensorBase {
     try {
       this._timeSyncEngine = new GlobalTimeSyncEngine(this);
       this._timeSyncEngine.setupListener(zclNode);
-      this._initialTimeSyncTimer = this.homey.setTimeout(async () => {
+      this._initialTimeSyncTimer = safeSetTimeout(this, async () => {
         if (this._destroyed) { return; }
         await this._timeSyncEngine.syncTime(zclNode).catch(() => {});
       }, 5000);
@@ -53,6 +54,23 @@ class ClimateSensorZt08Device extends UnifiedSensorBase {
     }
 
     this.log('[ZT08] Ready (P133 dedicated #513 driver)');
+  }
+
+  onUninit() {
+    if (this._initialTimeSyncTimer) {
+      safeClearTimeout(this, this._initialTimeSyncTimer);
+      this._initialTimeSyncTimer = null;
+    }
+    try { this._timeSyncEngine?.destroy?.(); } catch (_e) { /* noop */ }
+    if (typeof super.onUninit === 'function') { return super.onUninit(); }
+  }
+
+  async onDeleted() {
+    if (this._initialTimeSyncTimer) {
+      safeClearTimeout(this, this._initialTimeSyncTimer);
+      this._initialTimeSyncTimer = null;
+    }
+    return super.onDeleted?.();
   }
 
   onTuyaDP(dpId, value) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.77",
+  "version": "5.12.78",
   "description": "Tuya Unified Zigbee - Local-first control with AI automation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fix Publish Stable→Test: Homey needs 5.12.xx: { en }` keys (array-only was not enough for 5.12.75–77).
- Bump to **5.12.78** with Athom keys for 5.12.75–78.
- Backport ZT08 `safeSetTimeout` / clear on uninit (Peter crash class / BOTH).

## Test plan
- [ ] Publish Stable→Test succeeds for 5.12.78
- [ ] Peter updates Homey Test to ≥5.12.78
- [ ] No AlarmPolarity / feature managers on this branch