### PR TITLE
fix(stable): republish 5.12.79 after Athom socket hang up

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,6 +1,13 @@
 {
   "changelog": [
     {
+      "version": "5.12.79",
+      "date": "2026-08-15",
+      "channel": "stable",
+      "en": "P102 reliability republish after Athom processing_failed on 5.12.78 (socket hang up). Includes ZT08 safe timers + Athom changelog keys.",
+      "fr": "Republication fiabilite P102 apres processing_failed Athom sur 5.12.78. Inclut timers ZT08 + cles changelog Athom."
+    },
+    {
       "version": "5.12.78",
       "date": "2026-08-15",
       "channel": "stable",
@@ -1266,5 +1273,9 @@
   "5.12.75": {
     "en": "Reliability: guard DCM auditCapabilities + safe IAS timers; stop TS0041 matching door/window sensors.",
     "fr": "Fiabilite: garde auditCapabilities DCM + timers IAS; TS0041 hors door/window."
+  },
+  "5.12.79": {
+    "en": "P102 reliability republish after Athom processing_failed on 5.12.78 (socket hang up). Includes ZT08 safe timers + Athom changelog keys.",
+    "fr": "Republication fiabilite P102 apres processing_failed Athom sur 5.12.78. Inclut timers ZT08 + cles changelog Athom."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.78",
+  "version": "5.12.79",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Generated from .homeycompose/app.json. STABLE channel — only bug fixes applied.",
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.78",
+  "version": "5.12.79",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.78",
+  "version": "5.12.79",
   "description": "Tuya Unified Zigbee - Local-first control with AI automation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Athom build **5.12.78** `#2822` ended `processing_failed` (socket hang up) — classic P102.
- Bump to **5.12.79** with Athom changelog key and republish (code already includes ZT08 safe timers + changelog keys from #522).

## Test plan
- [ ] Publish Stable Draft succeeds
- [ ] Promote/verify shows **5.12.79** on Test (note: shared App ID overwrites master Test slot)