### PR TITLE
fix(stable): harden clusterUtils timeouts (P137)

### DIFF
--- a/lib/utils/clusterUtils.js
+++ b/lib/utils/clusterUtils.js
@@ -2,8 +2,24 @@
 
 /**
  * Safe Cluster Utilities
- * Prevents crashes from missing clusters or invalid cluster IDs
+ * Prevents crashes from missing clusters or invalid cluster IDs.
+ *
+ * IMPORTANT: these are free functions — never use `this`. Gmail crash logs
+ * showed TypeError reading `_destroyed` when timeouts closed over unbound this
+ * (clusterUtils.js timeout callbacks).
  */
+
+function _scheduleTimeout(fn, timeoutMs) {
+  const ms = Number.isFinite(timeoutMs) && timeoutMs > 0 ? timeoutMs : 5000;
+  // module-level native setTimeout — no device / no homey (script utility)
+  try {
+    if (typeof globalThis.setTimeout === 'function') {
+      return globalThis.setTimeout(fn, ms);
+    }
+  } catch (_e) { /* ignore */ }
+  // module-level native setTimeout fallback — no Homey instance
+  return setTimeout(fn, ms);
+}
 
 /**
  * Safely read cluster attributes with timeout protection
@@ -14,25 +30,19 @@
  */
 async function safeReadCluster(cluster, attrs = [], timeoutMs = 5000) {
   try {
-    // Validate cluster exists and has readAttributes method
     if (!cluster || typeof cluster.readAttributes !== 'function') {
       return null;
     }
 
-    // Create timeout promise
     const timeoutPromise = new Promise((_, reject) => {
-      (this && this.homey && typeof this.homey.setTimeout === 'function' ? this.homey : globalThis).setTimeout(() => { if (this && this._destroyed) {return;} reject(new Error('Timeout: Expected Response')); }, timeoutMs);
+      _scheduleTimeout(() => reject(new Error('Timeout: Expected Response')), timeoutMs);
     });
 
-    // Race between read and timeout
-    const result = await Promise.race([
+    return await Promise.race([
       cluster.readAttributes(attrs),
-      timeoutPromise
+      timeoutPromise,
     ]);
-
-    return result;
-  } catch (err) {
-    // Return null to signal fallback should be used
+  } catch (_err) {
     return null;
   }
 }
@@ -46,24 +56,21 @@ async function safeReadCluster(cluster, attrs = [], timeoutMs = 5000) {
  */
 async function safeConfigureReporting(cluster, config = {}, timeoutMs = 5000) {
   try {
-    // Validate cluster
     if (!cluster || typeof cluster.configureReporting !== 'function') {
       return false;
     }
 
-    // Create timeout promise
     const timeoutPromise = new Promise((_, reject) => {
-      (this && this.homey && typeof this.homey.setTimeout === 'function' ? this.homey : globalThis).setTimeout(() => { if (this && this._destroyed) {return;} reject(new Error('Timeout: Expected Response')); }, timeoutMs);
+      _scheduleTimeout(() => reject(new Error('Timeout: Expected Response')), timeoutMs);
     });
 
-    // Race between configure and timeout
     await Promise.race([
       cluster.configureReporting(config),
-      timeoutPromise
+      timeoutPromise,
     ]);
 
     return true;
-  } catch (err) {
+  } catch (_err) {
     return false;
   }
 }
@@ -81,16 +88,16 @@ async function safeBindCluster(cluster, timeoutMs = 5000) {
     }
 
     const timeoutPromise = new Promise((_, reject) => {
-      (this && this.homey && typeof this.homey.setTimeout === 'function' ? this.homey : globalThis).setTimeout(() => { if (this && this._destroyed) {return;} reject(new Error('Timeout: Expected Response')); }, timeoutMs);
+      _scheduleTimeout(() => reject(new Error('Timeout: Expected Response')), timeoutMs);
     });
 
     await Promise.race([
       cluster.bind(),
-      timeoutPromise
+      timeoutPromise,
     ]);
 
     return true;
-  } catch (err) {
+  } catch (_err) {
     return false;
   }
 }
@@ -107,13 +114,11 @@ function getCluster(endpoint, clusterName) {
       return null;
     }
 
-    // Try direct access
     if (endpoint.clusters[clusterName]) {
       return endpoint.clusters[clusterName];
     }
 
-    // Try case-insensitive search
-    const lowerName = clusterName.toLowerCase();
+    const lowerName = String(clusterName).toLowerCase();
     for (const [key, cluster] of Object.entries(endpoint.clusters)) {
       if (key.toLowerCase() === lowerName) {
         return cluster;
@@ -121,7 +126,7 @@ function getCluster(endpoint, clusterName) {
     }
 
     return null;
-  } catch (err) {
+  } catch (_err) {
     return null;
   }
 }
@@ -130,5 +135,5 @@ module.exports = {
   safeReadCluster,
   safeConfigureReporting,
   safeBindCluster,
-  getCluster
+  getCluster,
 };


### PR DESCRIPTION
## Summary
- Surgical BOTH reliability backport from master: `lib/utils/clusterUtils.js` only
- Prevents TypeError on `_destroyed` when timeout callbacks closed over unbound `this`
- No feature managers; no App ID / version identity changes

## Test plan
- [ ] Unified CI / Validate on this PR green
- [ ] Publish Stable succeeds after merge
- [ ] Gmail gate still ok for this crash class
