### PR TITLE
fix(stable): capability crash + MTG284 radar (5.12.81)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -1,6 +1,13 @@
 {
   "changelog": [
     {
+      "version": "5.12.81",
+      "date": "2026-08-15",
+      "channel": "stable",
+      "en": "Reliability BOTH: generic_tuya capability crash fix; MTG284 clrdrnya relay DP map.",
+      "fr": "Fiabilite BOTH: crash capability generic_tuya; map relay MTG284 clrdrnya."
+    },
+    {
       "version": "5.12.80",
       "date": "2026-08-15",
       "channel": "stable",
@@ -1288,5 +1295,9 @@
   "5.12.80": {
     "en": "P102 Athom republish after processing_failed on 5.12.78/79 (socket hang up). Lower Zigbee combo budget for publish processing.",
     "fr": "Republication P102 apres processing_failed 5.12.78/79. Budget combos Zigbee reduit pour Athom."
+  },
+  "5.12.81": {
+    "en": "Reliability BOTH: generic_tuya capability crash fix; MTG284 clrdrnya relay DP map.",
+    "fr": "Fiabilite BOTH: crash capability generic_tuya; map relay MTG284 clrdrnya."
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.80",
+  "version": "5.12.81",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "Generated from .homeycompose/app.json. STABLE channel — only bug fixes applied.",
   "id": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.80",
+  "version": "5.12.81",
   "compatibility": ">=12.2.0",
   "platforms": [
     "local"

--- a/drivers/generic_tuya/device.js
+++ b/drivers/generic_tuya/device.js
@@ -88,7 +88,7 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
     this._setupDPDiscovery();
 
     // Request common DPs after delay (for mains-powered devices)
-    this.homey.setTimeout(() => { if (this._destroyed) return; this._requestCommonDPs().catch(() => {}); }, 5000);
+    this.homey.setTimeout(() => { if (this._destroyed) {return;} this._requestCommonDPs().catch(() => {}); }, 5000);
 
     // Log auto-adaptive status
     const status = this.getAutoAdaptiveStatus();
@@ -103,7 +103,7 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
    * Override: Handle device-specific DP processing
    */
   async _handleDeviceSpecificDP(dpId, value, mapping) {
-    if (this._destroyed) return;
+    if (this._destroyed) {return;}
     // Log discovery for unknown devices
     this.log(`[GENERIC]  DP${dpId}  ${mapping.capability} = ${value}`);
 
@@ -165,7 +165,7 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
    * Handle discovered DP and auto-map to capabilities
    */
   async _handleDiscoveredDP(data) {
-    if (this._destroyed) return;
+    if (this._destroyed) {return;}
     const { dp, value, type } = data;
 
     this.log(`[GENERIC]  Discovered DP${dp} = ${JSON.stringify(value)} (type: ${type})`);
@@ -208,16 +208,14 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
       101: { capability: 'measure_battery', parser: v => Math.min(100, Math.max(0, v)), confidence: 1 },
       105: { capability: 'measure_battery', parser: v => Math.min(100, Math.max(0, v)), confidence: 1 },
 
-      // Temperature (CONFIDENCE: 0)
-      1: { capability: 'measure_temperature', parser: v => safeMultiply(v, 10), confidence: 1 }, // Some devices
+      // Temperature (CONFIDENCE: 0) — DP1 must stay climate; do not overwrite with motion
+      // (duplicate key previously made DP1 always alarm_motion and broke catch-all climate).
+      1: { capability: 'measure_temperature', parser: v => safeMultiply(v, 10), confidence: 1 },
       3: { capability: 'measure_temperature', parser: v => safeMultiply(v, 10), confidence: 0 }, // Soil sensor
 
       // Humidity (CONFIDENCE: 0)
       2: { capability: 'measure_humidity', parser: v => v, confidence: 0 },
       5: { capability: 'measure_humidity', parser: v => v, confidence: 0 }, // Soil moisture
-
-      // Motion/Presence (CONFIDENCE: 0)
-      1: { capability: 'alarm_motion', parser: v => !!v, confidence: 0 },
 
       // Voltage (CONFIDENCE: 1 - USB/Mains devices)
       247: { capability: 'measure_voltage', parser: v => v * 1000, confidence: 1 },
@@ -230,7 +228,12 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
       return;
     }
 
-    const { parser, confidence } = mapping;
+    const { capability, parser, confidence, internal } = mapping;
+    // DP14 battery_low is internal-only (no Homey cap). Missing capability binding
+    // previously threw ReferenceError: capability is not defined (Gmail WATCH).
+    if (internal || !capability || typeof parser !== 'function') {
+      return;
+    }
     const confidenceLabel = ['Official', 'Community', 'Heuristic'][confidence];
 
     // Add capability if missing
@@ -290,7 +293,7 @@ class GenericTuyaDevice extends AutoAdaptiveDevice {
    * Override onDeleted to cleanup
    */
   async onDeleted() {
-    if (this._destroyed) return;
+    if (this._destroyed) {return;}
     this._destroyed = true;
     this.log('[GENERIC] Device deleted, cleaning up...');
     this._discoveredDPs?.clear();

--- a/drivers/presence_sensor_radar/configs.js
+++ b/drivers/presence_sensor_radar/configs.js
@@ -86,6 +86,7 @@ const SENSOR_CONFIGS = {
       '_TZE204_mtoaryre', '_TZE200_mp902om5',
       '_TZE204_pfayrzcw', '_TZE284_4qznlkbu',
       '_TZE200_clrdrnya', '_TZE200_sbyx0lm6',
+      '_TZE284_clrdrnya',
     ],
     battery: false,
     mainsPowered: true,

--- a/drivers/presence_sensor_radar/device.js
+++ b/drivers/presence_sensor_radar/device.js
@@ -22,6 +22,7 @@ const MTG_RELAY_RADARS = [
   '_tze284_4qznlkbu',
   '_tze200_clrdrnya',
   '_tze200_sbyx0lm6',
+  '_tze284_clrdrnya',
 ];
 
 const MAINS_POWERED_RADARS = new Set([

--- a/drivers/sensor_illuminance_presence/configs.js
+++ b/drivers/sensor_illuminance_presence/configs.js
@@ -113,6 +113,7 @@ const SENSOR_CONFIGS = {
       '_TZE204_mtoaryre', '_TZE200_mp902om5',
       '_TZE204_pfayrzcw', '_TZE284_4qznlkbu',
       '_TZE200_clrdrnya', '_TZE200_sbyx0lm6',
+      '_TZE284_clrdrnya',
     ],
     battery: false,
     mainsPowered: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.dlnraja.tuya.zigbee",
-  "version": "5.12.80",
+  "version": "5.12.81",
   "description": "Tuya Unified Zigbee - Local-first control with AI automation",
   "main": "app.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Fix `ReferenceError: capability is not defined` in `generic_tuya._autoMapDP` (Gmail WATCH / P136).
- Route `_TZE284_clrdrnya` to MTG075 relay DP map (GH #420 family).
- Bump **5.12.81** with Athom changelog key.

## Test plan
- [ ] Publish Stable→Test succeeds for 5.12.81
- [ ] Peter / radar users update Test ≥5.12.81