### PR TITLE
fix(stable): 5.12.80 Athom republish after socket hang ups

### DIFF
--- a/.github/workflows/publish-stable.yml
+++ b/.github/workflows/publish-stable.yml
@@ -35,8 +35,8 @@ env:
   # exceeding the default 20,000 limit. 30,000 gives headroom.
   # v5.12.1 (P59 sync): stable has 30,211 combos (more than master due to
   # driver differences over time). 35,000 covers stable with headroom.
-  HOMEY_ZIGBEE_MAX_TOTAL_COMBOS: "35000"
-  HOMEY_ZIGBEE_MAX_DRIVER_COMBOS: "1000"
+  HOMEY_ZIGBEE_MAX_TOTAL_COMBOS: "22000"
+  HOMEY_ZIGBEE_MAX_DRIVER_COMBOS: "500"
 
 jobs:
   upstream-guard:

--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,6 +1,13 @@
 {
   "changelog": [
     {
+      "version": "5.12.80",
+      "date": "2026-08-15",
+      "channel": "stable",
+      "en": "P102 Athom republish after processing_failed on 5.12.78/79 (socket hang up). Lower Zigbee combo budget for publish processing.",
+      "fr": "Republication P102 apres processing_failed 5.12.78/79. Budget combos Zigbee reduit pour Athom."
+    },
+    {
       "version": "5.12.79",
       "date": "2026-08-15",
       "channel": "stable",
@@ -1277,5 +1284,9 @@
   "5.12.79": {
     "en": "P102 reliability republish after Athom processing_failed on 5.12.78 (socket hang up). Includes ZT08 safe timers + Athom changelog keys.",
     "fr": "Republication fiabilite P102 apres processing_failed Athom sur 5.12.78. Inclut timers ZT08 + cles changelog Athom."
+  },
+  "5.12.80": {
+    "en": "P102 Athom republish after processing_failed on 5.12.78/79 (socket hang up). Lower Zigbee combo budget for publish processing.",
+    "fr": "Republication P102 apres processing_failed 5.12.78/79. Budget combos Zigbee reduit pour Athom."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.79",
+  "version": "5.12.80",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Generated from .homeycompose/app.json. STABLE channel — only bug fixes applied.",
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.79",
+  "version": "5.12.80",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.79",
+  "version": "5.12.80",
   "description": "Tuya Unified Zigbee - Local-first control with AI automation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Athom `processing_failed` (socket hang up) on **5.12.78** and **5.12.79**.
- Bump **5.12.80** + tighten publish Zigbee combo budgets (35k→22k total, 1k→500/driver) to ease Athom processing.

## Test plan
- [ ] Draft publish + Test channel shows **5.12.80**
- [ ] Peter updates Homey to ≥5.12.80